### PR TITLE
[widgets][iOS] Preserve view identity across widget and Live Activity updates

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Preserve SwiftUI view identity across widget and Live Activity updates so system update animations can run.
 - [iOS] Localize widget gallery names and descriptions using the app's `Localizable.strings` files. ([#49606](https://github.com/expo/expo/pull/49606) by [@jakex7](https://github.com/jakex7))
 - [iOS] Fix widget and Live Activity `Text` modifiers being applied twice. ([#49535](https://github.com/expo/expo/pull/49535) by [@gee1k](https://github.com/gee1k))
 - Resolve deep `react-native/*` imports as empty modules when bundling widget layouts, fixing every widget failing with "Could not create context for layout evaluation" after `@expo/ui` 57.0.14 introduced such an import. ([#49491](https://github.com/expo/expo/pull/49491) by [@usmsam](https://github.com/usmsam))

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [iOS] Add support for `Overlay`, `Background`, and `Mask` in widgets and Live Activities. ([#49810](https://github.com/expo/expo/pull/49810) by [@jakex7](https://github.com/jakex7))
 - [iOS] Expose stable ActivityKit identifiers on Live Activity instances. ([#48589](https://github.com/expo/expo/pull/48589) by [@developwithJB](https://github.com/developwithJB))
 - [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
 - [iOS] Expose ActivityKit's `staleDate` on `LiveActivity.start()` and `LiveActivity.update()`. ([#46343](https://github.com/expo/expo/pull/46343) by [@KyleAsaff](https://github.com/KyleAsaff))
@@ -25,7 +26,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Preserve SwiftUI view identity across widget and Live Activity updates so system update animations can run.
+- [iOS] Preserve SwiftUI view identity across widget and Live Activity updates so system update animations can run. ([#49810](https://github.com/expo/expo/pull/49810) by [@jakex7](https://github.com/jakex7))
 - [iOS] Localize widget gallery names and descriptions using the app's `Localizable.strings` files. ([#49606](https://github.com/expo/expo/pull/49606) by [@jakex7](https://github.com/jakex7))
 - [iOS] Fix widget and Live Activity `Text` modifiers being applied twice. ([#49535](https://github.com/expo/expo/pull/49535) by [@gee1k](https://github.com/gee1k))
 - Resolve deep `react-native/*` imports as empty modules when bundling widget layouts, fixing every widget failing with "Could not create context for layout evaluation" after `@expo/ui` 57.0.14 introduced such an import. ([#49491](https://github.com/expo/expo/pull/49491) by [@usmsam](https://github.com/usmsam))

--- a/packages/expo-widgets/bundle/__tests__/decorator.test.ts
+++ b/packages/expo-widgets/bundle/__tests__/decorator.test.ts
@@ -1,5 +1,6 @@
 import '../index';
 import { jsx, jsxs } from '../jsx-runtime-stub';
+import { Children } from '../react-stub';
 
 jest.mock('@expo/ui/swift-ui', () => ({}));
 jest.mock('@expo/ui/swift-ui/modifiers', () => ({}));
@@ -13,8 +14,14 @@ describe('jsx-runtime-stub', () => {
     globalThis.__expoWidgetLayout = () =>
       jsxs('View', {
         children: [
-          jsx('Button', { label: 'First', onButtonPress: () => ({ id: 'first' }) }),
-          jsx('Button', { label: 'Second', onButtonPress: () => ({ id: 'second' }) }),
+          jsx('Button', {
+            label: 'First',
+            onButtonPress: () => ({ id: 'first' }),
+          }),
+          jsx('Button', {
+            label: 'Second',
+            onButtonPress: () => ({ id: 'second' }),
+          }),
         ],
       });
 
@@ -28,10 +35,22 @@ describe('jsx-runtime-stub', () => {
     globalThis.__expoWidgetLayout = () =>
       jsxs('View', {
         children: [
-          jsx('FilledTonalButton', { label: 'First', onButtonPress: () => ({ id: 'first' }) }),
-          jsx('OutlinedButton', { label: 'Second', onButtonPress: () => ({ id: 'second' }) }),
-          jsx('ElevatedButton', { label: 'Third', onButtonPress: () => ({ id: 'third' }) }),
-          jsx('TextButton', { label: 'Fourth', onButtonPress: () => ({ id: 'fourth' }) }),
+          jsx('FilledTonalButton', {
+            label: 'First',
+            onButtonPress: () => ({ id: 'first' }),
+          }),
+          jsx('OutlinedButton', {
+            label: 'Second',
+            onButtonPress: () => ({ id: 'second' }),
+          }),
+          jsx('ElevatedButton', {
+            label: 'Third',
+            onButtonPress: () => ({ id: 'third' }),
+          }),
+          jsx('TextButton', {
+            label: 'Fourth',
+            onButtonPress: () => ({ id: 'fourth' }),
+          }),
         ],
       });
 
@@ -63,6 +82,29 @@ describe('jsx-runtime-stub', () => {
     expect(tree.props.children.props.children.props.target).toBe('__expo_widgets_target_0_row-1');
   });
 
+  it('does not use private function-component identity when generating button targets', () => {
+    function KeyedRow(props: { children: unknown }) {
+      return jsx('Row', props);
+    }
+
+    globalThis.__expoWidgetLayout = () =>
+      jsx(
+        KeyedRow,
+        {
+          children: jsx('Button', {
+            label: 'Press',
+            onButtonPress: () => ({ id: 'nested' }),
+          }),
+        },
+        'row-1'
+      );
+
+    const tree = globalThis.__expoWidgetRender({}, { timestamp: 1 }) as any;
+
+    expect(tree.__expoWidgetIdentity).toContain('row-1');
+    expect(tree.props.children.props.target).toBe('__expo_widgets_target_0');
+  });
+
   it('preserves explicit button targets', () => {
     globalThis.__expoWidgetLayout = () =>
       jsx('Button', {
@@ -76,6 +118,25 @@ describe('jsx-runtime-stub', () => {
     expect(tree.props.target).toBe('custom-target');
   });
 
+  it('preserves public keys for button targets after Children.toArray', () => {
+    const onPress = jest.fn(() => ({ id: 'pressed' }));
+    globalThis.__expoWidgetLayout = () =>
+      jsx('View', {
+        children: Children.toArray([
+          [jsx('Row', { children: jsx('Button', { onButtonPress: onPress }) }, 'row-1')],
+        ]),
+      });
+
+    const tree = globalThis.__expoWidgetRender({}, {}) as any;
+    const target = tree.props.children[0].props.children.props.target;
+
+    expect(target).toBe('__expo_widgets_target_0_row-1');
+    expect(globalThis.__expoWidgetHandlePress({}, { target })).toEqual({
+      id: 'pressed',
+    });
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
   it('reuses generated button targets when handling presses', () => {
     const firstPress = jest.fn(() => ({ id: 'first' }));
     const secondPress = jest.fn(() => ({ id: 'second' }));
@@ -85,12 +146,22 @@ describe('jsx-runtime-stub', () => {
         children: [
           jsx(
             'Row',
-            { children: jsx('Button', { label: 'First', onButtonPress: firstPress }) },
+            {
+              children: jsx('Button', {
+                label: 'First',
+                onButtonPress: firstPress,
+              }),
+            },
             'row-1'
           ),
           jsx(
             'Row',
-            { children: jsx('Button', { label: 'Second', onButtonPress: secondPress }) },
+            {
+              children: jsx('Button', {
+                label: 'Second',
+                onButtonPress: secondPress,
+              }),
+            },
             'row-2'
           ),
         ],

--- a/packages/expo-widgets/bundle/__tests__/decorator.test.ts
+++ b/packages/expo-widgets/bundle/__tests__/decorator.test.ts
@@ -1,6 +1,5 @@
 import '../index';
 import { jsx, jsxs } from '../jsx-runtime-stub';
-import { Children } from '../react-stub';
 
 jest.mock('@expo/ui/swift-ui', () => ({}));
 jest.mock('@expo/ui/swift-ui/modifiers', () => ({}));
@@ -14,14 +13,8 @@ describe('jsx-runtime-stub', () => {
     globalThis.__expoWidgetLayout = () =>
       jsxs('View', {
         children: [
-          jsx('Button', {
-            label: 'First',
-            onButtonPress: () => ({ id: 'first' }),
-          }),
-          jsx('Button', {
-            label: 'Second',
-            onButtonPress: () => ({ id: 'second' }),
-          }),
+          jsx('Button', { label: 'First', onButtonPress: () => ({ id: 'first' }) }),
+          jsx('Button', { label: 'Second', onButtonPress: () => ({ id: 'second' }) }),
         ],
       });
 
@@ -35,22 +28,10 @@ describe('jsx-runtime-stub', () => {
     globalThis.__expoWidgetLayout = () =>
       jsxs('View', {
         children: [
-          jsx('FilledTonalButton', {
-            label: 'First',
-            onButtonPress: () => ({ id: 'first' }),
-          }),
-          jsx('OutlinedButton', {
-            label: 'Second',
-            onButtonPress: () => ({ id: 'second' }),
-          }),
-          jsx('ElevatedButton', {
-            label: 'Third',
-            onButtonPress: () => ({ id: 'third' }),
-          }),
-          jsx('TextButton', {
-            label: 'Fourth',
-            onButtonPress: () => ({ id: 'fourth' }),
-          }),
+          jsx('FilledTonalButton', { label: 'First', onButtonPress: () => ({ id: 'first' }) }),
+          jsx('OutlinedButton', { label: 'Second', onButtonPress: () => ({ id: 'second' }) }),
+          jsx('ElevatedButton', { label: 'Third', onButtonPress: () => ({ id: 'third' }) }),
+          jsx('TextButton', { label: 'Fourth', onButtonPress: () => ({ id: 'fourth' }) }),
         ],
       });
 
@@ -82,29 +63,6 @@ describe('jsx-runtime-stub', () => {
     expect(tree.props.children.props.children.props.target).toBe('__expo_widgets_target_0_row-1');
   });
 
-  it('does not use private function-component identity when generating button targets', () => {
-    function KeyedRow(props: { children: unknown }) {
-      return jsx('Row', props);
-    }
-
-    globalThis.__expoWidgetLayout = () =>
-      jsx(
-        KeyedRow,
-        {
-          children: jsx('Button', {
-            label: 'Press',
-            onButtonPress: () => ({ id: 'nested' }),
-          }),
-        },
-        'row-1'
-      );
-
-    const tree = globalThis.__expoWidgetRender({}, { timestamp: 1 }) as any;
-
-    expect(tree.__expoWidgetIdentity).toContain('row-1');
-    expect(tree.props.children.props.target).toBe('__expo_widgets_target_0');
-  });
-
   it('preserves explicit button targets', () => {
     globalThis.__expoWidgetLayout = () =>
       jsx('Button', {
@@ -118,25 +76,6 @@ describe('jsx-runtime-stub', () => {
     expect(tree.props.target).toBe('custom-target');
   });
 
-  it('preserves public keys for button targets after Children.toArray', () => {
-    const onPress = jest.fn(() => ({ id: 'pressed' }));
-    globalThis.__expoWidgetLayout = () =>
-      jsx('View', {
-        children: Children.toArray([
-          [jsx('Row', { children: jsx('Button', { onButtonPress: onPress }) }, 'row-1')],
-        ]),
-      });
-
-    const tree = globalThis.__expoWidgetRender({}, {}) as any;
-    const target = tree.props.children[0].props.children.props.target;
-
-    expect(target).toBe('__expo_widgets_target_0_row-1');
-    expect(globalThis.__expoWidgetHandlePress({}, { target })).toEqual({
-      id: 'pressed',
-    });
-    expect(onPress).toHaveBeenCalledTimes(1);
-  });
-
   it('reuses generated button targets when handling presses', () => {
     const firstPress = jest.fn(() => ({ id: 'first' }));
     const secondPress = jest.fn(() => ({ id: 'second' }));
@@ -146,22 +85,12 @@ describe('jsx-runtime-stub', () => {
         children: [
           jsx(
             'Row',
-            {
-              children: jsx('Button', {
-                label: 'First',
-                onButtonPress: firstPress,
-              }),
-            },
+            { children: jsx('Button', { label: 'First', onButtonPress: firstPress }) },
             'row-1'
           ),
           jsx(
             'Row',
-            {
-              children: jsx('Button', {
-                label: 'Second',
-                onButtonPress: secondPress,
-              }),
-            },
+            { children: jsx('Button', { label: 'Second', onButtonPress: secondPress }) },
             'row-2'
           ),
         ],

--- a/packages/expo-widgets/bundle/__tests__/jsx-runtime.test.ts
+++ b/packages/expo-widgets/bundle/__tests__/jsx-runtime.test.ts
@@ -1,87 +1,257 @@
 import '../index';
 import { jsx, jsxs } from '../jsx-runtime-stub';
+import { Children } from '../react-stub';
 
 jest.mock('@expo/ui/swift-ui', () => ({}));
 jest.mock('@expo/ui/swift-ui/modifiers', () => ({}));
 
-describe('jsx-runtime-stub children flattening', () => {
+function render(tree: unknown): any {
+  globalThis.__expoWidgetLayout = () => tree as Record<string, unknown>;
+  return globalThis.__expoWidgetRender({}, { timestamp: 1 });
+}
+
+describe('jsx-runtime-stub', () => {
   afterEach(() => {
     delete globalThis.__expoWidgetLayout;
   });
 
-  it('flattens a .map() array mixed with sibling elements into a flat children list', () => {
-    const items = ['Hello', 'World'];
-    const tree = jsxs('HStackView', {
-      children: [items.map((item) => jsx('TextView', { text: item }, item)), jsx('SpacerView', {})],
+  it('flattens nested children at render time without mutating the source tree', () => {
+    const child = jsx('TextView', { text: 'a' }, 'a');
+    const source = jsx('VStackView', {
+      children: [[child, [jsx('TextView', { text: 'b' }, 'b')]], jsx('SpacerView', {})],
     });
+    const tree = render(source);
 
-    expect(tree.props.children).toHaveLength(3);
+    expect(tree).not.toBe(source);
+    expect(tree.props).not.toBe(source.props);
     expect(tree.props.children.map((child: any) => child.type)).toEqual([
       'TextView',
       'TextView',
       'SpacerView',
     ]);
-    expect(tree.props.children[0].props.text).toBe('Hello');
-    expect(tree.props.children[1].props.text).toBe('World');
-  });
-
-  it('flattens deeply nested children arrays while preserving order', () => {
-    const tree = jsxs('VStackView', {
-      children: [
-        jsx('TextView', { text: 'first' }),
-        [
-          jsx('TextView', { text: 'second' }),
-          [jsx('TextView', { text: 'third' }), jsx('TextView', { text: 'fourth' })],
-        ],
-        jsx('SpacerView', {}),
-      ],
-    });
-
-    expect(tree.props.children.map((child: any) => child.props.text ?? null)).toEqual([
-      'first',
-      'second',
-      'third',
-      'fourth',
-      null,
+    expect(tree.props.children.map((child: any) => child.__expoWidgetIdentity)).toEqual([
+      '["TextView","a"]',
+      '["TextView","b"]',
+      '["SpacerView",2]',
     ]);
+    expect(Array.isArray(source.props.children[0])).toBe(true);
+    expect(child.__expoWidgetIdentity).toBeUndefined();
   });
 
-  it('leaves a single non-array child untouched', () => {
-    const tree = jsx('HStackView', {
-      children: jsx('TextView', { text: 'only' }),
-    });
+  it('preserves single children, text and conditional placeholders', () => {
+    const tree = render(
+      jsx('VStackView', {
+        children: jsx('TextView', { children: ['count: ', [5, false, null]] }),
+      })
+    );
 
     expect(Array.isArray(tree.props.children)).toBe(false);
-    expect(tree.props.children.props.text).toBe('only');
+    expect(tree.props.children.__expoWidgetIdentity).toBe('["TextView",0]');
+    expect(tree.props.children.props.children).toEqual(['count: ', 5, false, null]);
   });
 
-  it('preserves text and conditional children in mixed arrays', () => {
-    const tree = jsxs('TextView', {
-      children: ['count: ', 5, false],
+  it('uses native type and key for identity, not props', () => {
+    const first = render(jsx('TextView', { text: 'first' }, 'label'));
+    const updated = render(jsx('TextView', { text: 'second' }, 'label'));
+
+    expect(first.__expoWidgetIdentity).toBe('["TextView","label"]');
+    expect(updated.__expoWidgetIdentity).toBe(first.__expoWidgetIdentity);
+    expect(render(jsx('TextView', {}, 'other')).__expoWidgetIdentity).not.toBe(
+      first.__expoWidgetIdentity
+    );
+    expect(render(jsx('ImageView', {}, 'label')).__expoWidgetIdentity).not.toBe(
+      first.__expoWidgetIdentity
+    );
+  });
+
+  it('keeps explicit numeric keys distinct from positional fallbacks', () => {
+    const tree = render(
+      jsx('VStackView', {
+        children: [jsx('TextView', {}, 1), jsx('TextView', {})],
+      })
+    );
+
+    expect(tree.props.children[0].__expoWidgetIdentity).toBe('["TextView","1"]');
+    expect(tree.props.children[1].__expoWidgetIdentity).toBe('["TextView",1]');
+  });
+
+  it('preserves the outer component key without changing the host key or source element', () => {
+    const host = jsx('TextView', {}, 'inner');
+    const Inner = () => host;
+    const Outer = jest.fn(() => jsx(Inner, {}));
+    const source = jsx(Outer, {}, 'outer');
+
+    expect(source.type).toBe(Outer);
+    expect(Outer).not.toHaveBeenCalled();
+
+    const tree = render(source);
+    expect(Outer).toHaveBeenCalledTimes(1);
+    expect(tree.__expoWidgetIdentity).toBe('["TextView","outer"]');
+    expect(tree.key).toBe('inner');
+    expect(host.__expoWidgetIdentity).toBeUndefined();
+  });
+
+  it('lets parents inspect unresolved child component types', () => {
+    function Text(props: { children: unknown }) {
+      const nestedText = Children.toArray(props.children).filter(
+        (child: any) => child?.type === Text
+      );
+      return jsx('TextView', { children: nestedText });
+    }
+    const tree = render(
+      jsx(Text, {
+        children: jsx(Text, { children: 'nested' }, 'nested'),
+      })
+    );
+
+    expect(tree.props.children).toHaveLength(1);
+    expect(tree.props.children[0].__expoWidgetIdentity).toBe('["TextView","nested"]');
+  });
+
+  it('keeps recreated layout helpers stable while their props update', () => {
+    globalThis.__expoWidgetLayout = ({ text }) => {
+      function Row() {
+        return jsx('TextView', { text });
+      }
+      return jsx('VStackView', { children: jsx(Row, {}, 'row') });
+    };
+
+    const first = globalThis.__expoWidgetRender({ text: 'first' }, {}) as any;
+    const second = globalThis.__expoWidgetRender({ text: 'second' }, {}) as any;
+
+    expect(first.props.children.__expoWidgetIdentity).toBe('["TextView","row"]');
+    expect(second.props.children.__expoWidgetIdentity).toBe(
+      first.props.children.__expoWidgetIdentity
+    );
+    expect(second.props.children.props.text).toBe('second');
+  });
+
+  it('treats function components as transparent wrappers for identity', () => {
+    const First = () => jsx('TextView', { text: 'first' });
+    const Second = () => jsx('TextView', { text: 'second' });
+
+    expect(render(jsx(First, {})).__expoWidgetIdentity).toBe('["TextView",0]');
+    expect(render(jsx(Second, {})).__expoWidgetIdentity).toBe('["TextView",0]');
+  });
+
+  it('keeps explicitly keyed children stable when a mapped list changes', () => {
+    const Row = ({ text }: { text: string }) => jsx('TextView', { text });
+    const makeTree = (items: string[]) =>
+      jsx('VStackView', {
+        children: [items.map((text) => jsx(Row, { text }, text)), jsx('SpacerView', {}, 'spacer')],
+      });
+    const first = render(makeTree(['a', 'b']));
+    const second = render(makeTree(['b', 'a', 'c']));
+    const identities = (tree: any) =>
+      Object.fromEntries(
+        tree.props.children.map((child: any) => [
+          child.props.text ?? 'spacer',
+          child.__expoWidgetIdentity,
+        ])
+      );
+
+    expect(identities(second)).toMatchObject(identities(first));
+  });
+
+  it('wraps array-returning components in a fragment that retains the component key', () => {
+    const Row = () => [jsx('TextView', {}, 'a'), jsx('TextView', {}, 'b')];
+    const tree = render(
+      jsx('VStackView', {
+        children: [jsx(Row, {}, 'row'), jsx('SpacerView', {})],
+      })
+    );
+
+    expect(tree.props.children[0].__expoWidgetIdentity).toBe('["react.fragment","row"]');
+    expect(
+      tree.props.children[0].props.children.map((child: any) => child.__expoWidgetIdentity)
+    ).toEqual(['["TextView","a"]', '["TextView","b"]']);
+  });
+
+  it('assigns unkeyed identities by position without mutating reused elements', () => {
+    const child = jsx('TextView', {});
+    const tree = render(jsx('VStackView', { children: [null, child, child] }));
+
+    expect(tree.props.children[1].__expoWidgetIdentity).toBe('["TextView",1]');
+    expect(tree.props.children[2].__expoWidgetIdentity).toBe('["TextView",2]');
+    expect(tree.props.children[1]).not.toBe(tree.props.children[2]);
+    expect(child.__expoWidgetIdentity).toBeUndefined();
+  });
+
+  it('normalizes Live Activity roots using their section name as the positional fallback', () => {
+    const tree = render({
+      banner: jsx('TextView', { text: 'banner' }),
+      compactTrailing: jsx('TextView', { text: 'trailing' }),
     });
 
-    expect(tree.props.children).toEqual(['count: ', 5, false]);
+    expect(tree.banner.__expoWidgetIdentity).toBe('["TextView","banner"]');
+    expect(tree.compactTrailing.__expoWidgetIdentity).toBe('["TextView","compactTrailing"]');
   });
 
-  it('finds and presses a button rendered inside a .map() mixed with siblings', () => {
-    const onPress = jest.fn(() => ({ id: 'pressed' }));
+  it.each(['widget', 'liveActivity'])('applies explicit keys to %s roots', (kind) => {
+    const renderRoot = (key: string) => {
+      const root = jsx('VStackView', { children: jsx('TextView', {}) }, key);
+      return kind === 'widget' ? render(root) : render({ banner: root }).banner;
+    };
+    const first = renderRoot('first');
+    const second = renderRoot('second');
 
+    expect(first.__expoWidgetIdentity).toBe('["VStackView","first"]');
+    expect(second.__expoWidgetIdentity).toBe('["VStackView","second"]');
+    expect(first.props.children.__expoWidgetIdentity).toBe(
+      second.props.children.__expoWidgetIdentity
+    );
+  });
+
+  it('finds and presses a button inside a mapped list', () => {
+    const onPress = jest.fn(() => ({ id: 'pressed' }));
     globalThis.__expoWidgetLayout = () =>
       jsxs('HStackView', {
         children: [
           ['a', 'b'].map((label) =>
-            jsx('Button', { label, onButtonPress: label === 'b' ? onPress : () => ({}) }, label)
+            jsx(
+              'Button',
+              {
+                label,
+                onButtonPress: label === 'b' ? onPress : () => ({}),
+              },
+              label
+            )
           ),
           jsx('SpacerView', {}),
         ],
       });
-
-    const tree = globalThis.__expoWidgetRender({}, { timestamp: 1 }) as any;
+    const tree = globalThis.__expoWidgetRender({}, {}) as any;
     const target = tree.props.children[1].props.target;
 
-    const result = globalThis.__expoWidgetHandlePress({}, { timestamp: 1, target });
-
-    expect(result).toEqual({ id: 'pressed' });
+    expect(globalThis.__expoWidgetHandlePress({}, { target })).toEqual({ id: 'pressed' });
     expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('React.Children stub', () => {
+  it('flattens and filters children without rewriting keys or mutating the source', () => {
+    const child = jsx('TextView', {}, 'label');
+    const children = [null, false, ['text', [child]], undefined];
+
+    expect(Children.toArray(children)).toEqual(['text', child]);
+    expect(Children.toArray(child)).toEqual([child]);
+    expect(Children.toArray(null)).toEqual([]);
+    expect(child.key).toBe('label');
+    expect(children).toEqual([null, false, ['text', [child]], undefined]);
+  });
+
+  it('preserves unique keys through flattening and reordering', () => {
+    const children = [[jsx('TextView', {}, 'a')], [jsx('TextView', {}, 'b')]];
+    const first = render(Children.toArray(children));
+    const second = render(Children.toArray(children).reverse());
+
+    expect(first.map((child: any) => child.__expoWidgetIdentity)).toEqual([
+      '["TextView","a"]',
+      '["TextView","b"]',
+    ]);
+    expect(second.map((child: any) => child.__expoWidgetIdentity)).toEqual([
+      '["TextView","b"]',
+      '["TextView","a"]',
+    ]);
   });
 });

--- a/packages/expo-widgets/bundle/__tests__/jsx-runtime.test.ts
+++ b/packages/expo-widgets/bundle/__tests__/jsx-runtime.test.ts
@@ -1,5 +1,5 @@
 import '../index';
-import { jsx, jsxs } from '../jsx-runtime-stub';
+import { jsx } from '../jsx-runtime-stub';
 import { Children } from '../react-stub';
 
 jest.mock('@expo/ui/swift-ui', () => ({}));
@@ -10,29 +10,23 @@ function render(tree: unknown): any {
   return globalThis.__expoWidgetRender({}, { timestamp: 1 });
 }
 
-describe('jsx-runtime-stub', () => {
+describe('widget rendering', () => {
   afterEach(() => {
     delete globalThis.__expoWidgetLayout;
   });
 
-  it('flattens nested children at render time without mutating the source tree', () => {
-    const child = jsx('TextView', { text: 'a' }, 'a');
+  it('flattens children and assigns keyed or positional identities without mutating JSX', () => {
+    const child = jsx('TextView', {});
     const source = jsx('VStackView', {
-      children: [[child, [jsx('TextView', { text: 'b' }, 'b')]], jsx('SpacerView', {})],
+      children: [[jsx('TextView', {}, 1), [child, child]], jsx('SpacerView', {})],
     });
     const tree = render(source);
 
-    expect(tree).not.toBe(source);
-    expect(tree.props).not.toBe(source.props);
-    expect(tree.props.children.map((child: any) => child.type)).toEqual([
-      'TextView',
-      'TextView',
-      'SpacerView',
-    ]);
     expect(tree.props.children.map((child: any) => child.__expoWidgetIdentity)).toEqual([
-      '["TextView","a"]',
-      '["TextView","b"]',
-      '["SpacerView",2]',
+      '["TextView","1"]',
+      '["TextView",1]',
+      '["TextView",2]',
+      '["SpacerView",3]',
     ]);
     expect(Array.isArray(source.props.children[0])).toBe(true);
     expect(child.__expoWidgetIdentity).toBeUndefined();
@@ -62,17 +56,6 @@ describe('jsx-runtime-stub', () => {
     expect(render(jsx('ImageView', {}, 'label')).__expoWidgetIdentity).not.toBe(
       first.__expoWidgetIdentity
     );
-  });
-
-  it('keeps explicit numeric keys distinct from positional fallbacks', () => {
-    const tree = render(
-      jsx('VStackView', {
-        children: [jsx('TextView', {}, 1), jsx('TextView', {})],
-      })
-    );
-
-    expect(tree.props.children[0].__expoWidgetIdentity).toBe('["TextView","1"]');
-    expect(tree.props.children[1].__expoWidgetIdentity).toBe('["TextView",1]');
   });
 
   it('preserves the outer component key without changing the host key or source element', () => {
@@ -108,123 +91,57 @@ describe('jsx-runtime-stub', () => {
     expect(tree.props.children[0].__expoWidgetIdentity).toBe('["TextView","nested"]');
   });
 
-  it('keeps recreated layout helpers stable while their props update', () => {
-    globalThis.__expoWidgetLayout = ({ text }) => {
-      function Row() {
-        return jsx('TextView', { text });
-      }
-      return jsx('VStackView', { children: jsx(Row, {}, 'row') });
+  it('keeps keyed rows stable across reordering, prop updates and recreated components', () => {
+    const renderRows = (items: string[], suffix: string) => {
+      const Row = ({ text }: { text: string }) => jsx('TextView', { text: text + suffix });
+      return render(jsx('VStackView', { children: items.map((text) => jsx(Row, { text }, text)) }));
     };
+    const first = renderRows(['a', 'b'], '1').props.children;
+    const second = renderRows(['b', 'a', 'c'], '2').props.children;
 
-    const first = globalThis.__expoWidgetRender({ text: 'first' }, {}) as any;
-    const second = globalThis.__expoWidgetRender({ text: 'second' }, {}) as any;
-
-    expect(first.props.children.__expoWidgetIdentity).toBe('["TextView","row"]');
-    expect(second.props.children.__expoWidgetIdentity).toBe(
-      first.props.children.__expoWidgetIdentity
-    );
-    expect(second.props.children.props.text).toBe('second');
-  });
-
-  it('treats function components as transparent wrappers for identity', () => {
-    const First = () => jsx('TextView', { text: 'first' });
-    const Second = () => jsx('TextView', { text: 'second' });
-
-    expect(render(jsx(First, {})).__expoWidgetIdentity).toBe('["TextView",0]');
-    expect(render(jsx(Second, {})).__expoWidgetIdentity).toBe('["TextView",0]');
-  });
-
-  it('keeps explicitly keyed children stable when a mapped list changes', () => {
-    const Row = ({ text }: { text: string }) => jsx('TextView', { text });
-    const makeTree = (items: string[]) =>
-      jsx('VStackView', {
-        children: [items.map((text) => jsx(Row, { text }, text)), jsx('SpacerView', {}, 'spacer')],
-      });
-    const first = render(makeTree(['a', 'b']));
-    const second = render(makeTree(['b', 'a', 'c']));
-    const identities = (tree: any) =>
-      Object.fromEntries(
-        tree.props.children.map((child: any) => [
-          child.props.text ?? 'spacer',
-          child.__expoWidgetIdentity,
-        ])
-      );
-
-    expect(identities(second)).toMatchObject(identities(first));
+    expect(second.map((child: any) => child.__expoWidgetIdentity)).toEqual([
+      first[1].__expoWidgetIdentity,
+      first[0].__expoWidgetIdentity,
+      '["TextView","c"]',
+    ]);
+    expect(second.map((child: any) => child.props.text)).toEqual(['b2', 'a2', 'c2']);
   });
 
   it('wraps array-returning components in a fragment that retains the component key', () => {
     const Row = () => [jsx('TextView', {}, 'a'), jsx('TextView', {}, 'b')];
-    const tree = render(
-      jsx('VStackView', {
-        children: [jsx(Row, {}, 'row'), jsx('SpacerView', {})],
-      })
-    );
+    const tree = render(jsx(Row, {}, 'row'));
 
-    expect(tree.props.children[0].__expoWidgetIdentity).toBe('["react.fragment","row"]');
-    expect(
-      tree.props.children[0].props.children.map((child: any) => child.__expoWidgetIdentity)
-    ).toEqual(['["TextView","a"]', '["TextView","b"]']);
+    expect(tree.__expoWidgetIdentity).toBe('["react.fragment","row"]');
+    expect(tree.props.children.map((child: any) => child.__expoWidgetIdentity)).toEqual([
+      '["TextView","a"]',
+      '["TextView","b"]',
+    ]);
   });
 
-  it('assigns unkeyed identities by position without mutating reused elements', () => {
-    const child = jsx('TextView', {});
-    const tree = render(jsx('VStackView', { children: [null, child, child] }));
-
-    expect(tree.props.children[1].__expoWidgetIdentity).toBe('["TextView",1]');
-    expect(tree.props.children[2].__expoWidgetIdentity).toBe('["TextView",2]');
-    expect(tree.props.children[1]).not.toBe(tree.props.children[2]);
-    expect(child.__expoWidgetIdentity).toBeUndefined();
-  });
-
-  it('normalizes Live Activity roots using their section name as the positional fallback', () => {
+  it('normalizes Live Activity roots using their key or section name', () => {
     const tree = render({
       banner: jsx('TextView', { text: 'banner' }),
       compactTrailing: jsx('TextView', { text: 'trailing' }),
+      compactLeading: jsx('TextView', {}, 'custom'),
     });
 
     expect(tree.banner.__expoWidgetIdentity).toBe('["TextView","banner"]');
     expect(tree.compactTrailing.__expoWidgetIdentity).toBe('["TextView","compactTrailing"]');
-  });
-
-  it.each(['widget', 'liveActivity'])('applies explicit keys to %s roots', (kind) => {
-    const renderRoot = (key: string) => {
-      const root = jsx('VStackView', { children: jsx('TextView', {}) }, key);
-      return kind === 'widget' ? render(root) : render({ banner: root }).banner;
-    };
-    const first = renderRoot('first');
-    const second = renderRoot('second');
-
-    expect(first.__expoWidgetIdentity).toBe('["VStackView","first"]');
-    expect(second.__expoWidgetIdentity).toBe('["VStackView","second"]');
-    expect(first.props.children.__expoWidgetIdentity).toBe(
-      second.props.children.__expoWidgetIdentity
-    );
+    expect(tree.compactLeading.__expoWidgetIdentity).toBe('["TextView","custom"]');
   });
 
   it('finds and presses a button inside a mapped list', () => {
-    const onPress = jest.fn(() => ({ id: 'pressed' }));
     globalThis.__expoWidgetLayout = () =>
-      jsxs('HStackView', {
+      jsx('HStackView', {
         children: [
-          ['a', 'b'].map((label) =>
-            jsx(
-              'Button',
-              {
-                label,
-                onButtonPress: label === 'b' ? onPress : () => ({}),
-              },
-              label
-            )
-          ),
+          ['a', 'b'].map((label) => jsx('Button', { onButtonPress: () => ({ id: label }) }, label)),
           jsx('SpacerView', {}),
         ],
       });
     const tree = globalThis.__expoWidgetRender({}, {}) as any;
     const target = tree.props.children[1].props.target;
 
-    expect(globalThis.__expoWidgetHandlePress({}, { target })).toEqual({ id: 'pressed' });
-    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(globalThis.__expoWidgetHandlePress({}, { target })).toEqual({ id: 'b' });
   });
 });
 
@@ -238,20 +155,5 @@ describe('React.Children stub', () => {
     expect(Children.toArray(null)).toEqual([]);
     expect(child.key).toBe('label');
     expect(children).toEqual([null, false, ['text', [child]], undefined]);
-  });
-
-  it('preserves unique keys through flattening and reordering', () => {
-    const children = [[jsx('TextView', {}, 'a')], [jsx('TextView', {}, 'b')]];
-    const first = render(Children.toArray(children));
-    const second = render(Children.toArray(children).reverse());
-
-    expect(first.map((child: any) => child.__expoWidgetIdentity)).toEqual([
-      '["TextView","a"]',
-      '["TextView","b"]',
-    ]);
-    expect(second.map((child: any) => child.__expoWidgetIdentity)).toEqual([
-      '["TextView","b"]',
-      '["TextView","a"]',
-    ]);
   });
 });

--- a/packages/expo-widgets/bundle/index.ts
+++ b/packages/expo-widgets/bundle/index.ts
@@ -18,6 +18,44 @@ declare global {
   var __expoWidgetEnvironment: Dictionary | undefined;
 }
 
+/**
+ * Resolve components at the render boundary so parents can inspect their JSX children.
+ * Identity is the native type plus the outermost explicit key, or flattened sibling index.
+ * Keys must be unique among flattened siblings; dynamic lists should provide explicit keys.
+ */
+function normalizeWidgetTree(node: unknown, position: string | number = 0): unknown {
+  let key: string | null = null;
+  while (React.isValidElement(node) && typeof node.type === 'function') {
+    key ??= node.key;
+    const rendered = node.type(node.props);
+    node = Array.isArray(rendered)
+      ? jsxRuntime.jsx(React.Fragment, { children: rendered })
+      : rendered;
+  }
+
+  if (Array.isArray(node)) {
+    return node.flat(Infinity).map((child, index) => normalizeWidgetTree(child, index));
+  }
+  if (React.isValidElement(node)) {
+    const props = { ...node.props };
+    if ('children' in props) {
+      props.children = normalizeWidgetTree(props.children);
+    }
+    return {
+      ...node,
+      props,
+      __expoWidgetIdentity: JSON.stringify([node.type, key ?? node.key ?? position]),
+    };
+  }
+  if (node && typeof node === 'object') {
+    // Live Activity layouts return a map of section names to roots.
+    return Object.fromEntries(
+      Object.entries(node).map(([section, child]) => [section, normalizeWidgetTree(child, section)])
+    );
+  }
+  return node;
+}
+
 const __expoWidgetRender = function (props: Dictionary, environment: Dictionary) {
   // `materialColors` backs the native expo-ui module stub and stays out of the layout environment.
   const { timestamp, materialColors, ...rest } = environment;
@@ -27,7 +65,9 @@ const __expoWidgetRender = function (props: Dictionary, environment: Dictionary)
   }
   globalThis.__expoWidgetEnvironment = { ...decoratedEnvironment, materialColors };
 
-  return decorateInteractiveTargets(globalThis.__expoWidgetLayout(props, decoratedEnvironment));
+  return decorateInteractiveTargets(
+    normalizeWidgetTree(globalThis.__expoWidgetLayout(props, decoratedEnvironment))
+  );
 };
 
 const __expoWidgetHandlePress = function (

--- a/packages/expo-widgets/bundle/jsx-runtime-stub.ts
+++ b/packages/expo-widgets/bundle/jsx-runtime-stub.ts
@@ -4,63 +4,16 @@ export type ReactElementNode = {
   type: unknown;
   key: string | null;
   props: Record<string, any>;
+  __expoWidgetIdentity?: string;
 };
-
-function ReactElement(
-  type: unknown,
-  key: string | null,
-  props: Record<string, any>
-): ReactElementNode {
-  if (typeof type === 'function') {
-    return (type as any)(props);
-  }
-
-  const element = {
-    type,
-    key,
-    props,
-  };
-
-  return element;
-}
 
 function jsxProd(
   type: unknown,
   config: any,
   maybeKey?: string | number | bigint
 ): ReactElementNode {
-  let key = null;
-  if (maybeKey !== undefined) {
-    key = '' + maybeKey;
-  }
-  if (hasValidKey(config)) {
-    key = '' + config.key;
-  }
-
-  let props: Record<string, any>;
-  if (!('key' in config)) {
-    props = config;
-  } else {
-    props = {};
-    for (const propName in config) {
-      if (propName !== 'key') {
-        props[propName] = config[propName];
-      }
-    }
-  }
-
-  // React flattens nested children arrays (e.g. a `.map()` result mixed with sibling
-  // elements) during reconciliation. There is no reconciler here - the element tree is
-  // serialized for the native widget parsers, which expect a flat children list.
-  if (Array.isArray(props.children)) {
-    props.children = props.children.flat(Infinity);
-  }
-
-  return ReactElement(type, key, props);
-}
-
-function hasValidKey(config: any) {
-  return config.key !== undefined;
+  const { key = maybeKey, ...props } = config;
+  return { type, key: key === undefined ? null : String(key), props };
 }
 
 const jsxFileName = 'widget';

--- a/packages/expo-widgets/bundle/react-stub.ts
+++ b/packages/expo-widgets/bundle/react-stub.ts
@@ -1,15 +1,17 @@
+import type { ReactElementNode } from './jsx-runtime-stub';
+
 export const Fragment = 'react.fragment';
 
 export const Children = {
   toArray(children: unknown) {
-    if (children === undefined || children === null) {
-      return [];
-    }
-    return Array.isArray(children) ? children : [children];
+    return [children]
+      .flat(Infinity)
+      .filter((child) => child !== undefined && child !== null && typeof child !== 'boolean');
   },
 };
-export const isValidElement = (value: unknown) => {
-  return Boolean(value) && typeof value === 'object' && 'type' in (value as object);
+
+export const isValidElement = (value: unknown): value is ReactElementNode => {
+  return value !== null && typeof value === 'object' && 'type' in value && 'props' in value;
 };
 
 // TODO(@jakex7): Make this a proper React reconciler in the future. For now, we just need a stub to allow the widget bundle to compile with @expo/ui/jetpack-compose.

--- a/packages/expo-widgets/ios/Widgets/ChildView.swift
+++ b/packages/expo-widgets/ios/Widgets/ChildView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import ExpoModulesCore
+
+private final class FallbackIdentity {}
+
+struct WidgetsChildView<Content: View>: ExpoSwiftUI.StringIdentityChild {
+  let childView: Content
+  let stringIdentity: String?
+  private let fallbackIdentity: FallbackIdentity?
+
+  init(childView: Content, stringIdentity: String?) {
+    self.childView = childView
+    self.stringIdentity = stringIdentity
+    fallbackIdentity = stringIdentity == nil ? FallbackIdentity() : nil
+  }
+
+  var id: ObjectIdentifier {
+    guard let fallbackIdentity else {
+      preconditionFailure("Keyed widget children must use childIdentity")
+    }
+    return ObjectIdentifier(fallbackIdentity)
+  }
+
+  var uiView: UIView? {
+    nil
+  }
+
+  var body: some View {
+    childView
+  }
+}

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -2,30 +2,23 @@ import SwiftUI
 import ExpoModulesCore
 import ExpoUI
 
-// TODO(@jakex7): Hack to satisfy ExpoSwiftUI.AnyChild with random UUID value
-class NodeIdentityWrapper {
-  let id: UUID
-  init(id: UUID) {
-    self.id = id
-  }
-}
-extension ObjectIdentifier: @retroactive Encodable {
-  public func encode(to encoder: Encoder) throws {
-    var container = encoder.singleValueContainer()
-    try container.encode(String(describing: self))
-  }
-}
+private final class FallbackIdentity {}
 
-public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
+public struct WidgetsDynamicView: View, ExpoSwiftUI.StringIdentityChild {
   let node: [String: Any]
   let name: String
   let kind: WidgetsKind
   let entryIndex: Int?
   let environmentString: String?
 
-  let uuid = NodeIdentityWrapper(id: UUID())
+  private let fallbackIdentity = FallbackIdentity()
+
   public var id: ObjectIdentifier {
-    ObjectIdentifier(uuid)
+    ObjectIdentifier(fallbackIdentity)
+  }
+
+  public var stringIdentity: String? {
+    node["__expoWidgetIdentity"] as? String
   }
 
   public init(name: String, kind: WidgetsKind, node: [String: Any]) {
@@ -44,8 +37,13 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
     self.environmentString = environmentString
   }
 
-  @ViewBuilder
   public var body: some View {
+    // Roots are not inside Children()'s ForEach, so consume their identity here as well.
+    content.id(childIdentity)
+  }
+
+  @ViewBuilder
+  private var content: some View {
     switch node["type"] as? String {
     case "TextView":
       // TextView applies common modifiers internally so concatenated text keeps
@@ -142,11 +140,10 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
         if let rawProps = node["props"] as? [String: Any] {
           let props = try propsType.init(rawProps: rawProps, context: WidgetsContext.shared.context)
           try updateProps?(props)
-          // TODO(@jakex7): Prevent unwanted transition when view is updated with new props - we want to have the same view instance recreated with new props instead of creating a new view instance and transitioning to it
           if wrapInUIBaseView {
-            return AnyView(UIBaseView<P, V>(props: props).transition(.identity))
+            return AnyView(UIBaseView<P, V>(props: props))
           }
-          return AnyView(V(props: props).transition(.identity))
+          return AnyView(V(props: props))
         }
         return AnyView(EmptyView())
       } catch {

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -1,180 +1,26 @@
 import SwiftUI
 import ExpoModulesCore
-import ExpoUI
 
-private final class FallbackIdentity {}
-
-public struct WidgetsDynamicView: View, ExpoSwiftUI.StringIdentityChild {
-  let node: [String: Any]
-  let name: String
-  let kind: WidgetsKind
-  let entryIndex: Int?
-  let environmentString: String?
-
-  private let fallbackIdentity = FallbackIdentity()
-
-  public var id: ObjectIdentifier {
-    ObjectIdentifier(fallbackIdentity)
-  }
-
-  public var stringIdentity: String? {
-    node["__expoWidgetIdentity"] as? String
-  }
+public struct WidgetsDynamicView: View {
+  private let child: any ExpoSwiftUI.AnyChild
 
   public init(name: String, kind: WidgetsKind, node: [String: Any]) {
-    self.name = name
-    self.kind = kind
-    self.node = node
-    self.entryIndex = nil
-    self.environmentString = nil
+    self.init(name: name, kind: kind, node: node, entryIndex: nil, environmentString: nil)
   }
 
   public init(name: String, kind: WidgetsKind, node: [String: Any], entryIndex: Int?, environmentString: String?) {
-    self.name = name
-    self.kind = kind
-    self.node = node
-    self.entryIndex = entryIndex
-    self.environmentString = environmentString
+    child = WidgetsViewRenderer(
+      name: name,
+      kind: kind,
+      node: node,
+      entryIndex: entryIndex,
+      environmentString: environmentString
+    ).render()
   }
 
   public var body: some View {
     // Roots are not inside Children()'s ForEach, so consume their identity here as well.
-    content.id(childIdentity)
-  }
-
-  @ViewBuilder
-  private var content: some View {
-    switch node["type"] as? String {
-    case "TextView":
-      // TextView applies common modifiers internally so concatenated text keeps
-      // its SwiftUI.Text representation. Avoid applying those modifiers again.
-      render(TextView.self, TextViewProps.self, updateProps: updateChildren, wrapInUIBaseView: false)
-    case "HStackView":
-      render(HStackView.self, HStackViewProps.self, updateProps: updateChildren)
-    case "VStackView":
-      render(VStackView.self, VStackViewProps.self, updateProps: updateChildren)
-    case "ZStackView":
-      render(ZStackView.self, ZStackViewProps.self, updateProps: updateChildren)
-    case "RectangleView":
-      render(RectangleView.self, RectangleViewProps.self)
-    case "RoundedRectangleView":
-      render(RoundedRectangleView.self, RoundedRectangleViewProps.self)
-    case "CapsuleView":
-      render(CapsuleView.self, CapsuleViewProps.self)
-    case "CircleView":
-      render(CircleView.self, CircleViewProps.self)
-    case "ImageView":
-      render(ImageView.self, ImageViewProps.self)
-    case "AccessoryWidgetBackgroundView":
-      render(AccessoryWidgetBackgroundView.self, AccessoryWidgetBackgroundProps.self)
-    case "DividerView":
-      render(DividerView.self, DividerProps.self)
-    case "EllipseView":
-      render(EllipseView.self, EllipseViewProps.self)
-    case "LabelView":
-      render(LabelView.self, LabelViewProps.self)
-    case "ProgressView":
-      render(ProgressView.self, ProgressViewProps.self)
-    case "SpacerView":
-      render(SpacerView.self, SpacerViewProps.self)
-    case "UnevenRoundedRectangleView":
-      render(UnevenRoundedRectangleView.self, UnevenRoundedRectangleViewProps.self)
-    case "GaugeView":
-      render(GaugeView.self, GaugeProps.self)
-    case "ChartView":
-      render(ChartView.self, ChartProps.self)
-    case "Button":
-      if #available(iOS 17.0, *) {
-        switch kind {
-        case .widget:
-          render(WidgetButtonView.self, ButtonProps.self) { buttonProps in
-            try updateChildren(buttonProps)
-            buttonProps.source = name
-            buttonProps.entryIndex = entryIndex
-            buttonProps.environmentString = environmentString
-          }
-        case .liveActivity:
-          render(LiveActivityButtonView.self, ButtonProps.self) { buttonProps in
-            try updateChildren(buttonProps)
-            buttonProps.source = name
-          }
-        }
-      } else {
-        render(ExpoUI.Button.self, ExpoUI.ButtonProps.self, updateProps: updateChildren)
-      }
-    case "react.fragment":
-      render(FragmentView.self, FragmentProps.self, updateProps: updateChildren)
-    case "LinkView":
-      render(LinkView.self, LinkViewProps.self, updateProps: updateChildren)
-#if DEBUG
-    case "RedBoxView":
-      render(RedBoxView.self, RedBoxViewProps.self) { redBoxProps in
-        redBoxProps.source = name
-        redBoxProps.kind = kind
-      }
-    default:
-      ZStack {
-        Color.red.opacity(0.5)
-        Text("Unable to get the view for: \(node["type"] as? String ?? "undefined")")
-      }
-#else
-    default:
-      EmptyView()
-#endif
-    }
-  }
-
-  // MARK: - Render Method
-
-  @ViewBuilder
-  private func render<P, V>(
-    _ viewType: V.Type,
-    _ propsType: P.Type,
-    updateProps: ((_ initialProps: P) throws -> Void)? = nil,
-    wrapInUIBaseView: Bool = true
-  ) -> some View
-  where P: UIBaseViewProps, V: ExpoSwiftUI.View, V.Props == P {
-    // immediately invoked closure {}() here because we can't use 'do-catch' inside @ViewBuilder
-    {
-      do {
-        if let rawProps = node["props"] as? [String: Any] {
-          let props = try propsType.init(rawProps: rawProps, context: WidgetsContext.shared.context)
-          try updateProps?(props)
-          if wrapInUIBaseView {
-            return AnyView(UIBaseView<P, V>(props: props))
-          }
-          return AnyView(V(props: props))
-        }
-        return AnyView(EmptyView())
-      } catch {
-        return AnyView(EmptyView())
-      }
-    }()
-  }
-
-  // MARK: - Function that sets children as DynamicView
-
-  private func updateChildren<P>(_ initialProps: P) throws
-  where P: UIBaseViewProps {
-    if let props = node["props"] as? [String: Any] {
-      if let children = props["children"] as? [Any] {
-        let validChildren = flattenChildNodes(children)
-        initialProps.children = validChildren.map { WidgetsDynamicView(name: name, kind: kind, node: $0, entryIndex: entryIndex, environmentString: environmentString) }
-      } else if let child = props["children"] as? [String: Any] {
-        initialProps.children = [WidgetsDynamicView(name: name, kind: kind, node: child, entryIndex: entryIndex, environmentString: environmentString)]
-      }
-    }
-  }
-
-  private func flattenChildNodes(_ children: [Any]) -> [[String: Any]] {
-    return children.flatMap { child -> [[String: Any]] in
-      if let node = child as? [String: Any] {
-        return [node]
-      }
-      if let nested = child as? [Any] {
-        return flattenChildNodes(nested)
-      }
-      return []
-    }
+    let view: any View = child.childView
+    AnyView(view).id(child.childIdentity)
   }
 }

--- a/packages/expo-widgets/ios/Widgets/ViewRenderer.swift
+++ b/packages/expo-widgets/ios/Widgets/ViewRenderer.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+import ExpoModulesCore
+import ExpoUI
+
+@MainActor
+struct WidgetsViewRenderer {
+  let name: String
+  let kind: WidgetsKind
+  let node: [String: Any]
+  let entryIndex: Int?
+  let environmentString: String?
+
+  func render() -> any ExpoSwiftUI.AnyChild {
+    switch node["type"] as? String {
+    case "TextView":
+      // TextView applies common modifiers internally so concatenated text keeps
+      // its SwiftUI.Text representation. Avoid applying those modifiers again.
+      return render(TextView.self, TextViewProps.self, updateProps: updateChildren)
+    case "SlotView":
+      return render(SlotView.self, SlotViewProps.self, updateProps: updateChildren)
+    case "HStackView":
+      return renderWithModifiers(HStackView.self, HStackViewProps.self, updateProps: updateChildren)
+    case "VStackView":
+      return renderWithModifiers(VStackView.self, VStackViewProps.self, updateProps: updateChildren)
+    case "ZStackView":
+      return renderWithModifiers(ZStackView.self, ZStackViewProps.self, updateProps: updateChildren)
+    case "OverlayView":
+      return renderWithModifiers(OverlayView.self, OverlayViewProps.self, updateProps: updateChildren)
+    case "BackgroundView":
+      return renderWithModifiers(BackgroundView.self, BackgroundViewProps.self, updateProps: updateChildren)
+    case "MaskView":
+      return renderWithModifiers(MaskView.self, MaskViewProps.self, updateProps: updateChildren)
+    case "RectangleView":
+      return renderWithModifiers(RectangleView.self, RectangleViewProps.self)
+    case "RoundedRectangleView":
+      return renderWithModifiers(RoundedRectangleView.self, RoundedRectangleViewProps.self)
+    case "CapsuleView":
+      return renderWithModifiers(CapsuleView.self, CapsuleViewProps.self)
+    case "CircleView":
+      return renderWithModifiers(CircleView.self, CircleViewProps.self)
+    case "ImageView":
+      return renderWithModifiers(ImageView.self, ImageViewProps.self)
+    case "AccessoryWidgetBackgroundView":
+      return renderWithModifiers(AccessoryWidgetBackgroundView.self, AccessoryWidgetBackgroundProps.self)
+    case "DividerView":
+      return renderWithModifiers(DividerView.self, DividerProps.self)
+    case "EllipseView":
+      return renderWithModifiers(EllipseView.self, EllipseViewProps.self)
+    case "LabelView":
+      return renderWithModifiers(LabelView.self, LabelViewProps.self)
+    case "ProgressView":
+      return renderWithModifiers(ProgressView.self, ProgressViewProps.self)
+    case "SpacerView":
+      return renderWithModifiers(SpacerView.self, SpacerViewProps.self)
+    case "UnevenRoundedRectangleView":
+      return renderWithModifiers(UnevenRoundedRectangleView.self, UnevenRoundedRectangleViewProps.self)
+    case "GaugeView":
+      return renderWithModifiers(GaugeView.self, GaugeProps.self)
+    case "ChartView":
+      return renderWithModifiers(ChartView.self, ChartProps.self)
+    case "Button":
+      if #available(iOS 17.0, *) {
+        switch kind {
+        case .widget:
+          return renderWithModifiers(WidgetButtonView.self, ButtonProps.self) { buttonProps in
+            try updateChildren(buttonProps)
+            buttonProps.source = name
+            buttonProps.entryIndex = entryIndex
+            buttonProps.environmentString = environmentString
+          }
+        case .liveActivity:
+          return renderWithModifiers(LiveActivityButtonView.self, ButtonProps.self) { buttonProps in
+            try updateChildren(buttonProps)
+            buttonProps.source = name
+          }
+        }
+      } else {
+        return renderWithModifiers(ExpoUI.Button.self, ExpoUI.ButtonProps.self, updateProps: updateChildren)
+      }
+    case "react.fragment":
+      return renderWithModifiers(FragmentView.self, FragmentProps.self, updateProps: updateChildren)
+    case "LinkView":
+      return renderWithModifiers(LinkView.self, LinkViewProps.self, updateProps: updateChildren)
+#if DEBUG
+    case "RedBoxView":
+      return renderWithModifiers(RedBoxView.self, RedBoxViewProps.self) { redBoxProps in
+        redBoxProps.source = name
+        redBoxProps.kind = kind
+      }
+    default:
+      return makeChild(
+        ZStack {
+          Color.red.opacity(0.5)
+          Text("Unable to get the view for: \(node["type"] as? String ?? "undefined")")
+        }
+      )
+#else
+    default:
+      return makeChild(EmptyView())
+#endif
+    }
+  }
+
+  // MARK: - Render Method
+
+  private func renderWithModifiers<P, V>(
+    _ viewType: V.Type,
+    _ propsType: P.Type,
+    updateProps: ((_ initialProps: P) throws -> Void)? = nil
+  ) -> any ExpoSwiftUI.AnyChild
+  where P: UIBaseViewProps, V: ExpoSwiftUI.View, V.Props == P {
+    render(UIBaseView<P, V>.self, propsType, updateProps: updateProps)
+  }
+
+  private func render<P, V>(
+    _ viewType: V.Type,
+    _ propsType: P.Type,
+    updateProps: ((_ initialProps: P) throws -> Void)? = nil
+  ) -> any ExpoSwiftUI.AnyChild
+  where P: ExpoSwiftUI.ViewProps, V: ExpoSwiftUI.View, V.Props == P {
+    do {
+      guard let rawProps = node["props"] as? [String: Any] else {
+        return makeChild(EmptyView())
+      }
+      let props = try propsType.init(rawProps: rawProps, context: WidgetsContext.shared.context)
+      try updateProps?(props)
+      return makeChild(V(props: props))
+    } catch {
+      return makeChild(EmptyView())
+    }
+  }
+
+  // MARK: - Child Views
+
+  private func updateChildren<P>(_ initialProps: P) throws
+  where P: ExpoSwiftUI.ViewProps {
+    if let props = node["props"] as? [String: Any] {
+      if let children = props["children"] as? [Any] {
+        let validChildren = flattenChildNodes(children)
+        initialProps.children = validChildren.map {
+          WidgetsViewRenderer(name: name, kind: kind, node: $0, entryIndex: entryIndex, environmentString: environmentString).render()
+        }
+      } else if let child = props["children"] as? [String: Any] {
+        initialProps.children = [
+          WidgetsViewRenderer(name: name, kind: kind, node: child, entryIndex: entryIndex, environmentString: environmentString).render()
+        ]
+      }
+    }
+  }
+
+  private func makeChild<Content: View>(_ view: Content) -> any ExpoSwiftUI.AnyChild {
+    // Preserve the native view type for ExpoUI's slot and text inspection.
+    WidgetsChildView(childView: view, stringIdentity: node["__expoWidgetIdentity"] as? String)
+  }
+
+  private func flattenChildNodes(_ children: [Any]) -> [[String: Any]] {
+    return children.flatMap { child -> [[String: Any]] in
+      if let node = child as? [String: Any] {
+        return [node]
+      }
+      if let nested = child as? [Any] {
+        return flattenChildNodes(nested)
+      }
+      return []
+    }
+  }
+}


### PR DESCRIPTION
# Why

Widget and Live Activity updates recreate child identities, preventing SwiftUI from matching views across updates. The renderer also cannot render `Overlay`, `Background`, and `Mask` because it hides the native child types used by ExpoUI's slot lookup.

# How

- Assign identities from each native view type and its React key or sibling position.
- Split native rendering into `WidgetsDynamicView`, `WidgetsViewRenderer`, and `WidgetsChildView`. Preserve the underlying `SlotView` and `TextView` types while forwarding string identities through `StringIdentityChild`.
- Add `Overlay`, `Background`, and `Mask` using the native views exposed in #49734.
- Allocate an object identity fallback only for children without a string identity.

# Test Plan

- `jest --runInBand --selectProjects bundle`: 15 tests passed.
- SwiftLint on the changed Swift files and the `bare-apps/widgets` TypeScript check passed.
- Built the app and extension for the iOS 26.5 simulator and verified all three components on the Home Screen.
- Nested-slot and nested-text PNGs matched native SwiftUI references byte for byte.
- Native identity checks passed for keyed children, empty keys, missing keys, copy stability, and distinct fallback identities.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
