### PR TITLE
[docs] Document EAS workflows concurrency groups, cancel_in_progress expressions, and queue

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -728,7 +728,7 @@ concurrency:
   # @end #
 ```
 
-The expressions can use the [`github`](#github), [`app_store_connect`](#app_store_connect), [`inputs`](#inputs), [`workflow`](#workflow), [`app`](#app), and [`account`](#account) contexts. They support all [context functions](#context-functions) except `success()`, `failure()`, and `hashFiles()`. Job-level contexts such as `needs`, `after`, `steps`, and `env` are not available. EAS rejects a template that references any other name, such as a job-level context, `success()`, or a misspelled context, when it validates the workflow file, before it creates a run. [`eas workflow:validate`](/eas/workflows/troubleshooting/#validate-the-workflow-file) reports the same errors. See [Context availability](#context-availability).
+The expressions can use the [`github`](#github), [`app_store_connect`](#app_store_connect), [`inputs`](#inputs), [`workflow`](#workflow), [`app`](#app), and [`account`](#account) contexts. They support all [context functions](#context-functions) except `success()`, `failure()`, and `hashFiles()`. Job-level contexts such as `needs`, `after`, `steps`, and `env` are not available. EAS rejects a template that references any other name, such as a job-level context, `success()`, or a misspelled context. It does this when it validates the workflow file, before it creates a run. [`eas workflow:validate`](/eas/workflows/troubleshooting/#validate-the-workflow-file) reports the same errors. See [Context availability](#context-availability).
 
 When EAS renders the key:
 
@@ -743,7 +743,7 @@ If rendering fails, EAS creates the run, marks it as failed, and shows the error
 
 Whether a new run cancels the runs of its group instead of waiting for them. The value is a boolean or a single `${{ }}` expression. Defaults to `false`.
 
-- `true`, or an expression that evaluates to a truthy value: the new run starts right away, and EAS cancels the active run and all waiting runs of its group. The new run does not wait for the canceled runs to stop.
+- `true`, or an expression that evaluates to a truthy value: the new run starts right away. EAS cancels the active run and all waiting runs of its group. The new run does not wait for the canceled runs to stop.
 - `false`, or an expression that evaluates to a falsy value: the new run waits until the group is free. `false` behaves the same as omitting the property.
 
 For deploys, leave `cancel_in_progress` out. The active deploy always finishes. The newest run waits for it, and EAS replaces the runs in between.
@@ -787,9 +787,9 @@ You cannot combine `queue: max` with `cancel_in_progress: true`. EAS rejects the
 ### Waiting and canceled runs
 
 - A run that waits for its group shows as **Queued** in the EAS dashboard, with a link to the run it waits for. `eas workflow:run --wait` prints "Workflow run is queued" with the name of that run. For runs triggered from GitHub, the commit status reads "Workflow run is waiting for another run in its concurrency group."
-- A waiting run has no jobs. It does not use build minutes or one of your account's concurrencies until it starts.
+- A waiting run has no jobs. It does not use build minutes or a concurrency slot on your account until it starts.
 - When the active run finishes, fails, or is canceled, the next waiting run starts. A run that needs a user action, such as an approval in a [`require-approval`](#require-approval) job, holds its group until it succeeds, fails, or is canceled.
-- A waiting run fails instead of starting if it waited more than 30 days, if its uploaded project sources expired, or if the user who started it lost access to the project. EAS then starts the next waiting run.
+- A waiting run fails instead of starting if it waited more than 30 days. It also fails if its uploaded project sources expired or if the user who started it lost access to the project. EAS then starts the next waiting run.
 - A run that `cancel_in_progress` canceled, whether it was active or waiting, shows as canceled with "Canceled by" and a link to the newer run.
 - A waiting run that a newer run replaced under `queue: single` shows as canceled with "Replaced by" and a link to the newer run. A run that EAS canceled because a `queue: max` group already had 100 waiting runs shows "Queue was full (limit 100)".
 - The GitHub commit status and `eas workflow:run --wait` show these runs as canceled without the reason. Open the run in the EAS dashboard to see it.
@@ -884,7 +884,11 @@ In [`on.<trigger>.if`](#ontriggerif), the `workflow` context has only `name` and
 
 `app_store_connect` has values only for runs that an App Store Connect event triggered. In steps, only `build` jobs receive it.
 
-At the job level, `env` is available only after EAS resolves the job's [`environment`](#jobsjob_idenvironment) (`production`, `preview`, or `development`). The fields EAS reads to resolve it cannot use `env`: `jobs.<job_id>.environment` itself, and the `params` of a `build` job that has no explicit `environment`. In [`jobs.<job_id>.if`](#jobsjob_idif), a condition that references `env` fails the job when EAS cannot resolve the environment, for example because the job's params are invalid. To make `env` available regardless of the job's params, set `environment` on the job.
+At the job level, `env` becomes available after EAS determines the job's [`environment`](#jobsjob_idenvironment). You cannot use `env` in `jobs.<job_id>.environment` itself.
+
+If a `build`, `repack`, `submit`, or `testflight` job has no explicit `environment`, EAS first evaluates its `params` to determine which environment to use. These parameters cannot use `env`. For example, a `submit` job inherits its source build's environment, but EAS must evaluate `params.build_id` before it can find that build. Set `environment` explicitly on the job to use `env` in its parameters.
+
+A condition in [`jobs.<job_id>.if`](#jobsjob_idif) that references `env` fails the job if EAS cannot determine the environment, for example because the job's parameters are invalid. Set `environment` explicitly to make `env` available to the condition without relying on those parameters.
 
 For `on.<trigger>.if` and `concurrency`, EAS rejects a reference to an unavailable context or function when it validates the workflow file. EAS does not check `run_name` at that time. A `run_name` template that references an unavailable context or function fails the run when EAS renders the title.
 
@@ -1114,7 +1118,7 @@ Information about the project the workflow run belongs to.
 ```ts
 type AppContext = {
   id: string;
-  slug: string; // e.g. my-app
+  slug: string; // For example, my-app
 };
 ```
 
@@ -1138,7 +1142,7 @@ Information about the account that owns the project.
 ```ts
 type AccountContext = {
   id: string;
-  name: string; // e.g. my-account
+  name: string; // For example, my-account
 };
 ```
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -71,7 +71,7 @@ on:
 
 The value is a string. It can include `${{ }}` expressions. EAS renders the template when it creates the run, before any job starts.
 
-The expression can use the [`github`](#github), [`app_store_connect`](#app_store_connect), `inputs`, [`workflow`](#workflow), `app`, and `account` contexts. It supports all [context functions](#context-functions) except `success()`, `failure()`, and `hashFiles()`. Those functions need a job or step that has already run.
+The expression can use the [`github`](#github), [`app_store_connect`](#app_store_connect), [`inputs`](#inputs), [`workflow`](#workflow), [`app`](#app), and [`account`](#account) contexts. It supports all [context functions](#context-functions) except `success()`, `failure()`, and `hashFiles()`. Those functions need a job or step that has already run.
 
 Job-level contexts such as `needs`, `steps`, and `env` are not available. If the template references an unsupported context, the run fails. EAS stores an error and does not store a custom title.
 
@@ -495,7 +495,7 @@ The expression must fit in one `${{ }}` block and can be at most 250 characters.
 
 When the condition evaluates to false, no workflow run starts for that trigger event. A retry of an existing run skips this check. It only applies when a new run is created.
 
-The expression can use the [`github`](#github), [`app_store_connect`](#app_store_connect), `inputs`, [`workflow`](#workflow), `app`, and `account` contexts. It supports all [context functions](#context-functions) except `success()`, `failure()`, and `hashFiles()`. Those functions need a job or step that has already run, but a trigger's `if` condition evaluates before any job starts.
+The expression can use the [`github`](#github), [`app_store_connect`](#app_store_connect), [`inputs`](#inputs), [`workflow`](#workflow), [`app`](#app), and [`account`](#account) contexts. It supports all [context functions](#context-functions) except `success()`, `failure()`, and `hashFiles()`. Those functions need a job or step that has already run, but a trigger's `if` condition evaluates before any job starts.
 
 ```yaml
 on:
