### PR TITLE
[expo-image] Add `onPlaceholderDisplay` event

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,7 @@
 - add expo-observe integration ([#47145](https://github.com/expo/expo/pull/47145) by [@Ubax](https://github.com/Ubax))
 - [iOS][Android] Added a `skipOnCacheHit` field to `transition` that skips the fade the first time a cached image appears (`'memory'` for memory-cache hits, `'all'` for any cache hit), so already-loaded images don't re-animate on mount, tab change, or when scrolling back into view. A transition from a `source` change still plays. ([#48181](https://github.com/expo/expo/pull/48181) by [@janicduplessis](https://github.com/janicduplessis))
 - Added an `includeUrlParams` option to the expo-observe integration; reported image URLs now have their query string and fragment removed unless it is enabled, basic-auth credentials are always removed, and only `http(s)`, `file`, and `android.resource` URLs are reported. ([#49083](https://github.com/expo/expo/pull/49083) by [@tsapeta](https://github.com/tsapeta))
+- Add `onPlaceholderDisplay` event, emitted when a placeholder image is rendered. ([#49812](https://github.com/expo/expo/pull/49812) by [@vargajacint](https://github.com/vargajacint))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -310,7 +310,8 @@ class ExpoImageModule : Module() {
         "onProgress",
         "onError",
         "onLoad",
-        "onDisplay"
+        "onDisplay",
+        "onPlaceholderDisplay"
       )
 
       Prop("source") { view: ExpoImageViewWrapper, sources: EitherOfThree<List<SourceMap>, SharedRef<Drawable>, SharedRef<Bitmap>>? ->

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -75,6 +75,7 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
   internal val onError by EventDispatcher<ImageErrorEvent>()
   internal val onLoad by EventDispatcher<ImageLoadEvent>()
   internal val onDisplay by EventDispatcher<Unit>()
+  internal val onPlaceholderDisplay by EventDispatcher<Unit>()
 
   internal var sources: List<Source> = emptyList()
   private val bestSource: Source?
@@ -305,7 +306,11 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
           configureView(newView, target, resource, isPlaceholder)
 
           // Dispatch "onDisplay" event only for the main source (no placeholder).
-          if (target.hasSource) {
+          // A placeholder reaching this branch is rendered as the main image, so it gets
+          // "onPlaceholderDisplay" instead.
+          if (isPlaceholder) {
+            onPlaceholderDisplay.invoke(Unit)
+          } else if (target.hasSource) {
             onDisplay.invoke(Unit)
           }
 
@@ -352,6 +357,7 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
             }
 
           configureView(firstView, target, resource, isPlaceholder)
+          onPlaceholderDisplay.invoke(Unit)
           val transitionDuration = (transition?.duration ?: 0).toLong()
           if (transitionDuration > 0) {
             firstView.bringToFront()

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -31,7 +31,8 @@ public final class ImageModule: Module {
         "onProgress",
         "onError",
         "onLoad",
-        "onDisplay"
+        "onDisplay",
+        "onPlaceholderDisplay"
       )
 
       Prop("source") { (view: ImageView, sources: Either<[ImageSource], SharedRef<UIImage>>?) in

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -105,6 +105,8 @@ public final class ImageView: ExpoView {
 
   let onDisplay = EventDispatcher()
 
+  let onPlaceholderDisplay = EventDispatcher()
+
   // MARK: - View
 
   public override var bounds: CGRect {
@@ -579,6 +581,8 @@ public final class ImageView: ExpoView {
 
     if !isPlaceholder {
       onDisplay()
+    } else if image != nil {
+      onPlaceholderDisplay()
     }
 
 #if !os(tvOS)

--- a/packages/expo-image/src/ExpoImage.web.tsx
+++ b/packages/expo-image/src/ExpoImage.web.tsx
@@ -74,6 +74,7 @@ export default function ExpoImage({
   responsivePolicy,
   onLoadEnd,
   onDisplay,
+  onPlaceholderDisplay,
   priority,
   loading,
   blurRadius,
@@ -122,6 +123,7 @@ export default function ExpoImage({
               className={className}
               events={{
                 onTransitionEnd: [onAnimationFinished],
+                onPlaceholderDisplay: [onPlaceholderDisplay],
               }}
               contentPosition={{ left: '50%', top: '50%' }}
               hashPlaceholderContentPosition={contentPosition}

--- a/packages/expo-image/src/Image.types.ts
+++ b/packages/expo-image/src/Image.types.ts
@@ -341,6 +341,11 @@ export interface ImageProps extends Omit<ViewProps, 'style' | 'children'> {
    */
   onDisplay?: () => void;
 
+  /**
+   * Called when the image view successfully rendered a placeholder image.
+   */
+  onPlaceholderDisplay?: () => void;
+
   // DEPRECATED
 
   /**

--- a/packages/expo-image/src/web/ImageWrapper.types.ts
+++ b/packages/expo-image/src/web/ImageWrapper.types.ts
@@ -14,6 +14,7 @@ export type OnLoadEvent =
 export type OnTransitionEndEvent = (() => void) | undefined | null;
 export type OnMountEvent = (() => void) | undefined | null;
 export type OnDisplayEvent = (() => void) | undefined | null;
+export type OnPlaceholderDisplayEvent = (() => void) | undefined | null;
 
 export type ImageWrapperEvents = {
   onLoad?: OnLoadEvent[];
@@ -21,6 +22,7 @@ export type ImageWrapperEvents = {
   onTransitionEnd?: OnTransitionEndEvent[];
   onMount?: OnMountEvent[];
   onDisplay?: OnDisplayEvent[];
+  onPlaceholderDisplay?: OnPlaceholderDisplayEvent[];
 };
 
 export type ImageWrapperProps = {

--- a/packages/expo-image/src/web/getImageWrapperEventHandler.ts
+++ b/packages/expo-image/src/web/getImageWrapperEventHandler.ts
@@ -16,6 +16,7 @@ export function getImageWrapperEventHandler(
         // On Web there is no way to detect when the image gets displayed, but we can assume it happens on the repaint right after the image is successfully loaded.
         window.requestAnimationFrame(() => {
           events?.onDisplay?.forEach((e) => e?.());
+          events?.onPlaceholderDisplay?.forEach((e) => e?.());
         });
       }
     },


### PR DESCRIPTION
# Why

`onDisplay` is only fired for the source image, never for a `placeholder`. Anything drawn on top of the image (a caption gradient, for example) has no way to know when the placeholder is on screen, so it either shows over nothing or waits for the full source.

# How

New `onPlaceholderDisplay` view event, fired when a placeholder image has been rendered. Same shape as `onDisplay`, no payload.

- iOS: second `EventDispatcher` in `ImageView`, called from the placeholder branch of `setImage`.
- Android: dispatched from `onResourceReady` in both places a placeholder gets drawn (thumbnail path, and placeholder with no source).
- Web: wired onto the placeholder `ImageWrapper` the same way `onDisplay` is wired onto the source wrapper.
- Types: `onPlaceholderDisplay?: () => void` on `ImageProps`.

# Test Plan

Checked on iOS and Android devices:

- `placeholder` + `source`: `onPlaceholderDisplay` fires once for the placeholder, then `onLoad` / `onDisplay` for the source.
- No `placeholder`: event never fires, `onDisplay` unchanged.
- Recycled list cells fire it again for each new placeholder.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)