### PR TITLE
[router] Propagate prevent-remove guards to ancestors

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -94,6 +94,7 @@
 ### 💡 Others
 
 - Resolve queued navigation actions against render-time state. ([#49846](https://github.com/expo/expo/pull/49846) by [@Ubax](https://github.com/Ubax))
+- Register `usePreventRemove` guards on ancestor routes so navigators no longer walk nested state. `removePrevented` now also fires on the ancestor route whose removal was blocked. (by [@Ubax](https://github.com/Ubax))
 - Mark preloaded routes with `isPreloaded: true` on the route object. ([#49826](https://github.com/expo/expo/pull/49826) by [@Ubax](https://github.com/Ubax))
 - Replace latest-value refs with `useLatestCallback` and `useEffectEvent`. ([#49643](https://github.com/expo/expo/pull/49643) by [@Ubax](https://github.com/Ubax))
 - Remove the root `options` event, `DocumentTitleOptions`, and the `documentTitle` prop from `expo-router/react-navigation`. ([#49590](https://github.com/expo/expo/pull/49590) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -94,7 +94,7 @@
 ### 💡 Others
 
 - Resolve queued navigation actions against render-time state. ([#49846](https://github.com/expo/expo/pull/49846) by [@Ubax](https://github.com/Ubax))
-- Register `usePreventRemove` guards on ancestor routes so navigators no longer walk nested state. `removePrevented` now also fires on the ancestor route whose removal was blocked. ([#49829](https://github.com/expo/expo/pull/49829) by [@Ubax](https://github.com/Ubax))
+- Propagate prevent-remove guards to ancestors. ([#49829](https://github.com/expo/expo/pull/49829) by [@Ubax](https://github.com/Ubax))
 - Mark preloaded routes with `isPreloaded: true` on the route object. ([#49826](https://github.com/expo/expo/pull/49826) by [@Ubax](https://github.com/Ubax))
 - Replace latest-value refs with `useLatestCallback` and `useEffectEvent`. ([#49643](https://github.com/expo/expo/pull/49643) by [@Ubax](https://github.com/Ubax))
 - Remove the root `options` event, `DocumentTitleOptions`, and the `documentTitle` prop from `expo-router/react-navigation`. ([#49590](https://github.com/expo/expo/pull/49590) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -94,7 +94,7 @@
 ### 💡 Others
 
 - Resolve queued navigation actions against render-time state. ([#49846](https://github.com/expo/expo/pull/49846) by [@Ubax](https://github.com/Ubax))
-- Register `usePreventRemove` guards on ancestor routes so navigators no longer walk nested state. `removePrevented` now also fires on the ancestor route whose removal was blocked. (by [@Ubax](https://github.com/Ubax))
+- Register `usePreventRemove` guards on ancestor routes so navigators no longer walk nested state. `removePrevented` now also fires on the ancestor route whose removal was blocked. ([#49829](https://github.com/expo/expo/pull/49829) by [@Ubax](https://github.com/Ubax))
 - Mark preloaded routes with `isPreloaded: true` on the route object. ([#49826](https://github.com/expo/expo/pull/49826) by [@Ubax](https://github.com/Ubax))
 - Replace latest-value refs with `useLatestCallback` and `useEffectEvent`. ([#49643](https://github.com/expo/expo/pull/49643) by [@Ubax](https://github.com/Ubax))
 - Remove the root `options` event, `DocumentTitleOptions`, and the `documentTitle` prop from `expo-router/react-navigation`. ([#49590](https://github.com/expo/expo/pull/49590) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/global-state/__tests__/removalPrevention.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/removalPrevention.test.ios.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react-native';
+import { act, render, renderHook } from '@testing-library/react-native';
 import * as React from 'react';
 import { use } from 'react';
 
@@ -48,70 +48,50 @@ test('aggregates prevention across routes', () => {
 });
 
 test('propagates prevention from a child route to its parent route', () => {
-  let setChildPrevented: React.ContextType<typeof ScreenRemovalPreventionSetterContext>;
-  const routes: ReadonlySet<string>[] = [];
-  function CaptureChildSetter() {
-    setChildPrevented = use(ScreenRemovalPreventionSetterContext);
-    return null;
-  }
-  function RoutesCapture() {
-    routes.push(use(GlobalRoutesWithRemovalPreventedContext)!);
-    return null;
-  }
-  render(
+  const wrapper = ({ children }: React.PropsWithChildren) => (
     <RemovalPreventionProvider>
       <PreventRemovalProvider routeKey="parent">
-        <PreventRemovalProvider routeKey="child">
-          <CaptureChildSetter />
-        </PreventRemovalProvider>
+        <PreventRemovalProvider routeKey="child">{children}</PreventRemovalProvider>
       </PreventRemovalProvider>
-      <RoutesCapture />
     </RemovalPreventionProvider>
   );
 
-  act(() => setChildPrevented!('guard', true));
-  expect(routes.at(-1)).toEqual(new Set(['child', 'parent']));
+  const { result } = renderHook(
+    () => ({
+      setPrevented: use(ScreenRemovalPreventionSetterContext)!,
+      preventedRoutes: use(GlobalRoutesWithRemovalPreventedContext)!,
+    }),
+    { wrapper }
+  );
 
-  act(() => setChildPrevented!('guard', false));
-  expect(routes.at(-1)).toEqual(new Set());
+  act(() => result.current.setPrevented('guard', true));
+  expect(result.current.preventedRoutes).toEqual(new Set(['child', 'parent']));
+
+  act(() => result.current.setPrevented('guard', false));
+  expect(result.current.preventedRoutes).toEqual(new Set());
 });
 
-test('does not register prevention for a preloaded child route and re-registers when active', () => {
-  const routes: ReadonlySet<string>[] = [];
-  function Guard() {
-    const setPrevented = use(ScreenRemovalPreventionSetterContext)!;
-    React.useLayoutEffect(() => {
-      setPrevented('guard', true);
-      return () => setPrevented('guard', false);
-    }, [setPrevented]);
-    return null;
-  }
-  function RoutesCapture() {
-    routes.push(use(GlobalRoutesWithRemovalPreventedContext)!);
-    return null;
-  }
-  function Tree({ isPreloaded }: { isPreloaded: boolean }) {
-    return (
-      <RemovalPreventionProvider>
-        <PreventRemovalProvider routeKey="parent">
-          <IsPreloadedContext value={isPreloaded}>
-            <PreventRemovalProvider routeKey="child">
-              <Guard />
-            </PreventRemovalProvider>
-          </IsPreloadedContext>
-        </PreventRemovalProvider>
-        <RoutesCapture />
-      </RemovalPreventionProvider>
-    );
-  }
-  const result = render(<Tree isPreloaded />);
-  expect(routes.at(-1)).toEqual(new Set());
+test('does not register prevention for a preloaded child route', () => {
+  const wrapper = ({ children }: React.PropsWithChildren) => (
+    <RemovalPreventionProvider>
+      <PreventRemovalProvider routeKey="parent">
+        <IsPreloadedContext value>
+          <PreventRemovalProvider routeKey="child">{children}</PreventRemovalProvider>
+        </IsPreloadedContext>
+      </PreventRemovalProvider>
+    </RemovalPreventionProvider>
+  );
 
-  result.rerender(<Tree isPreloaded={false} />);
-  expect(routes.at(-1)).toEqual(new Set(['child', 'parent']));
+  const { result } = renderHook(
+    () => ({
+      setPrevented: use(ScreenRemovalPreventionSetterContext)!,
+      preventedRoutes: use(GlobalRoutesWithRemovalPreventedContext)!,
+    }),
+    { wrapper }
+  );
 
-  result.rerender(<Tree isPreloaded />);
-  expect(routes.at(-1)).toEqual(new Set());
+  act(() => result.current.setPrevented('guard', true));
+  expect(result.current.preventedRoutes).toEqual(new Set());
 });
 
 test('keeps a route emitter until the end of the task after its provider unmounts', async () => {

--- a/packages/expo-router/src/global-state/__tests__/removalPrevention.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/removalPrevention.test.ios.tsx
@@ -2,10 +2,10 @@ import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 import { use } from 'react';
 
+import { IsPreloadedContext } from '../../react-navigation/core/IsPreloadedContext';
 import {
   GlobalRoutesWithRemovalPreventedContext,
   GlobalRemovalEventEmitterRegistryContext,
-  isRouteRemovalPrevented,
   PreventRemovalProvider,
   RemovalPreventionProvider,
   ScreenRemovalPreventionSetterContext,
@@ -47,31 +47,72 @@ test('aggregates prevention across routes', () => {
   expect(routes.at(-1)).toEqual(new Set());
 });
 
-test.each(['stack', 'tab'] as const)(
-  'detects prevention in an active descendant but not a preloaded %s route',
-  (type) => {
-    const route = {
-      key: 'parent',
-      name: 'parent',
-      state: {
-        stale: false as const,
-        type,
-        key: type,
-        routeKeySeq: 0,
-        index: 0,
-        routeNames: ['active', 'preloaded'],
-        routes: [
-          { key: 'active', name: 'active' },
-          { key: 'preloaded', name: 'preloaded', isPreloaded: true as const },
-        ],
-      },
-    };
-
-    expect(isRouteRemovalPrevented(route, new Set(['active']))).toBe(true);
-    expect(isRouteRemovalPrevented(route, new Set(['preloaded']))).toBe(false);
-    expect(isRouteRemovalPrevented(route, new Set(['parent']))).toBe(true);
+test('propagates prevention from a child route to its parent route', () => {
+  let setChildPrevented: React.ContextType<typeof ScreenRemovalPreventionSetterContext>;
+  const routes: ReadonlySet<string>[] = [];
+  function CaptureChildSetter() {
+    setChildPrevented = use(ScreenRemovalPreventionSetterContext);
+    return null;
   }
-);
+  function RoutesCapture() {
+    routes.push(use(GlobalRoutesWithRemovalPreventedContext)!);
+    return null;
+  }
+  render(
+    <RemovalPreventionProvider>
+      <PreventRemovalProvider routeKey="parent">
+        <PreventRemovalProvider routeKey="child">
+          <CaptureChildSetter />
+        </PreventRemovalProvider>
+      </PreventRemovalProvider>
+      <RoutesCapture />
+    </RemovalPreventionProvider>
+  );
+
+  act(() => setChildPrevented!('guard', true));
+  expect(routes.at(-1)).toEqual(new Set(['child', 'parent']));
+
+  act(() => setChildPrevented!('guard', false));
+  expect(routes.at(-1)).toEqual(new Set());
+});
+
+test('does not register prevention for a preloaded child route and re-registers when active', () => {
+  const routes: ReadonlySet<string>[] = [];
+  function Guard() {
+    const setPrevented = use(ScreenRemovalPreventionSetterContext)!;
+    React.useLayoutEffect(() => {
+      setPrevented('guard', true);
+      return () => setPrevented('guard', false);
+    }, [setPrevented]);
+    return null;
+  }
+  function RoutesCapture() {
+    routes.push(use(GlobalRoutesWithRemovalPreventedContext)!);
+    return null;
+  }
+  function Tree({ isPreloaded }: { isPreloaded: boolean }) {
+    return (
+      <RemovalPreventionProvider>
+        <PreventRemovalProvider routeKey="parent">
+          <IsPreloadedContext value={isPreloaded}>
+            <PreventRemovalProvider routeKey="child">
+              <Guard />
+            </PreventRemovalProvider>
+          </IsPreloadedContext>
+        </PreventRemovalProvider>
+        <RoutesCapture />
+      </RemovalPreventionProvider>
+    );
+  }
+  const result = render(<Tree isPreloaded />);
+  expect(routes.at(-1)).toEqual(new Set());
+
+  result.rerender(<Tree isPreloaded={false} />);
+  expect(routes.at(-1)).toEqual(new Set(['child', 'parent']));
+
+  result.rerender(<Tree isPreloaded />);
+  expect(routes.at(-1)).toEqual(new Set());
+});
 
 test('keeps a route emitter until the end of the task after its provider unmounts', async () => {
   const action = { type: 'POP' };

--- a/packages/expo-router/src/global-state/__tests__/removalPrevention.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/removalPrevention.test.ios.tsx
@@ -71,17 +71,85 @@ test('propagates prevention from a child route to its parent route', () => {
   expect(result.current.preventedRoutes).toEqual(new Set());
 });
 
-test('does not register prevention for a preloaded child route', () => {
+test('updates prevention when a child route becomes active or preloaded', () => {
+  const routes: ReadonlySet<string>[] = [];
+  function Guard() {
+    const setPrevented = use(ScreenRemovalPreventionSetterContext)!;
+    React.useLayoutEffect(() => {
+      setPrevented('guard', true);
+      return () => setPrevented('guard', false);
+    }, [setPrevented]);
+    return null;
+  }
+  function RoutesCapture() {
+    routes.push(use(GlobalRoutesWithRemovalPreventedContext)!);
+    return null;
+  }
+  function Tree({ isPreloaded }: { isPreloaded: boolean }) {
+    return (
+      <RemovalPreventionProvider>
+        <PreventRemovalProvider routeKey="parent">
+          <IsPreloadedContext value={isPreloaded}>
+            <PreventRemovalProvider routeKey="child">
+              <Guard />
+            </PreventRemovalProvider>
+          </IsPreloadedContext>
+        </PreventRemovalProvider>
+        <RoutesCapture />
+      </RemovalPreventionProvider>
+    );
+  }
+
+  const result = render(<Tree isPreloaded />);
+  expect(routes.at(-1)).toEqual(new Set());
+
+  result.rerender(<Tree isPreloaded={false} />);
+  expect(routes.at(-1)).toEqual(new Set(['child', 'parent']));
+
+  result.rerender(<Tree isPreloaded />);
+  expect(routes.at(-1)).toEqual(new Set());
+});
+
+test('keeps a parent prevented while either child prevents removal with the same id', () => {
+  const setters = new Map<string, (id: string, isPrevented: boolean) => void>();
+  function Capture({ routeKey }: { routeKey: string }) {
+    setters.set(routeKey, use(ScreenRemovalPreventionSetterContext)!);
+    return null;
+  }
   const wrapper = ({ children }: React.PropsWithChildren) => (
     <RemovalPreventionProvider>
       <PreventRemovalProvider routeKey="parent">
-        <IsPreloadedContext value>
+        <PreventRemovalProvider routeKey="child-a">
+          <Capture routeKey="child-a" />
+        </PreventRemovalProvider>
+        <PreventRemovalProvider routeKey="child-b">
+          <Capture routeKey="child-b" />
+        </PreventRemovalProvider>
+      </PreventRemovalProvider>
+      {children}
+    </RemovalPreventionProvider>
+  );
+  const { result } = renderHook(() => use(GlobalRoutesWithRemovalPreventedContext)!, { wrapper });
+
+  act(() => {
+    setters.get('child-a')!('guard', true);
+    setters.get('child-b')!('guard', true);
+  });
+  act(() => setters.get('child-a')!('guard', false));
+
+  expect(result.current).toEqual(new Set(['child-b', 'parent']));
+});
+
+test('propagates prevention through every ancestor route', () => {
+  const wrapper = ({ children }: React.PropsWithChildren) => (
+    <RemovalPreventionProvider>
+      <PreventRemovalProvider routeKey="grandparent">
+        <PreventRemovalProvider routeKey="parent">
           <PreventRemovalProvider routeKey="child">{children}</PreventRemovalProvider>
-        </IsPreloadedContext>
+        </PreventRemovalProvider>
       </PreventRemovalProvider>
     </RemovalPreventionProvider>
   );
-
   const { result } = renderHook(
     () => ({
       setPrevented: use(ScreenRemovalPreventionSetterContext)!,
@@ -91,7 +159,31 @@ test('does not register prevention for a preloaded child route', () => {
   );
 
   act(() => result.current.setPrevented('guard', true));
-  expect(result.current.preventedRoutes).toEqual(new Set());
+
+  expect(result.current.preventedRoutes).toEqual(new Set(['child', 'parent', 'grandparent']));
+});
+
+test('registers prevention for a preloaded child route when requested', () => {
+  const wrapper = ({ children }: React.PropsWithChildren) => (
+    <RemovalPreventionProvider>
+      <PreventRemovalProvider routeKey="parent">
+        <IsPreloadedContext value>
+          <PreventRemovalProvider routeKey="child">{children}</PreventRemovalProvider>
+        </IsPreloadedContext>
+      </PreventRemovalProvider>
+    </RemovalPreventionProvider>
+  );
+  const { result } = renderHook(
+    () => ({
+      setPrevented: use(ScreenRemovalPreventionSetterContext)!,
+      preventedRoutes: use(GlobalRoutesWithRemovalPreventedContext)!,
+    }),
+    { wrapper }
+  );
+
+  act(() => result.current.setPrevented('guard', true, true));
+
+  expect(result.current.preventedRoutes).toEqual(new Set(['child', 'parent']));
 });
 
 test('keeps a route emitter until the end of the task after its provider unmounts', async () => {

--- a/packages/expo-router/src/global-state/removalPrevention.tsx
+++ b/packages/expo-router/src/global-state/removalPrevention.tsx
@@ -3,8 +3,9 @@
 import * as React from 'react';
 import { createContext, use, useMemo, useState, type PropsWithChildren } from 'react';
 
+import { IsPreloadedContext } from '../react-navigation/core/IsPreloadedContext';
 import { useClientLayoutEffect } from '../react-navigation/core/useClientLayoutEffect';
-import type { NavigationAction, NavigationState, PartialState } from '../react-navigation/routers';
+import type { NavigationAction } from '../react-navigation/routers';
 
 type RemovalEventType = 'removePrevented' | 'removed';
 type RemovalEventEmitter = (type: RemovalEventType, action: NavigationAction) => void;
@@ -134,9 +135,17 @@ function useRegisterRouteEmitter(routeKey: string, emitRemovalEvent?: RouteRemov
 
 function useRouteRemovalPreventionSetter(routeKey: string) {
   const preventionSetter = use(GlobalRouteRemovalPreventionSetterContext);
+  const parentPreventionSetter = use(ScreenRemovalPreventionSetterContext);
+  const isPreloaded = use(IsPreloadedContext);
   return React.useCallback(
-    (id: string, isPrevented: boolean) => preventionSetter?.(routeKey, id, isPrevented),
-    [preventionSetter, routeKey]
+    (id: string, isPrevented: boolean) => {
+      if (isPreloaded) {
+        return;
+      }
+      preventionSetter?.(routeKey, id, isPrevented);
+      parentPreventionSetter?.(id, isPrevented);
+    },
+    [isPreloaded, parentPreventionSetter, preventionSetter, routeKey]
   );
 }
 
@@ -164,26 +173,3 @@ export function useRoutesWithRemovalPrevented() {
 }
 
 const EMPTY_SET: ReadonlySet<string> = new Set();
-
-export function isRouteRemovalPrevented(
-  route: {
-    key: string | undefined;
-    state?: NavigationState | PartialState<NavigationState>;
-  },
-  preventedRouteKeys: ReadonlySet<string>
-): boolean {
-  if (route.key !== undefined && preventedRouteKeys.has(route.key)) {
-    return true;
-  }
-
-  const visitState = (state: NavigationState): boolean => {
-    return state.routes.some(
-      (route) =>
-        !route.isPreloaded &&
-        (preventedRouteKeys.has(route.key) ||
-          (route.state?.stale === false && visitState(route.state)))
-    );
-  };
-
-  return route.state?.stale === false && visitState(route.state);
-}

--- a/packages/expo-router/src/global-state/removalPrevention.tsx
+++ b/packages/expo-router/src/global-state/removalPrevention.tsx
@@ -36,7 +36,7 @@ export const GlobalRemovalEventEmitterRegistryContext =
 
 /** Registers independent prevention requests with the nearest route provider. */
 export const ScreenRemovalPreventionSetterContext = createContext<
-  ((id: string, isPrevented: boolean) => void) | undefined
+  ((id: string, isPrevented: boolean, preventInPreloadedRoutes?: boolean) => void) | undefined
 >(undefined);
 
 function RemovalEventEmitterRegistryProvider({ children }: PropsWithChildren) {
@@ -138,12 +138,12 @@ function useRouteRemovalPreventionSetter(routeKey: string) {
   const parentPreventionSetter = use(ScreenRemovalPreventionSetterContext);
   const isPreloaded = use(IsPreloadedContext);
   return React.useCallback(
-    (id: string, isPrevented: boolean) => {
-      if (isPreloaded) {
+    (id: string, isPrevented: boolean, preventInPreloadedRoutes = false) => {
+      if (isPreloaded && !preventInPreloadedRoutes) {
         return;
       }
       preventionSetter?.(routeKey, id, isPrevented);
-      parentPreventionSetter?.(id, isPrevented);
+      parentPreventionSetter?.(`${routeKey}:${id}`, isPrevented, preventInPreloadedRoutes);
     },
     [isPreloaded, parentPreventionSetter, preventionSetter, routeKey]
   );

--- a/packages/expo-router/src/layouts/experimental-stack/ExperimentalStackView.tsx
+++ b/packages/expo-router/src/layouts/experimental-stack/ExperimentalStackView.tsx
@@ -3,10 +3,7 @@ import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Stack as ScreensStackV5 } from 'react-native-screens/experimental';
 
-import {
-  isRouteRemovalPrevented,
-  useRoutesWithRemovalPrevented,
-} from '../../global-state/removalPrevention';
+import { useRoutesWithRemovalPrevented } from '../../global-state/removalPrevention';
 import {
   type ParamListBase,
   StackActions,
@@ -44,7 +41,7 @@ export function ExperimentalStackView({ state, navigation, descriptors }: Props)
           const descriptor = descriptors[route.key]!;
           const isPreloaded = index > state.index;
           const options = (descriptor.options ?? {}) as ExperimentalStackNavigationOptions;
-          const preventFromContext = isRouteRemovalPrevented(route, routesWithRemovalPrevented);
+          const preventFromContext = routesWithRemovalPrevented.has(route.key);
 
           return (
             <ScreenView

--- a/packages/expo-router/src/react-navigation/core/index.tsx
+++ b/packages/expo-router/src/react-navigation/core/index.tsx
@@ -74,7 +74,7 @@ export { useNavigationBuilder } from './useNavigationBuilder';
  */
 export { useNavigationContainerRef } from './useNavigationContainerRef';
 export { useNavigationState } from './useNavigationState';
-export { usePreventRemove } from './usePreventRemove';
+export { type PreventRemoveOptions, usePreventRemove } from './usePreventRemove';
 /**
  * @deprecated Import `useRoute` from `expo-router` instead. Will be removed in a future SDK.
  */

--- a/packages/expo-router/src/react-navigation/core/usePreventRemove.tsx
+++ b/packages/expo-router/src/react-navigation/core/usePreventRemove.tsx
@@ -4,12 +4,19 @@ import * as React from 'react';
 import { ScreenRemovalPreventionSetterContext } from '../../global-state/removalPrevention';
 import useLatestCallback from '../../utils/useLatestCallback';
 import type { NavigationAction } from '../routers';
-import { IsPreloadedContext } from './IsPreloadedContext';
 import type { EventListenerCallback, EventMapCore } from './types';
 import { useClientLayoutEffect } from './useClientLayoutEffect';
 import { useNavigation } from './useNavigation';
 
 const NOOP = () => {};
+
+export type PreventRemoveOptions = {
+  /**
+   * Whether removal prevention remains active while the screen is preloaded.
+   * @default false
+   */
+  preventInPreloadedRoutes?: boolean;
+};
 
 function useWarnOnStalePreventRemoveDev(preventRemove: boolean) {
   const [shouldCheck, setShouldCheck] = React.useState(false);
@@ -65,16 +72,18 @@ const useWarnOnStalePreventRemove: (preventRemove: boolean) => () => void =
  *
  * @param preventRemove Boolean indicating whether to prevent screen from being removed.
  * @param callback Optional function called when the screen was prevented from being removed.
+ * @param options Options that configure removal prevention.
  */
 export function usePreventRemove(
   preventRemove: boolean,
-  callback?: (options: { data: { action: NavigationAction } }) => void
+  callback?: (options: { data: { action: NavigationAction } }) => void,
+  options?: PreventRemoveOptions
 ) {
   const id = React.useId();
   const navigation = useNavigation();
-  const isPreloaded = React.use(IsPreloadedContext);
   const setPreventRemove = React.use(ScreenRemovalPreventionSetterContext);
   const markDisabled = useWarnOnStalePreventRemove(preventRemove);
+  const preventInPreloadedRoutes = options?.preventInPreloadedRoutes ?? false;
 
   if (setPreventRemove === undefined) {
     throw new Error(
@@ -83,11 +92,11 @@ export function usePreventRemove(
   }
 
   useClientLayoutEffect(() => {
-    setPreventRemove(id, preventRemove && !isPreloaded);
+    setPreventRemove(id, preventRemove, preventInPreloadedRoutes);
     return () => {
-      setPreventRemove(id, false);
+      setPreventRemove(id, false, preventInPreloadedRoutes);
     };
-  }, [id, isPreloaded, preventRemove, setPreventRemove]);
+  }, [id, preventInPreloadedRoutes, preventRemove, setPreventRemove]);
 
   const removePreventedListener = useLatestCallback<
     EventListenerCallback<EventMapCore<any>, 'removePrevented'>
@@ -104,7 +113,7 @@ export function usePreventRemove(
   // TODO(@ubax): use standard useCallback if possible
   // TODO(@ubax): add repeat function which will call this and repeat the action
   return useLatestCallback(() => {
-    setPreventRemove(id, false);
+    setPreventRemove(id, false, preventInPreloadedRoutes);
     markDisabled();
   });
 }

--- a/packages/expo-router/src/react-navigation/native-stack/utils/useInvalidPreventRemoveError.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/utils/useInvalidPreventRemoveError.tsx
@@ -1,17 +1,14 @@
 'use client';
 import * as React from 'react';
 
-import {
-  isRouteRemovalPrevented,
-  useRoutesWithRemovalPrevented,
-} from '../../../global-state/removalPrevention';
+import { useRoutesWithRemovalPrevented } from '../../../global-state/removalPrevention';
 import type { NativeStackDescriptorMap } from '../types';
 
 export function useInvalidPreventRemoveError(descriptors: NativeStackDescriptorMap) {
   // TODO(@ubax): remove this hook later.
   const routesWithRemovalPrevented = useRoutesWithRemovalPrevented();
-  const preventedDescriptor = Object.values(descriptors).find(({ route }) =>
-    isRouteRemovalPrevented(route, routesWithRemovalPrevented)
+  const preventedDescriptor = Object.values(descriptors).find(
+    ({ route }) => route.key !== undefined && routesWithRemovalPrevented.has(route.key)
   );
   const isHeaderBackButtonMenuEnabledOnPreventedScreen =
     preventedDescriptor?.options?.headerBackButtonMenuEnabled;

--- a/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
@@ -10,10 +10,7 @@ import {
   ScreenStackItem,
 } from 'react-native-screens';
 
-import {
-  isRouteRemovalPrevented,
-  useRoutesWithRemovalPrevented,
-} from '../../../global-state/removalPrevention';
+import { useRoutesWithRemovalPrevented } from '../../../global-state/removalPrevention';
 import {
   getDefaultHeaderHeight,
   getHeaderTitle,
@@ -252,7 +249,7 @@ const SceneView = ({
     return undefined;
   }, [canGoBack, backTitle]);
 
-  const isRemovePrevented = isRouteRemovalPrevented(route, routesWithRemovalPrevented);
+  const isRemovePrevented = routesWithRemovalPrevented.has(route.key);
 
   const headerConfig = useHeaderConfigProps({
     ...options,


### PR DESCRIPTION
# Why

When a route cannot be removed, all of it parents should prevent removal as well.

# How

1. Propagate prevent remove flag to parent

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)