@@ -696,20 +696,104 @@ jobs:
 
 ## `concurrency`
 
-Configuration for concurrency control. Currently only allows setting `cancel_in_progress` for same-branch workflows.
+Controls how workflow runs of the same concurrency group overlap. Runs whose `group` renders to the same key belong to one group. When a new run arrives while another run of its group is active, the new run either waits for that run to finish or cancels it.
 
 ```yaml
 # @info #
 concurrency:
-  cancel_in_progress: true
   group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
 # @end #
 ```
 
-| Property             | Type     | Description                                                                                                                                             |
-| -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cancel_in_progress` | `true`   | If true, new workflow runs started from GitHub will cancel current in-progress runs for the same branch.                                                |
-| `group`              | `string` | We do not support custom concurrency groups yet. Set this placeholder value so that when we do support custom groups, your workflow remains compatible. |
+With this configuration, a new run cancels the unfinished runs of the same workflow file for the same branch. Only the newest run remains.
+
+| Property             | Type                    | Required    | Description                                                                                                                                                                 |
+| -------------------- | ----------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `group`              | `string`                | <YesIcon /> | The concurrency group key. Literal text and `${{ }}` expressions. See [`concurrency.group`](#concurrencygroup).                                                             |
+| `cancel_in_progress` | `boolean` or expression | <NoIcon />  | Whether the new run cancels the runs of its group instead of waiting for them. Defaults to `false`. See [`concurrency.cancel_in_progress`](#concurrencycancel_in_progress). |
+| `queue`              | `single` or `max`       | <NoIcon />  | How many runs can wait for the group. Defaults to `single`. See [`concurrency.queue`](#concurrencyqueue).                                                                   |
+
+### `concurrency.group`
+
+A template for the concurrency group key. Write literal text, `${{ }}` expressions, or both. EAS renders the template into the key once, when it creates the run.
+
+Each group belongs to one project. Runs of the same project with the same rendered key share one group, even when they come from different workflow files. Different projects never share a group. Each new run applies its own `cancel_in_progress` and `queue` settings to the whole group. For example, a run with `queue: single` replaces every waiting run in the group, even runs that another workflow file queued with `queue: max`. Use the same settings in every workflow file that shares a group.
+
+```yaml
+# Every workflow file that uses this key shares one group per branch.
+concurrency:
+  # @info #
+  group: deploy-${{ github.ref }}
+  # @end #
+```
+
+The expressions can use the [`github`](#github), [`app_store_connect`](#app_store_connect), [`inputs`](#inputs), [`workflow`](#workflow), [`app`](#app), and [`account`](#account) contexts. They support all [context functions](#context-functions) except `success()`, `failure()`, and `hashFiles()`. Job-level contexts such as `needs`, `after`, `steps`, and `env` are not available. EAS rejects a template that references any other name, such as a job-level context, `success()`, or a misspelled context, when it validates the workflow file, before it creates a run. [`eas workflow:validate`](/eas/workflows/troubleshooting/#validate-the-workflow-file) reports the same errors. See [Context availability](#context-availability).
+
+When EAS renders the key:
+
+- Each expression must evaluate to a string, a number, or a boolean. Other values, such as objects, fail the run.
+- A missing value renders as an empty string, so every run without that value gets the same key and shares one group. For example, `github.event.pull_request.number` is missing for `push` runs, so `e2e-${{ github.event.pull_request.number }}` puts every push run in the group `e2e-`. Use `||` to provide a fallback: `e2e-${{ github.event.pull_request.number || github.ref }}`.
+- If the rendered key is empty, the run fails. Add literal text such as `ci-` if every expression can be empty for some trigger.
+- The template can be at most 250 characters. EAS rejects a longer template when it validates the workflow file. The rendered key can be at most 2048 bytes. A longer key fails the run.
+
+If rendering fails, EAS creates the run, marks it as failed, and shows the error on the run's page. The run does not enter its group.
+
+### `concurrency.cancel_in_progress`
+
+Whether a new run cancels the runs of its group instead of waiting for them. The value is a boolean or a single `${{ }}` expression. Defaults to `false`.
+
+- `true`, or an expression that evaluates to a truthy value: the new run starts right away, and EAS cancels the active run and all waiting runs of its group. The new run does not wait for the canceled runs to stop.
+- `false`, or an expression that evaluates to a falsy value: the new run waits until the group is free. `false` behaves the same as omitting the property.
+
+For deploys, leave `cancel_in_progress` out. The active deploy always finishes. The newest run waits for it, and EAS replaces the runs in between.
+
+```yaml
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+```
+
+With an expression, you decide per run. In this example, a new run on a feature branch cancels the stale runs of that branch. On `main`, runs wait for each other instead, so a deploy is never interrupted.
+
+```yaml
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  # @info #
+  cancel_in_progress: ${{ github.ref_name != 'main' }}
+  # @end #
+```
+
+EAS evaluates the expression once, when it creates the run. The expression must be one `${{ }}` block of at most 250 characters. It can use the same contexts and functions as [`concurrency.group`](#concurrencygroup), and EAS validates it the same way when it validates the workflow file. If the expression fails to evaluate, EAS creates the run and marks it as failed. The run does not cancel anything and does not enter its group.
+
+### `concurrency.queue`
+
+How many runs can wait for the group. Defaults to `single`.
+
+- `single`: only the newest run waits. When a newer run arrives, it replaces the run that is waiting. EAS cancels the replaced run, which never starts.
+- `max`: up to 100 runs wait. They start one at a time, in the order EAS created them. When 100 runs are already waiting, EAS cancels the new run.
+
+Use `max` when every run must execute, such as database migrations. With a literal key such as `migrate-production`, runs from every branch wait for each other.
+
+```yaml
+concurrency:
+  group: migrate-production
+  # @info #
+  queue: max
+  # @end #
+```
+
+You cannot combine `queue: max` with `cancel_in_progress: true`. EAS rejects the combination when it validates the workflow file. When `cancel_in_progress` is an expression, EAS checks each run when it creates it. If the expression evaluates to a truthy value while `queue` is `max`, EAS marks the new run as failed. The run does not cancel anything and does not enter its group.
+
+### Waiting and canceled runs
+
+- A run that waits for its group shows as **Queued** in the EAS dashboard, with a link to the run it waits for. `eas workflow:run --wait` prints "Workflow run is queued" with the name of that run. For runs triggered from GitHub, the commit status reads "Workflow run is waiting for another run in its concurrency group."
+- A waiting run has no jobs. It does not use build minutes or one of your account's concurrencies until it starts.
+- When the active run finishes, fails, or is canceled, the next waiting run starts. A run that needs a user action, such as an approval in a [`require-approval`](#require-approval) job, holds its group until it succeeds, fails, or is canceled.
+- A waiting run fails instead of starting if it waited more than 30 days, if its uploaded project sources expired, or if the user who started it lost access to the project. EAS then starts the next waiting run.
+- A run that `cancel_in_progress` canceled, whether it was active or waiting, shows as canceled with "Canceled by" and a link to the newer run.
+- A waiting run that a newer run replaced under `queue: single` shows as canceled with "Replaced by" and a link to the newer run. A run that EAS canceled because a `queue: max` group already had 100 waiting runs shows "Queue was full (limit 100)".
+- The GitHub commit status and `eas workflow:run --wait` show these runs as canceled without the reason. Open the run in the EAS dashboard to see it.
+- You can cancel a waiting run the same way as any other run.
 
 ## Control flow
 
@@ -770,6 +854,39 @@ jobs:
 You can customize the behavior of a workflow — commands to execute, control flow, environment variables, build profile, app version, and more — based on the workflow run's context.
 
 Use the `${{ expression }}` syntax to access context properties and functions. For example: `${{ github.ref_name }}` or `${{ needs.build_ios.outputs.build_id }}`.
+
+### Context availability
+
+EAS evaluates `${{ }}` expressions at three points. Each point has its own set of contexts and functions.
+
+- **Run creation**: [`run_name`](#run_name), [`on.<trigger>.if`](#ontriggerif), [`concurrency.group`](#concurrencygroup), and [`concurrency.cancel_in_progress`](#concurrencycancel_in_progress). EAS evaluates them when it creates the run, before any job exists.
+- **Job**: every field of a job except `steps`, `hooks`, and `outputs`, for example [`jobs.<job_id>.if`](#jobsjob_idif), `env`, and `params`. EAS evaluates them when the job is ready to start.
+- **Steps**: [`jobs.<job_id>.steps`](#jobsjob_idsteps), [`jobs.<job_id>.hooks`](#jobsjob_idhooks), and [`jobs.<job_id>.outputs`](#jobsjob_idoutputs). EAS evaluates them on the worker while the job runs.
+
+| Context or function                                                                                     | Run creation | Job         | Steps                           |
+| ------------------------------------------------------------------------------------------------------- | ------------ | ----------- | ------------------------------- |
+| [`github`](#github)                                                                                     | <YesIcon />  | <YesIcon /> | <YesIcon />                     |
+| [`inputs`](#inputs)                                                                                     | <YesIcon />  | <YesIcon /> | <YesIcon />                     |
+| [`workflow`](#workflow)                                                                                 | <YesIcon />  | <YesIcon /> | <YesIcon />                     |
+| [`app`](#app)                                                                                           | <YesIcon />  | <YesIcon /> | <YesIcon />                     |
+| [`account`](#account)                                                                                   | <YesIcon />  | <YesIcon /> | <YesIcon />                     |
+| [`app_store_connect`](#app_store_connect)                                                               | <YesIcon />  | <YesIcon /> | <YesIcon /> (`build` jobs only) |
+| [`needs`](#needs)                                                                                       | <NoIcon />   | <YesIcon /> | <YesIcon />                     |
+| [`after`](#after)                                                                                       | <NoIcon />   | <YesIcon /> | <YesIcon />                     |
+| [`env`](#env)                                                                                           | <NoIcon />   | <YesIcon /> | <YesIcon />                     |
+| [`steps`](#steps)                                                                                       | <NoIcon />   | <NoIcon />  | <YesIcon />                     |
+| [`always()`](#always) and [`never()`](#never)                                                           | <YesIcon />  | <YesIcon /> | <YesIcon />                     |
+| [`success()`](#success) and [`failure()`](#failure)                                                     | <NoIcon />   | <YesIcon /> | <YesIcon />                     |
+| `fromJSON()`, `toJSON()`, `contains()`, `startsWith()`, `endsWith()`, `replaceAll()`, and `substring()` | <YesIcon />  | <YesIcon /> | <YesIcon />                     |
+| `hashFiles()`                                                                                           | <NoIcon />   | <NoIcon />  | <YesIcon />                     |
+
+In [`on.<trigger>.if`](#ontriggerif), the `workflow` context has only `name` and `filename`. EAS evaluates the condition before it creates the run, so `workflow.id` and `workflow.url` do not exist yet.
+
+`app_store_connect` has values only for runs that an App Store Connect event triggered. In steps, only `build` jobs receive it.
+
+At the job level, `env` is available only after EAS resolves the job's [`environment`](#jobsjob_idenvironment) (`production`, `preview`, or `development`). The fields EAS reads to resolve it cannot use `env`: `jobs.<job_id>.environment` itself, and the `params` of a `build` job that has no explicit `environment`. In [`jobs.<job_id>.if`](#jobsjob_idif), a condition that references `env` fails the job when EAS cannot resolve the environment, for example because the job's params are invalid. To make `env` available regardless of the job's params, set `environment` on the job.
+
+For `on.<trigger>.if` and `concurrency`, EAS rejects a reference to an unavailable context or function when it validates the workflow file. EAS does not check `run_name` at that time. A `run_name` template that references an unavailable context or function fails the run when EAS renders the title.
 
 ### Context properties
 
@@ -846,7 +963,7 @@ jobs:
 
 A record of all steps in the current job. Each step provides its outputs set using the [`set-output`](#set-output) function.
 
-> **Note:** The `steps` context is only available within a job's steps, not at the workflow level. To expose a step's output to other jobs, use the [`set-output`](#set-output) function and [`outputs` configuration of the job](#jobsjob_idoutputs).
+> **Note:** The `steps` context is only available within a job's steps, not at the workflow level. To expose a step's output to other jobs, use the [`set-output`](#set-output) function and [`outputs` configuration of the job](#jobsjob_idoutputs). See [Context availability](#context-availability).
 
 Example:
 
@@ -990,6 +1107,43 @@ jobs:
         View details: ${{ workflow.url }}
 ```
 
