### PR TITLE
[router] Prevent native-tabs remounts when opened from deep-link

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent Native Tabs from remounting the focused tab while preloading other tabs after a cold-start deep link. (by [@Ubax](https://github.com/Ubax))
+- Prevent Native Tabs from remounting the focused tab while preloading other tabs after a cold-start deep link. (by [@Ubax](https://github.com/Ubax)) ([#49811](https://github.com/expo/expo/pull/49811) by [@Ubax](https://github.com/Ubax))
 - Re-export the vendored JavaScript stack API from `expo-router/js-stack`. ([#49657](https://github.com/expo/expo/pull/49657) by [@davidmokos](https://github.com/davidmokos))
 - Fix `useLoaderData()` throwing "Update hook called on initial render" when React replays a suspended route after its loader settles during a transition. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -70,6 +70,7 @@
 
 ### 🐛 Bug fixes
 
+- Prevent Native Tabs from remounting the focused tab while preloading other tabs after a cold-start deep link. (by [@Ubax](https://github.com/Ubax))
 - Re-export the vendored JavaScript stack API from `expo-router/js-stack`. ([#49657](https://github.com/expo/expo/pull/49657) by [@davidmokos](https://github.com/davidmokos))
 - Fix `useLoaderData()` throwing "Update hook called on initial render" when React replays a suspended route after its loader settles during a transition. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -49,6 +49,7 @@ function NativeTabsContent({
   emitter,
   preload,
   navigateSync,
+  tabConfigurationKey,
   // These per-tab style props are folded into `screenOptions` by `NativeTabsNavigatorWrapper` and
   // read back per-tab from `descriptors`. Pull them out of `rest` so they aren't forwarded to
   // `NativeTabsView` as top-level props.
@@ -94,11 +95,6 @@ function NativeTabsContent({
       ),
     [descriptors, visibleRoutes]
   );
-  const visibleTabNames = useMemo(
-    () => visibleTabs.map((tab) => tab.name).join(';'),
-    [visibleTabs]
-  );
-
   usePreloadPlaceholderRoutes({
     routes: visibleRoutes,
     descriptors,
@@ -170,7 +166,7 @@ function NativeTabsContent({
     <NativeTabsContext value>
       <NativeTabsView
         {...nativeTabsViewProps}
-        key={visibleTabNames}
+        key={tabConfigurationKey}
         focusedIndex={focusedIndex}
         // Provenance should only be sent with updates, and updates
         // on JS side are only triggered by rerender, so passing ref
@@ -210,6 +206,7 @@ export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
     () => getAllChildrenNotOfType(props.children, NativeTabTrigger),
     [props.children]
   );
+  const tabConfigurationKey = triggerChildren.map((child) => child.props.name).join(';');
 
   const {
     backBehavior = defaultBackBehavior,
@@ -279,6 +276,7 @@ export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
       {...props}
       children={triggerChildren}
       nonTriggerChildren={nonTriggerChildren}
+      tabConfigurationKey={tabConfigurationKey}
       screenOptions={screenOptions}
       // Passed to TabRouter
       backBehavior={backBehavior}

--- a/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
@@ -104,6 +104,44 @@ it('does not rerender the focused screen while preloading other tabs', () => {
   expect(screen.getByTestId('second')).toBeVisible();
 });
 
+it('does not remount the focused screen while preloading other tabs after a deep link', () => {
+  const mount = jest.fn();
+  const unmount = jest.fn();
+
+  function Run() {
+    React.useEffect(() => {
+      mount();
+      return unmount;
+    }, []);
+
+    return <View testID="run" />;
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <NativeTabs>
+          <NativeTabs.Trigger name="test-suite" />
+          <NativeTabs.Trigger name="apis" />
+          <NativeTabs.Trigger name="playground" />
+          <NativeTabs.Trigger name="components" />
+        </NativeTabs>
+      ),
+      'test-suite/_layout': () => <Stack />,
+      'test-suite/index': () => <View testID="test-suite" />,
+      'test-suite/run': Run,
+      apis: () => <View testID="apis" />,
+      playground: () => <View testID="playground" />,
+      components: () => <View testID="components" />,
+    },
+    { initialUrl: '/test-suite/run?tests=AppMetrics' }
+  );
+
+  expect(screen.getByTestId('run')).toBeVisible();
+  expect(mount).toHaveBeenCalledTimes(1);
+  expect(unmount).not.toHaveBeenCalled();
+});
+
 describe('Tabs visibility', () => {
   it('does not render tab, when not specified', () => {
     renderRouter({
@@ -578,8 +616,8 @@ describe('Dynamic tab visibility remounting', () => {
         third: () => <ScreenWithMount testID="third" />,
       });
 
-      // Initial render records four mounts across three screens.
-      expect(onMount).toHaveBeenCalledTimes(4);
+      // Initial render mounts each screen once.
+      expect(onMount).toHaveBeenCalledTimes(3);
       expect(onMount).toHaveBeenCalledWith('index');
       expect(onMount).toHaveBeenCalledWith('second');
       expect(onMount).toHaveBeenCalledWith('third');
@@ -629,8 +667,8 @@ describe('Dynamic tab visibility remounting', () => {
         third: () => <ScreenWithMount testID="third" />,
       });
 
-      // Initial render records four mounts across index, stack-index, and third.
-      expect(onMount).toHaveBeenCalledTimes(4);
+      // Initial render mounts each screen once.
+      expect(onMount).toHaveBeenCalledTimes(3);
       expect(onMount).toHaveBeenCalledWith('index');
       expect(onMount).toHaveBeenCalledWith('stack-index');
       expect(onMount).toHaveBeenCalledWith('third');

--- a/packages/expo-router/src/native-tabs/types.ts
+++ b/packages/expo-router/src/native-tabs/types.ts
@@ -498,6 +498,7 @@ export interface NativeTabsProps extends PropsWithChildren {
 
 export interface InternalNativeTabsProps extends NativeTabsProps {
   nonTriggerChildren?: React.ReactNode;
+  tabConfigurationKey: string;
 }
 export interface OnTabChangeEventPayload {
   /**
@@ -536,6 +537,7 @@ export interface NativeTabsViewProps extends Omit<
   | 'rippleColor'
   | 'disableIndicator'
   | 'labelVisibilityMode'
+  | 'tabConfigurationKey'
 > {
   focusedIndex: number;
   /**


### PR DESCRIPTION
# Why

See the ticket

# How

Compute the `key` for `NativeTabsView` from visible tab order - declared by user using `NativeTabs.Trigger` - instead of the state based one

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
