### PR TITLE
[web][image-manipulator] Release image resources

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Web] Fixed `release()` not releasing image manipulation resources.
 - Fixed `ImageManipulator.Image` being typed as an `ImageRef` instance rather than the class it holds at runtime, which rejected `instanceof` checks and made instance members appear to exist on it. ([#48613](https://github.com/expo/expo/pull/48613) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Web] Fixed `release()` not releasing image manipulation resources.
+- [Web] Fixed `release()` not releasing image manipulation resources. ([#49831](https://github.com/expo/expo/pull/49831) by [@mozzius](https://github.com/mozzius))
 - Fixed `ImageManipulator.Image` being typed as an `ImageRef` instance rather than the class it holds at runtime, which rejected `instanceof` checks and made instance members appear to exist on it. ([#48613](https://github.com/expo/expo/pull/48613) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others

--- a/packages/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
+++ b/packages/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
@@ -85,8 +85,8 @@ export default class ImageManipulatorContext extends SharedObject {
     clonedCanvasCtx?.drawImage(canvas, 0, 0);
 
     return new Promise((resolve) => {
-      // Create a full-sized, full-quality blob from the original canvas.
-      canvas.toBlob(
+      // Encode the clone, which remains valid if the context is released or reset.
+      clonedCanvas.toBlob(
         (blob) => {
           const url = blob ? URL.createObjectURL(blob) : clonedCanvas.toDataURL();
           const image = new ImageManipulatorImageRef(url, clonedCanvas);

--- a/packages/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
+++ b/packages/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
@@ -3,14 +3,17 @@ import { SharedObject } from 'expo';
 import type { ActionCrop, ActionExtent, FlipType } from '../ImageManipulator.types';
 import ImageManipulatorImageRef from './ImageManipulatorImageRef.web';
 import { crop, extent, flip, resize, rotate } from './actions/index.web';
+import { releaseCanvas } from './utils.web';
 
 type ContextLoader = () => HTMLCanvasElement | Promise<HTMLCanvasElement>;
 
 export default class ImageManipulatorContext extends SharedObject {
   private loader: ContextLoader;
+  private isReleased = false;
 
   private _currentTask: Promise<HTMLCanvasElement> | undefined;
   get currentTask() {
+    this.ensureNotReleased();
     if (this._currentTask) {
       return this._currentTask;
     }
@@ -18,6 +21,7 @@ export default class ImageManipulatorContext extends SharedObject {
     return this._currentTask;
   }
   set currentTask(task) {
+    this.ensureNotReleased();
     this._currentTask = task;
   }
 
@@ -47,8 +51,25 @@ export default class ImageManipulatorContext extends SharedObject {
   }
 
   reset(): ImageManipulatorContext {
+    this.ensureNotReleased();
+    const previousTask = this._currentTask;
     this.currentTask = new Promise((resolve) => resolve(this.loader()));
+    this.releaseTask(previousTask);
     return this;
+  }
+
+  release(): void {
+    if (this.isReleased) {
+      return;
+    }
+    this.isReleased = true;
+
+    this.releaseTask(this._currentTask);
+    this._currentTask = undefined;
+    this.loader = () => {
+      throw new Error('Cannot use shared object that was already released');
+    };
+    super.release();
   }
 
   async renderAsync(): Promise<ImageManipulatorImageRef> {
@@ -67,7 +88,7 @@ export default class ImageManipulatorContext extends SharedObject {
       // Create a full-sized, full-quality blob from the original canvas.
       canvas.toBlob(
         (blob) => {
-          const url = blob ? URL.createObjectURL(blob) : canvas.toDataURL();
+          const url = blob ? URL.createObjectURL(blob) : clonedCanvas.toDataURL();
           const image = new ImageManipulatorImageRef(url, clonedCanvas);
 
           resolve(image);
@@ -82,9 +103,32 @@ export default class ImageManipulatorContext extends SharedObject {
   private addTask(
     task: (canvas: HTMLCanvasElement) => HTMLCanvasElement | Promise<HTMLCanvasElement>
   ): ImageManipulatorContext {
-    this.currentTask = this.currentTask.then((canvas) => {
-      return task(canvas);
+    this.currentTask = this.currentTask.then(async (canvas) => {
+      try {
+        const result = await task(canvas);
+        if (result !== canvas) {
+          releaseCanvas(canvas);
+        }
+        return result;
+      } catch (error) {
+        releaseCanvas(canvas);
+        throw error;
+      }
     });
     return this;
+  }
+
+  private ensureNotReleased(): void {
+    if (this.isReleased) {
+      throw new Error('Cannot use shared object that was already released');
+    }
+  }
+
+  private releaseTask(task: Promise<HTMLCanvasElement> | undefined): void {
+    task?.then(releaseCanvas, (reason) => {
+      if (typeof HTMLCanvasElement !== 'undefined' && reason instanceof HTMLCanvasElement) {
+        releaseCanvas(reason);
+      }
+    });
   }
 }

--- a/packages/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
+++ b/packages/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
@@ -126,10 +126,7 @@ export default class ImageManipulatorContext extends SharedObject {
   }
 
   private releaseTask(task: Promise<HTMLCanvasElement> | undefined): void {
-    task?.then(releaseCanvas, (reason) => {
-      if (typeof HTMLCanvasElement !== 'undefined' && reason instanceof HTMLCanvasElement) {
-        releaseCanvas(reason);
-      }
-    });
+    // Failed tasks clean up their own canvases.
+    task?.then(releaseCanvas, () => {});
   }
 }

--- a/packages/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
+++ b/packages/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
@@ -1,4 +1,4 @@
-import { SharedObject } from 'expo';
+import { CodedError, SharedObject } from 'expo';
 
 import type { ActionCrop, ActionExtent, FlipType } from '../ImageManipulator.types';
 import ImageManipulatorImageRef from './ImageManipulatorImageRef.web';
@@ -118,7 +118,10 @@ export default class ImageManipulatorContext extends SharedObject {
 
   private ensureNotReleased(): void {
     if (this.isReleased) {
-      throw new Error('Cannot use shared object that was already released');
+      throw new CodedError(
+        'ERR_IMAGE_MANIPULATOR_RELEASED',
+        'This image manipulation context was released by release() or by useImageManipulator when its source changed or its component unmounted. Create a new context with ImageManipulator.manipulate(...).'
+      );
     }
   }
 

--- a/packages/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
+++ b/packages/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
@@ -8,7 +8,7 @@ import { releaseCanvas } from './utils.web';
 type ContextLoader = () => HTMLCanvasElement | Promise<HTMLCanvasElement>;
 
 export default class ImageManipulatorContext extends SharedObject {
-  private loader: ContextLoader;
+  private loader: ContextLoader | undefined;
   private isReleased = false;
 
   private _currentTask: Promise<HTMLCanvasElement> | undefined;
@@ -17,7 +17,7 @@ export default class ImageManipulatorContext extends SharedObject {
     if (this._currentTask) {
       return this._currentTask;
     }
-    this._currentTask = new Promise((resolve) => resolve(this.loader()));
+    this._currentTask = new Promise((resolve) => resolve(this.loader!()));
     return this._currentTask;
   }
   set currentTask(task) {
@@ -53,7 +53,7 @@ export default class ImageManipulatorContext extends SharedObject {
   reset(): ImageManipulatorContext {
     this.ensureNotReleased();
     const previousTask = this._currentTask;
-    this.currentTask = new Promise((resolve) => resolve(this.loader()));
+    this.currentTask = new Promise((resolve) => resolve(this.loader!()));
     this.releaseTask(previousTask);
     return this;
   }
@@ -66,9 +66,7 @@ export default class ImageManipulatorContext extends SharedObject {
 
     this.releaseTask(this._currentTask);
     this._currentTask = undefined;
-    this.loader = () => {
-      throw new Error('Cannot use shared object that was already released');
-    };
+    this.loader = undefined;
     super.release();
   }
 

--- a/packages/expo-image-manipulator/src/web/ImageManipulatorImageRef.web.ts
+++ b/packages/expo-image-manipulator/src/web/ImageManipulatorImageRef.web.ts
@@ -67,7 +67,7 @@ export default class ImageManipulatorImageRef extends SharedRef<'image'> {
     }
     this.isReleased = true;
 
-    if (this.uri.startsWith('blob:')) {
+    if (this.uri.toLowerCase().startsWith('blob:')) {
       URL.revokeObjectURL(this.uri);
     }
     releaseCanvas(this.canvas);

--- a/packages/expo-image-manipulator/src/web/ImageManipulatorImageRef.web.ts
+++ b/packages/expo-image-manipulator/src/web/ImageManipulatorImageRef.web.ts
@@ -2,10 +2,11 @@ import { SharedRef } from 'expo';
 
 import type { ImageResult, SaveOptions } from '../ImageManipulator.types';
 import { SaveFormat } from '../ImageManipulator.types';
-import { blobToBase64String } from './utils.web';
+import { blobToBase64String, releaseCanvas } from './utils.web';
 
 export default class ImageManipulatorImageRef extends SharedRef<'image'> {
   readonly nativeRefType: string = 'image';
+  private isReleased = false;
 
   readonly uri: string;
   readonly canvas: HTMLCanvasElement;
@@ -17,14 +18,19 @@ export default class ImageManipulatorImageRef extends SharedRef<'image'> {
   }
 
   get width() {
+    this.ensureNotReleased();
     return this.canvas.width;
   }
 
   get height() {
+    this.ensureNotReleased();
     return this.canvas.height;
   }
 
   async saveAsync(options: SaveOptions = { base64: false }): Promise<ImageResult> {
+    this.ensureNotReleased();
+    const width = this.width;
+    const height = this.height;
     return new Promise((resolve, reject) => {
       const requestedType = `image/${options.format ?? SaveFormat.JPEG}`;
       this.canvas.toBlob(
@@ -44,8 +50,8 @@ export default class ImageManipulatorImageRef extends SharedRef<'image'> {
 
           resolve({
             uri,
-            width: this.width,
-            height: this.height,
+            width,
+            height,
             base64,
           });
         },
@@ -53,5 +59,24 @@ export default class ImageManipulatorImageRef extends SharedRef<'image'> {
         options.compress
       );
     });
+  }
+
+  release(): void {
+    if (this.isReleased) {
+      return;
+    }
+    this.isReleased = true;
+
+    if (this.uri.startsWith('blob:')) {
+      URL.revokeObjectURL(this.uri);
+    }
+    releaseCanvas(this.canvas);
+    super.release();
+  }
+
+  private ensureNotReleased(): void {
+    if (this.isReleased) {
+      throw new Error('Cannot use shared object that was already released');
+    }
   }
 }

--- a/packages/expo-image-manipulator/src/web/ImageManipulatorImageRef.web.ts
+++ b/packages/expo-image-manipulator/src/web/ImageManipulatorImageRef.web.ts
@@ -1,4 +1,4 @@
-import { SharedRef } from 'expo';
+import { CodedError, SharedRef } from 'expo';
 
 import type { ImageResult, SaveOptions } from '../ImageManipulator.types';
 import { SaveFormat } from '../ImageManipulator.types';
@@ -76,7 +76,10 @@ export default class ImageManipulatorImageRef extends SharedRef<'image'> {
 
   private ensureNotReleased(): void {
     if (this.isReleased) {
-      throw new Error('Cannot use shared object that was already released');
+      throw new CodedError(
+        'ERR_IMAGE_MANIPULATOR_RELEASED',
+        'This image was released by release(). Render a new image with ImageManipulatorContext.renderAsync().'
+      );
     }
   }
 }

--- a/packages/expo-image-manipulator/src/web/__tests__/release.web-test.ts
+++ b/packages/expo-image-manipulator/src/web/__tests__/release.web-test.ts
@@ -66,19 +66,14 @@ describe('release', () => {
     await expect(context.currentTask).resolves.toBe(secondCanvas);
   });
 
-  it('releases a canvas returned by a failed context task', async () => {
-    if (typeof document === 'undefined') {
-      return;
-    }
-    const canvas = document.createElement('canvas');
-    const context = new ImageManipulatorContext(() => Promise.reject(canvas));
+  it('can release a context whose loader failed', async () => {
+    const error = new Error('Failed to load image');
+    const context = new ImageManipulatorContext(() => Promise.reject(error));
     const task = context.currentTask;
 
     context.release();
-    await expect(task).rejects.toBe(canvas);
-
-    expect(canvas.width).toBe(0);
-    expect(canvas.height).toBe(0);
+    await expect(task).rejects.toBe(error);
+    expect(() => context.release()).not.toThrow();
   });
 
   it('releases a canvas replaced by an action', async () => {

--- a/packages/expo-image-manipulator/src/web/__tests__/release.web-test.ts
+++ b/packages/expo-image-manipulator/src/web/__tests__/release.web-test.ts
@@ -43,7 +43,12 @@ describe('release', () => {
 
     expect(canvas.width).toBe(0);
     expect(canvas.height).toBe(0);
-    expect(() => context.reset()).toThrow('Cannot use shared object that was already released');
+    expect(() => context.reset()).toThrow(
+      expect.objectContaining({ code: 'ERR_IMAGE_MANIPULATOR_RELEASED' })
+    );
+    await expect(context.renderAsync()).rejects.toMatchObject({
+      code: 'ERR_IMAGE_MANIPULATOR_RELEASED',
+    });
   });
 
   it('releases the previous context canvas when resetting', async () => {
@@ -113,7 +118,9 @@ describe('release', () => {
     expect(revokeObjectURL).toHaveBeenCalledWith(uri);
     expect(canvas.width).toBe(0);
     expect(canvas.height).toBe(0);
-    expect(() => image.width).toThrow('Cannot use shared object that was already released');
+    expect(() => image.width).toThrow(
+      expect.objectContaining({ code: 'ERR_IMAGE_MANIPULATOR_RELEASED' })
+    );
   });
 
   it('does not revoke a data URL', () => {

--- a/packages/expo-image-manipulator/src/web/__tests__/release.web-test.ts
+++ b/packages/expo-image-manipulator/src/web/__tests__/release.web-test.ts
@@ -1,0 +1,129 @@
+import ImageManipulatorContext from '../ImageManipulatorContext.web';
+import ImageManipulatorImageRef from '../ImageManipulatorImageRef.web';
+
+function addTask(
+  context: ImageManipulatorContext,
+  task: (canvas: HTMLCanvasElement) => HTMLCanvasElement | Promise<HTMLCanvasElement>
+): void {
+  (
+    context as unknown as {
+      addTask: (
+        task: (canvas: HTMLCanvasElement) => HTMLCanvasElement | Promise<HTMLCanvasElement>
+      ) => void;
+    }
+  ).addTask(task);
+}
+
+describe('release', () => {
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  let revokeObjectURL: jest.Mock;
+
+  beforeEach(() => {
+    revokeObjectURL = jest.fn();
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: originalRevokeObjectURL,
+    });
+  });
+
+  it('releases the context canvas after pending work settles', async () => {
+    const canvas = { width: 100, height: 50 } as HTMLCanvasElement;
+    const context = new ImageManipulatorContext(() => canvas);
+    const task = context.currentTask;
+
+    context.release();
+    await task;
+
+    expect(canvas.width).toBe(0);
+    expect(canvas.height).toBe(0);
+    expect(() => context.reset()).toThrow('Cannot use shared object that was already released');
+  });
+
+  it('releases the previous context canvas when resetting', async () => {
+    const firstCanvas = { width: 100, height: 50 } as HTMLCanvasElement;
+    const secondCanvas = { width: 200, height: 100 } as HTMLCanvasElement;
+    const loader = jest.fn().mockReturnValueOnce(firstCanvas).mockReturnValueOnce(secondCanvas);
+    const context = new ImageManipulatorContext(loader);
+    const firstTask = context.currentTask;
+
+    context.reset();
+    await firstTask;
+
+    expect(firstCanvas.width).toBe(0);
+    expect(firstCanvas.height).toBe(0);
+    await expect(context.currentTask).resolves.toBe(secondCanvas);
+  });
+
+  it('releases a canvas returned by a failed context task', async () => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const canvas = document.createElement('canvas');
+    const context = new ImageManipulatorContext(() => Promise.reject(canvas));
+    const task = context.currentTask;
+
+    context.release();
+    await expect(task).rejects.toBe(canvas);
+
+    expect(canvas.width).toBe(0);
+    expect(canvas.height).toBe(0);
+  });
+
+  it('releases a canvas replaced by an action', async () => {
+    const sourceCanvas = { width: 100, height: 50 } as HTMLCanvasElement;
+    const resultCanvas = { width: 50, height: 25 } as HTMLCanvasElement;
+    const context = new ImageManipulatorContext(() => sourceCanvas);
+
+    addTask(context, () => resultCanvas);
+    await expect(context.currentTask).resolves.toBe(resultCanvas);
+
+    expect(sourceCanvas.width).toBe(0);
+    expect(sourceCanvas.height).toBe(0);
+  });
+
+  it('releases an action input canvas when the action fails', async () => {
+    const canvas = { width: 100, height: 50 } as HTMLCanvasElement;
+    const error = new Error('Failed to resize');
+    const context = new ImageManipulatorContext(() => canvas);
+
+    addTask(context, () => {
+      throw error;
+    });
+    await expect(context.currentTask).rejects.toBe(error);
+
+    expect(canvas.width).toBe(0);
+    expect(canvas.height).toBe(0);
+  });
+
+  it('releases an image ref only once', () => {
+    const canvas = { width: 100, height: 50 } as HTMLCanvasElement;
+    const image = new ImageManipulatorImageRef('blob:image', canvas);
+
+    image.release();
+    image.release();
+
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:image');
+    expect(canvas.width).toBe(0);
+    expect(canvas.height).toBe(0);
+    expect(() => image.width).toThrow('Cannot use shared object that was already released');
+  });
+
+  it('does not revoke a data URL', () => {
+    const image = new ImageManipulatorImageRef('data:image/png;base64,example', {
+      width: 100,
+      height: 50,
+    } as HTMLCanvasElement);
+
+    image.release();
+
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+});

--- a/packages/expo-image-manipulator/src/web/__tests__/release.web-test.ts
+++ b/packages/expo-image-manipulator/src/web/__tests__/release.web-test.ts
@@ -102,15 +102,15 @@ describe('release', () => {
     expect(canvas.height).toBe(0);
   });
 
-  it('releases an image ref only once', () => {
+  it.each(['blob:image', 'BLOB:image', 'Blob:image'])('releases %s only once', (uri) => {
     const canvas = { width: 100, height: 50 } as HTMLCanvasElement;
-    const image = new ImageManipulatorImageRef('blob:image', canvas);
+    const image = new ImageManipulatorImageRef(uri, canvas);
 
     image.release();
     image.release();
 
     expect(revokeObjectURL).toHaveBeenCalledTimes(1);
-    expect(revokeObjectURL).toHaveBeenCalledWith('blob:image');
+    expect(revokeObjectURL).toHaveBeenCalledWith(uri);
     expect(canvas.width).toBe(0);
     expect(canvas.height).toBe(0);
     expect(() => image.width).toThrow('Cannot use shared object that was already released');

--- a/packages/expo-image-manipulator/src/web/__tests__/render.test.web.ts
+++ b/packages/expo-image-manipulator/src/web/__tests__/render.test.web.ts
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 
 import ImageManipulatorContext from '../ImageManipulatorContext.web';
+import { loadImageAsync } from '../utils.web';
 
 describe('rendering during release', () => {
   const originalCreateObjectURL = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
@@ -94,5 +95,20 @@ describe('rendering during release', () => {
     expect(image.width).toBe(300);
     expect(image.height).toBe(150);
     image.release();
+  });
+
+  it('cleans up failed image loads and rejects with a coded error', async () => {
+    const image = new Image();
+    const canvas = document.createElement('canvas');
+    jest.spyOn(globalThis, 'Image').mockImplementation(() => image);
+    jest.spyOn(document, 'createElement').mockReturnValue(canvas);
+
+    const load = loadImageAsync('blob:released');
+    image.dispatchEvent(new Event('error'));
+
+    await expect(load).rejects.toBeInstanceOf(Error);
+    await expect(load).rejects.toMatchObject({ code: 'ERR_IMAGE_MANIPULATOR_LOAD' });
+    expect(canvas.width).toBe(0);
+    expect(canvas.height).toBe(0);
   });
 });

--- a/packages/expo-image-manipulator/src/web/__tests__/render.test.web.ts
+++ b/packages/expo-image-manipulator/src/web/__tests__/render.test.web.ts
@@ -1,0 +1,98 @@
+/** @jest-environment jsdom */
+
+import ImageManipulatorContext from '../ImageManipulatorContext.web';
+
+describe('rendering during release', () => {
+  const originalCreateObjectURL = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+  const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+
+  beforeEach(() => {
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(() => 'blob:rendered'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage: jest.fn(),
+    } as unknown as CanvasRenderingContext2D);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalCreateObjectURL) {
+      Object.defineProperty(URL, 'createObjectURL', originalCreateObjectURL);
+    } else {
+      delete (URL as Partial<typeof URL>).createObjectURL;
+    }
+    if (originalRevokeObjectURL) {
+      Object.defineProperty(URL, 'revokeObjectURL', originalRevokeObjectURL);
+    } else {
+      delete (URL as Partial<typeof URL>).revokeObjectURL;
+    }
+  });
+
+  it.each(['release', 'reset'] as const)(
+    'encodes an independent canvas while %s clears the context',
+    async (action) => {
+      const source = document.createElement('canvas');
+      source.width = 300;
+      source.height = 150;
+      const context = new ImageManipulatorContext(() => source);
+      const encodingStarted = new Promise<[HTMLCanvasElement, BlobCallback]>((resolve) => {
+        jest
+          .spyOn(HTMLCanvasElement.prototype, 'toBlob')
+          .mockImplementation(function (this: HTMLCanvasElement, callback) {
+            resolve([this, callback]);
+          });
+      });
+      const render = context.renderAsync();
+      const [encodedCanvas, finishEncoding] = await encodingStarted;
+
+      context[action]();
+      await Promise.resolve();
+
+      expect(source.width).toBe(0);
+      expect(source.height).toBe(0);
+      expect(encodedCanvas).not.toBe(source);
+      expect(encodedCanvas.width).toBe(300);
+      expect(encodedCanvas.height).toBe(150);
+
+      const blob = new Blob(['image'], { type: 'image/png' });
+      finishEncoding(blob);
+      const image = await render;
+      expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
+      expect(image.uri).toBe('blob:rendered');
+      expect(image.width).toBe(300);
+      expect(image.height).toBe(150);
+      image.release();
+      context.release();
+    }
+  );
+
+  it('uses the clone for the data URL fallback after release', async () => {
+    const source = document.createElement('canvas');
+    const context = new ImageManipulatorContext(() => source);
+    const encodingStarted = new Promise<BlobCallback>((resolve) => {
+      jest.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(resolve);
+    });
+    const toDataURL = jest
+      .spyOn(HTMLCanvasElement.prototype, 'toDataURL')
+      .mockReturnValue('data:image/png;base64,rendered');
+    const render = context.renderAsync();
+    const finishEncoding = await encodingStarted;
+
+    context.release();
+    await Promise.resolve();
+    finishEncoding(null);
+
+    const image = await render;
+    expect(toDataURL.mock.instances[0]).toBe(image.canvas);
+    expect(image.uri).toBe('data:image/png;base64,rendered');
+    expect(image.width).toBe(300);
+    expect(image.height).toBe(150);
+    image.release();
+  });
+});

--- a/packages/expo-image-manipulator/src/web/utils.web.ts
+++ b/packages/expo-image-manipulator/src/web/utils.web.ts
@@ -49,7 +49,15 @@ export function loadImageAsync(
 
       resolve(canvas);
     };
-    imageSource.onerror = () => reject(canvas);
+    imageSource.onerror = () => {
+      releaseCanvas(canvas);
+      reject(
+        new CodedError(
+          'ERR_IMAGE_MANIPULATOR_LOAD',
+          'Failed to load the image. Make sure the source URI is accessible and has not been revoked or released.'
+        )
+      );
+    };
     imageSource.src = uri;
   });
 }

--- a/packages/expo-image-manipulator/src/web/utils.web.ts
+++ b/packages/expo-image-manipulator/src/web/utils.web.ts
@@ -21,6 +21,11 @@ export async function blobToBase64String(blob: Blob): Promise<string> {
   return dataURL.replace(/^data:image\/\w+;base64,/, '');
 }
 
+export function releaseCanvas(canvas: HTMLCanvasElement): void {
+  canvas.width = 0;
+  canvas.height = 0;
+}
+
 export function loadImageAsync(
   uri: string,
   options?: ImageLoadOptions


### PR DESCRIPTION
# Why

The web ImageManipulator classes inherited the no-op `SharedObject.release()`, leaving internal blob URLs and canvas backing stores alive until page unload or nondeterministic garbage collection.

# How

- Override context release to clear current, reset, failed, and superseded transform canvases.
- Override image ref release to revoke its internal blob URL and clear its canvas.
- Make release idempotent and reject use after release, matching native behavior.
- Keep render fallbacks independent from released context canvases.
- Add regression coverage and a package changelog entry.

# Test Plan

1. In a web app, repeatedly manipulate a large image, save the result, and release the context and image ref.
2. Confirm the rendered result remains valid while intermediate blob URLs and canvas backing stores do not accumulate in browser memory.
3. Confirm using the released context or image ref reports that the shared object was already released.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)