### PR TITLE
[ios][dom-webview] Import Foundation in DomWebViewRegistry

### DIFF
--- a/packages/@expo/dom-webview/CHANGELOG.md
+++ b/packages/@expo/dom-webview/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unpublished
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+- [iOS] Import `Foundation` in `DomWebViewRegistry` so the module builds with Swift Package Manager. ([#49822](https://github.com/expo/expo/pull/49822) by [@chrfalch](https://github.com/chrfalch))
+
+### 💡 Others

--- a/packages/@expo/dom-webview/ios/DomWebViewRegistry.swift
+++ b/packages/@expo/dom-webview/ios/DomWebViewRegistry.swift
@@ -1,5 +1,10 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+// DispatchQueue below. CocoaPods compiles this module alongside an underlying
+// ObjC module that pulls Foundation in implicitly; a SwiftPM Swift-only target
+// does not, so import it explicitly.
+import Foundation
+
 private let lockQueue = DispatchQueue(label: "expo.modules.domWebView.RegistryQueue")
 
 internal typealias WebViewId = Int


### PR DESCRIPTION
# Why

The file uses `DispatchQueue` with no imports at all. Under CocoaPods the
module is compiled alongside an underlying ObjC module that pulls Foundation
in implicitly, so it resolves; a SwiftPM Swift-only target has no such module
and the compile fails with `cannot find 'DispatchQueue' in scope`.

# How

Added `import Foundation` to the file `packages/@expo/dom-webview/ios/DomWebViewRegistry.swift`

# Testplan

✅ Builds

# Checklist

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

_Part **5 of 8** of the SwiftPM-enablement stack. Base: `spm-restructure-log-box`. Draft for review._