+#### `app`
+
+Information about the project the workflow run belongs to.
+
+```ts
+type AppContext = {
+  id: string;
+  slug: string; // e.g. my-app
+};
+```
+
+Example:
+
+```yaml
+jobs:
+  notify:
+    type: slack
+    params:
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      message: ${{ account.name }}/${{ app.slug }} started ${{ workflow.name }}
+```
+
+The example reads the webhook URL from a `SLACK_WEBHOOK_URL` [environment variable](/eas/environment-variables/manage/#manage-environment-variables). Create it in the `production` environment before running the workflow.
+
+#### `account`
+
+Information about the account that owns the project.
+
+```ts
+type AccountContext = {
+  id: string;
+  name: string; // e.g. my-account
+};
+```
+
+See the [`app`](#app) example, which uses both contexts in one Slack message.
+
 #### `app_store_connect`
 
 Information about App Store Connect entities associated with the workflow run. This context is available only for workflows triggered by an App Store Connect event. See [`on.app_store_connect`](#onapp_store_connect).
@@ -1080,7 +1234,7 @@ jobs:
 
 A record of environment variables available in the current job context.
 
-> **Note:** The `env` context is only available within a job's context, not at the workflow level.
+> **Note:** The `env` context is available in jobs and steps, not when EAS creates the run. In job fields, it is available only after EAS resolves the job's environment. See [Context availability](#context-availability).
 
 Example:
 
@@ -1117,6 +1271,38 @@ jobs:
     if: ${{ failure() }}
     steps:
       - run: echo "A job failed"
+```
+
+#### `always()`
+
+Always returns `true`. Use it in a step's `if` to run the step even when an earlier step failed. In a job's `if`, `always()` does not override `needs`: EAS skips the job when a job in its `needs` list did not succeed. Use [`after`](#jobsjob_idafter) instead of `needs` to run a job regardless of another job's result.
+
+```yaml
+jobs:
+  test:
+    steps:
+      - uses: eas/checkout
+      - run: ./scripts/run-tests.sh # writes results into ./results
+      - uses: eas/upload_artifact
+        # @info #
+        if: ${{ always() }}
+        # @end #
+        with:
+          type: other
+          name: test-results
+          path: results/**/*
+```
+
+#### `never()`
+
+Always returns `false`. Use it to keep a job or step in the file without running it.
+
+```yaml
+jobs:
+  my_job:
+    if: ${{ never() }}
+    steps:
+      - run: echo "Never runs"
 ```
 
 #### `fromJSON(value)`
@@ -1197,7 +1383,7 @@ jobs:
 
 Returns a hash of files matching the provided glob patterns. Useful for cache keys.
 
-> **Note:** The `hashFiles` function is only available within a job's steps, not at the workflow level.
+> **Note:** The `hashFiles` function is only available within a job's steps, not at the workflow level. See [Context availability](#context-availability).
 
 Example:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `concurrency` section of the workflows syntax page still describes the placeholder-only behavior: a fixed `group` value and `cancel_in_progress: true`. Workflows are gaining custom `group` expressions, boolean or expression `cancel_in_progress`, `queue: single | max`, and a waiting run state. This PR adds the user-facing documentation for all of it.

The implementation PRs are still in review, but the docs are ready for a look now. This PR stays a draft and merges only after the feature ships.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Rewrote the `concurrency` section: a property table, one subsection per property (`group`, `cancel_in_progress`, `queue`) with a copy-paste-ready example each, and a section on how waiting and canceled runs appear in the dashboard, `eas workflow:run --wait`, and the GitHub commit status.
- Added a "Context availability" table to the Interpolation section that says which contexts and functions work at run creation, in job fields, and in steps. The existing `steps`, `env`, and `hashFiles` notes now link to it.
- Documented the `app` and `account` contexts and the `always()` and `never()` functions, which existed but were not on the page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- `pnpm lint-prose` and `oxfmt --check` pass on the page.
- Every YAML example in the changed sections was parsed with the server's workflow schema to confirm it validates as written.
- Every intra-page anchor added here resolves to a heading on the page.
- Behavior statements were checked against the server implementation and the dashboard and eas-cli copy.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

