### PR TITLE
[android][expo-go] Request local network access before reaching a dev server on Android 17

### DIFF
--- a/apps/expo-go/android/expoview/src/main/AndroidManifest.xml
+++ b/apps/expo-go/android/expoview/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     android:xlargeScreens="true"/>
 
   <uses-permission android:name="android.permission.INTERNET" />
+  <!-- Android 17 gates local network access behind this runtime permission; Home asks before reaching a dev server. -->
+  <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="host.exp.exponent.permission.C2D_MESSAGE" />

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -102,6 +102,8 @@ open class HomeActivity : AppCompatActivity() {
     SoLoader.init(this, OpenSourceMergedSoMapping)
     super.onResume()
     updateStatusBarForTheme(viewModel.selectedTheme.value)
+    // The user may have changed it in Settings while Home was in the background.
+    viewModel.refreshLocalNetworkPermission()
   }
   //endregion Activity Lifecycle
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AppNavHost.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AppNavHost.kt
@@ -12,9 +12,11 @@ import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -88,16 +90,18 @@ fun RootNavigation(
   val themeSetting by viewModel.selectedTheme.collectAsStateWithLifecycle()
 
   HomeAppTheme(themeSetting = themeSetting) {
-    Box(
-      modifier = Modifier
-        .fillMaxSize()
-        .background(MaterialTheme.colorScheme.background)
-    ) {
-      AppNavHost(
-        navController = navController,
-        startDestination = Destination.Home,
-        viewModel = viewModel
-      )
+    CompositionLocalProvider(LocalUriHandler provides rememberLocalNetworkGatedUriHandler(viewModel)) {
+      Box(
+        modifier = Modifier
+          .fillMaxSize()
+          .background(MaterialTheme.colorScheme.background)
+      ) {
+        AppNavHost(
+          navController = navController,
+          startDestination = Destination.Home,
+          viewModel = viewModel
+        )
+      }
     }
   }
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/HomeAppViewModel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/HomeAppViewModel.kt
@@ -30,6 +30,7 @@ import host.exp.exponent.graphql.ProjectsQuery
 import host.exp.exponent.graphql.fragment.CurrentUserActorData
 import host.exp.exponent.home.auth.AuthRequestType
 import host.exp.exponent.kernel.ExpoViewKernel
+import host.exp.exponent.network.LocalNetworkPermission
 import host.exp.exponent.nsd.NsdDiscovery
 import host.exp.exponent.nsd.NsdPreferences
 import host.exp.exponent.nsd.PackagerInfo
@@ -229,6 +230,16 @@ class HomeAppViewModel(
   val feedbackState = MutableStateFlow(FeedbackState())
 
   private val nsdDiscovery = NsdDiscovery(application, client)
+
+  private val _isLocalNetworkPermissionGranted =
+    MutableStateFlow(LocalNetworkPermission.isGranted(application))
+
+  /** False only on Android 17+ until the user grants local network access, which NSD and dev-server loads need. */
+  val isLocalNetworkPermissionGranted: StateFlow<Boolean> = _isLocalNetworkPermissionGranted
+
+  fun refreshLocalNetworkPermission() {
+    _isLocalNetworkPermissionGranted.value = LocalNetworkPermission.isGranted(getApplication<Application>())
+  }
   val nsdPreferences = NsdPreferences(application)
 
   // Reactive trigger that re-emits whenever NSD preferences change
@@ -419,9 +430,15 @@ class HomeAppViewModel(
       updateUserReviewState(appsList.size, snacksList.size)
     }.launchIn(viewModelScope)
 
-    // Start NSD discovery and enable health checks
-    nsdDiscovery.start()
-    nsdDiscovery.resumeHealthCheck()
+    // NSD needs the local network permission on Android 17, so start discovery once it is granted.
+    isLocalNetworkPermissionGranted
+      .onEach { isGranted ->
+        if (isGranted) {
+          nsdDiscovery.start()
+          nsdDiscovery.resumeHealthCheck()
+        }
+      }
+      .launchIn(viewModelScope)
 
     // Re-filter when NSD preferences change
     nsdPreferences.addOnChangeListener(nsdPreferencesListener)

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/HomeScreen.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/HomeScreen.kt
@@ -121,6 +121,7 @@ fun HomeScreen(
           viewModel = viewModel,
           navigateToFeedback = { navigateToFeedback() }
         )
+        LocalNetworkPermissionBanner(viewModel = viewModel)
         LabeledGroup(
           label = "Development servers",
           modifier = Modifier.padding(top = 8.dp),

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/LocalNetworkPermissionBanner.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/LocalNetworkPermissionBanner.kt
@@ -1,0 +1,99 @@
+package host.exp.exponent.home
+
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import host.exp.exponent.network.LocalNetworkPermission
+import host.exp.expoview.R
+
+/**
+ * Shown on Android 17+ until local network access is granted. Tapping asks for the permission, or
+ * opens the app's settings once the system no longer shows the prompt.
+ */
+@Composable
+fun LocalNetworkPermissionBanner(viewModel: HomeAppViewModel) {
+  val isGranted by viewModel.isLocalNetworkPermissionGranted.collectAsStateWithLifecycle()
+  if (isGranted) {
+    return
+  }
+
+  val context = LocalContext.current
+  val launcher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+    viewModel.refreshLocalNetworkPermission()
+  }
+
+  Spacer(modifier = Modifier.height(16.dp))
+
+  Surface(
+    onClick = {
+      if (LocalNetworkPermission.canPrompt(context)) {
+        LocalNetworkPermission.markPrompted(context)
+        launcher.launch(LocalNetworkPermission.PERMISSION)
+      } else {
+        val settings = Intent(
+          Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+          Uri.fromParts("package", context.packageName, null)
+        )
+        context.startActivity(settings)
+      }
+    },
+    modifier = Modifier.padding(horizontal = 16.dp),
+    shape = RoundedCornerShape(12.dp),
+    color = MaterialTheme.colorScheme.secondaryContainer,
+    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+  ) {
+    Row(
+      modifier = Modifier.padding(16.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Icon(
+        painter = painterResource(id = R.drawable.warning),
+        contentDescription = null,
+        modifier = Modifier.size(24.dp)
+      )
+      Column(
+        modifier = Modifier
+          .weight(1f)
+          .padding(horizontal = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+      ) {
+        Text(
+          "Local network access needed",
+          fontWeight = FontWeight.Bold,
+          style = MaterialTheme.typography.labelLarge
+        )
+        Text(
+          "Projects running on your computer can't be discovered. Tap to enable access.",
+          style = MaterialTheme.typography.bodySmall
+        )
+      }
+      Icon(
+        painter = painterResource(id = R.drawable.chevron_right),
+        contentDescription = null
+      )
+    }
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/LocalNetworkPermissionGate.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/LocalNetworkPermissionGate.kt
@@ -1,0 +1,45 @@
+package host.exp.exponent.home
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import host.exp.exponent.network.LocalNetworkPermission
+
+/**
+ * Wraps the platform [UriHandler] so opening a project on the local network asks for the permission
+ * first. The URL opens once the prompt is answered either way; a denied request fails the same way an
+ * unprompted one did, and the Home banner offers the way to Settings.
+ */
+@Composable
+fun rememberLocalNetworkGatedUriHandler(viewModel: HomeAppViewModel): UriHandler {
+  val context = LocalContext.current
+  val platformHandler = LocalUriHandler.current
+  val pendingUrl = remember { mutableStateOf<String?>(null) }
+  val launcher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+    viewModel.refreshLocalNetworkPermission()
+    pendingUrl.value?.let(platformHandler::openUri)
+    pendingUrl.value = null
+  }
+
+  return remember(platformHandler) {
+    object : UriHandler {
+      override fun openUri(uri: String) {
+        val needsPrompt = LocalNetworkPermission.isLocalNetworkUrl(uri) &&
+          !LocalNetworkPermission.isGranted(context) &&
+          LocalNetworkPermission.canPrompt(context)
+        if (needsPrompt) {
+          LocalNetworkPermission.markPrompted(context)
+          pendingUrl.value = uri
+          launcher.launch(LocalNetworkPermission.PERMISSION)
+        } else {
+          platformHandler.openUri(uri)
+        }
+      }
+    }
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/network/LocalNetworkPermission.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/network/LocalNetworkPermission.kt
@@ -1,0 +1,77 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+package host.exp.exponent.network
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import androidx.core.content.edit
+import java.net.URI
+
+/**
+ * Android 17 gates local network access behind a runtime permission. Expo Go declares it, so the
+ * implicit grant older apps keep no longer applies, and Home has to ask before reaching a dev server
+ * or discovering one over NSD. Loopback, and so `adb reverse`, is exempt.
+ */
+object LocalNetworkPermission {
+  const val PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK"
+
+  private const val FIRST_ENFORCED_SDK = 37 // Android 17
+  private const val PREFS = "expo.localnetwork"
+  private const val KEY_PROMPTED = "prompted"
+
+  fun isRequired(): Boolean = Build.VERSION.SDK_INT >= FIRST_ENFORCED_SDK
+
+  fun isGranted(context: Context): Boolean =
+    !isRequired() ||
+      ContextCompat.checkSelfPermission(context, PERMISSION) == PackageManager.PERMISSION_GRANTED
+
+  /**
+   * False once the system has stopped showing the prompt, after the user denied it twice, so callers
+   * send the user to Settings instead of launching a request that returns immediately.
+   */
+  fun canPrompt(context: Context): Boolean {
+    val activity = context.findActivity() ?: return true
+    val promptedBefore = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getBoolean(KEY_PROMPTED, false)
+    return !promptedBefore || activity.shouldShowRequestPermissionRationale(PERMISSION)
+  }
+
+  fun markPrompted(context: Context) {
+    context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit { putBoolean(KEY_PROMPTED, true) }
+  }
+
+  /** Whether opening this URL reaches a host on the local network. Malformed URLs are not local. */
+  fun isLocalNetworkUrl(url: String): Boolean {
+    val host = try {
+      URI(url).host
+    } catch (e: Exception) {
+      null
+    } ?: return false
+    return isLocalNetworkHost(host)
+  }
+
+  /** Private IPv4 ranges, link-local IPv4 and IPv6, and mDNS `.local` names. */
+  fun isLocalNetworkHost(host: String): Boolean {
+    val bare = host.trim('[', ']').lowercase()
+    if (bare.endsWith(".local") || bare.startsWith("fe80:")) {
+      return true
+    }
+    val octets = bare.split('.')
+    if (octets.size != 4) {
+      return false
+    }
+    val (a, b) = octets.map { it.toIntOrNull()?.takeIf { value -> value in 0..255 } ?: return false }
+    return a == 10 ||
+      (a == 172 && b in 16..31) ||
+      (a == 192 && b == 168) ||
+      (a == 169 && b == 254)
+  }
+
+  private fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+  }
+}

--- a/apps/expo-go/android/expoview/src/test/java/host/exp/exponent/network/LocalNetworkPermissionTest.kt
+++ b/apps/expo-go/android/expoview/src/test/java/host/exp/exponent/network/LocalNetworkPermissionTest.kt
@@ -1,0 +1,50 @@
+package host.exp.exponent.network
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalNetworkPermissionTest {
+  @Test
+  fun privateIpv4RangesAreLocal() {
+    assertTrue(LocalNetworkPermission.isLocalNetworkHost("192.168.1.5"))
+    assertTrue(LocalNetworkPermission.isLocalNetworkHost("10.0.2.2"))
+    assertTrue(LocalNetworkPermission.isLocalNetworkHost("172.16.0.1"))
+    assertTrue(LocalNetworkPermission.isLocalNetworkHost("172.31.255.254"))
+    assertTrue(LocalNetworkPermission.isLocalNetworkHost("169.254.1.1"))
+  }
+
+  @Test
+  fun publicAndLoopbackHostsAreNotLocal() {
+    assertFalse(LocalNetworkPermission.isLocalNetworkHost("172.32.0.1"))
+    assertFalse(LocalNetworkPermission.isLocalNetworkHost("8.8.8.8"))
+    assertFalse(LocalNetworkPermission.isLocalNetworkHost("127.0.0.1"))
+    assertFalse(LocalNetworkPermission.isLocalNetworkHost("localhost"))
+    assertFalse(LocalNetworkPermission.isLocalNetworkHost("u.expo.dev"))
+    assertFalse(LocalNetworkPermission.isLocalNetworkHost("abc-123.anonymous.exp.direct"))
+  }
+
+  @Test
+  fun mdnsAndLinkLocalIpv6HostsAreLocal() {
+    assertTrue(LocalNetworkPermission.isLocalNetworkHost("my-mac.local"))
+    assertTrue(LocalNetworkPermission.isLocalNetworkHost("[fe80::1%wlan0]"))
+    assertTrue(LocalNetworkPermission.isLocalNetworkHost("fe80::1"))
+  }
+
+  @Test
+  fun urlsAreClassifiedByHost() {
+    assertTrue(LocalNetworkPermission.isLocalNetworkUrl("exp://192.168.1.5:8081"))
+    assertTrue(LocalNetworkPermission.isLocalNetworkUrl("http://192.168.1.5:8081/--/settings?x=1"))
+    assertTrue(LocalNetworkPermission.isLocalNetworkUrl("exp://my-mac.local:8081"))
+    assertFalse(LocalNetworkPermission.isLocalNetworkUrl("exp://127.0.0.1:8081"))
+    assertFalse(LocalNetworkPermission.isLocalNetworkUrl("exp://u.expo.dev/933fd9c0?runtime-version=exposdk:58.0.0"))
+    assertFalse(LocalNetworkPermission.isLocalNetworkUrl("https://expo.dev/@user/project"))
+  }
+
+  @Test
+  fun malformedUrlsAreNotLocal() {
+    assertFalse(LocalNetworkPermission.isLocalNetworkUrl("not a url"))
+    assertFalse(LocalNetworkPermission.isLocalNetworkUrl(""))
+    assertFalse(LocalNetworkPermission.isLocalNetworkUrl("exp://"))
+  }
+}


### PR DESCRIPTION
# Why
Android 17 gates local network access behind the ACCESS_LOCAL_NETWORK runtime permission. Apps targeting SDK 36 keep an implicit grant unless they declare the permission, and React Native 0.87's debug manifest declares it, so Expo Go lost the grant without ever asking for it. React Native requests the permission from ReactActivityDelegate, which Expo Go does not use, and its helper is internal and debug-only.

# How
Declare the permission in Expo Go's own manifest so release builds behave the same as debug builds and the app is ready for target SDK 37.

Add a `LocalNetworkPermission` helper that knows when the permission applies, whether it is granted, whether the system will still show the prompt, and whether a URL's host is on the local network (private IPv4 ranges, link-local, mDNS `.local` names; loopback exempt).

Provide a `UriHandler` at Home's root that requests the permission before opening a URL whose host is local, so QR scans, typed URLs, recents, and dev session rows all prompt, while Snack and EAS Update URLs do not. Start NSD discovery only once the permission is granted, and re-check it when Home resumes. A banner above the development servers list explains the missing access and requests it, or opens the app's settings once the system stops prompting.

# Test Plan
Unit tests cover the host and URL classifier. On a Pixel 7a running Android 17: the banner shows on Home, the first QR scan prompts, the scanned project loads after granting, and the development servers list fills in. Denying twice makes the banner open Settings.

