### PR TITLE
[app-metrics] Fall back to a no-op module when the native module is unavailable

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -22,7 +22,7 @@
 - [iOS] Retry the OTA `AppInfo` patch on updates state changes, so a launch where the module registry is created before `expo-updates` has assigned its startup procedure no longer keeps the embedded build's update attribution for the whole session. ([#48899](https://github.com/expo/expo/pull/48899) by [@spsaucier](https://github.com/spsaucier))
 - [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class and protocol checks for the delegate it wraps. ([#48360](https://github.com/expo/expo/pull/48360) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Explicitly enable `buildFeatures.buildConfig`, required by AGP 9. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Fall back to a no-op module when the native module is unavailable, such as in Expo Go, instead of throwing on import.
+- Fall back to a no-op module when the native module is unavailable, such as in Expo Go, instead of throwing on import. ([#49841](https://github.com/expo/expo/pull/49841) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [iOS] Retry the OTA `AppInfo` patch on updates state changes, so a launch where the module registry is created before `expo-updates` has assigned its startup procedure no longer keeps the embedded build's update attribution for the whole session. ([#48899](https://github.com/expo/expo/pull/48899) by [@spsaucier](https://github.com/spsaucier))
 - [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class and protocol checks for the delegate it wraps. ([#48360](https://github.com/expo/expo/pull/48360) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Explicitly enable `buildFeatures.buildConfig`, required by AGP 9. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fall back to a no-op module when the native module is unavailable, such as in Expo Go, instead of throwing on import.
 
 ### 💡 Others
 

--- a/packages/expo-app-metrics/src/ExpoAppMetricsShim.ts
+++ b/packages/expo-app-metrics/src/ExpoAppMetricsShim.ts
@@ -1,0 +1,63 @@
+import { EventEmitter, NativeModule } from 'expo';
+
+import type { Session } from './Session';
+import type { ExpoAppMetricsModuleType, NetworkRequestObserverEvents, SessionType } from './types';
+
+class NoopNetworkRequestObserver extends EventEmitter<NetworkRequestObserverEvents> {
+  setFilter(): void {}
+  release(): void {}
+}
+
+class NoopSession extends EventEmitter {
+  readonly id = 'noop-session';
+  readonly startDate = new Date().toISOString();
+
+  constructor(readonly type: SessionType) {
+    super();
+  }
+
+  async isActive(): Promise<boolean> {
+    return true;
+  }
+  async getEndDate(): Promise<string | null> {
+    return null;
+  }
+  async getMetrics() {
+    return [];
+  }
+  async getLogs() {
+    return [];
+  }
+  async addMetric(): Promise<void> {}
+  release(): void {}
+}
+
+/**
+ * The module's shape with nothing behind it. Web has no native implementation, and hosts such as
+ * Expo Go leave the package out, so both stand this in for the native module: metric and log calls
+ * are no-ops, session queries resolve to empty results, and the observer never emits.
+ */
+export class ExpoAppMetricsShim extends NativeModule implements ExpoAppMetricsModuleType {
+  NetworkRequestObserver =
+    NoopNetworkRequestObserver as unknown as ExpoAppMetricsModuleType['NetworkRequestObserver'];
+  Session = NoopSession as unknown as typeof Session;
+
+  private mainSession: Session | null = null;
+
+  markFirstRender() {}
+  markInteractive() {}
+  logEvent() {}
+  setGlobalAttributes() {}
+  async clearStoredEntries() {}
+  async getInactiveSessions() {
+    return [];
+  }
+  reportError() {}
+  getMainSession(): Session {
+    this.mainSession ??= new NoopSession('main') as unknown as Session;
+    return this.mainSession;
+  }
+  async getForegroundSession() {
+    return null;
+  }
+}

--- a/packages/expo-app-metrics/src/__tests__/module.test.native.ts
+++ b/packages/expo-app-metrics/src/__tests__/module.test.native.ts
@@ -1,0 +1,110 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+export {};
+
+const mockRequireOptionalNativeModule = jest.fn();
+
+jest.mock('expo', () => {
+  class MockEventEmitter {
+    private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    addListener(name: string, listener: (...args: unknown[]) => void) {
+      const set = this.listeners.get(name) ?? new Set();
+      set.add(listener);
+      this.listeners.set(name, set);
+      return { remove: () => this.removeListener(name, listener) };
+    }
+    removeListener(name: string, listener: (...args: unknown[]) => void) {
+      this.listeners.get(name)?.delete(listener);
+    }
+    removeAllListeners(name: string) {
+      this.listeners.delete(name);
+    }
+    emit(name: string, ...args: unknown[]) {
+      this.listeners.get(name)?.forEach((listener) => listener(...args));
+    }
+    listenerCount(name: string) {
+      return this.listeners.get(name)?.size ?? 0;
+    }
+  }
+  class MockNativeModule extends MockEventEmitter {}
+  return {
+    requireOptionalNativeModule: (...args: unknown[]) => mockRequireOptionalNativeModule(...args),
+    EventEmitter: MockEventEmitter,
+    NativeModule: MockNativeModule,
+  };
+});
+
+beforeEach(() => {
+  jest.resetModules();
+  mockRequireOptionalNativeModule.mockReset();
+});
+
+function loadModule() {
+  return (require('../module') as typeof import('../module')).default;
+}
+
+describe('when the native module is available', () => {
+  it('exports it unchanged', () => {
+    const native = { markFirstRender: jest.fn() };
+    mockRequireOptionalNativeModule.mockReturnValue(native);
+
+    expect(loadModule()).toBe(native);
+    expect(mockRequireOptionalNativeModule).toHaveBeenCalledWith('ExpoAppMetrics');
+  });
+});
+
+describe('when the native module is unavailable', () => {
+  beforeEach(() => {
+    mockRequireOptionalNativeModule.mockReturnValue(null);
+  });
+
+  it('does not throw on import', () => {
+    expect(() => loadModule()).not.toThrow();
+  });
+
+  it('is a NativeModule like the real one', () => {
+    const { NativeModule } = require('expo');
+    expect(loadModule()).toBeInstanceOf(NativeModule);
+  });
+
+  it('turns metric, log, and error calls into no-ops', () => {
+    const AppMetrics = loadModule();
+
+    expect(() => {
+      AppMetrics.markFirstRender();
+      AppMetrics.markInteractive({ routeName: 'Home' });
+      AppMetrics.logEvent('checkout', { attributes: { step: 1 } });
+      AppMetrics.setGlobalAttributes({ tier: 'pro' });
+      AppMetrics.reportError({ source: 'global', message: 'boom', isFatal: false });
+    }).not.toThrow();
+  });
+
+  it('answers session queries with empty results', async () => {
+    const AppMetrics = loadModule();
+
+    await expect(AppMetrics.clearStoredEntries()).resolves.toBeUndefined();
+    await expect(AppMetrics.getInactiveSessions()).resolves.toEqual([]);
+    await expect(AppMetrics.getForegroundSession()).resolves.toBeNull();
+
+    const session = AppMetrics.getMainSession();
+    expect(session.type).toBe('main');
+    expect(AppMetrics.getMainSession()).toBe(session);
+    await expect(session.isActive()).resolves.toBe(true);
+    await expect(session.getEndDate()).resolves.toBeNull();
+    await expect(session.getMetrics()).resolves.toEqual([]);
+    await expect(session.getLogs()).resolves.toEqual([]);
+    await expect(session.addMetric({ name: 'x', value: 1 } as any)).resolves.toBeUndefined();
+  });
+
+  it('provides a network request observer that never emits', () => {
+    const AppMetrics = loadModule();
+    const observer = new AppMetrics.NetworkRequestObserver({ hosts: ['example.com'] });
+    const listener = jest.fn();
+
+    const subscription = observer.addListener('requestStarted', listener);
+    expect(() => observer.setFilter(null)).not.toThrow();
+    expect(() => observer.release()).not.toThrow();
+    subscription.remove();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/expo-app-metrics/src/module.ts
+++ b/packages/expo-app-metrics/src/module.ts
@@ -1,5 +1,9 @@
-import { requireNativeModule } from 'expo';
+import { requireOptionalNativeModule } from 'expo';
 
+import { ExpoAppMetricsShim } from './ExpoAppMetricsShim';
 import type { ExpoAppMetricsModuleType } from './types';
 
-export default requireNativeModule<ExpoAppMetricsModuleType>('ExpoAppMetrics');
+// Hosts that leave expo-app-metrics out, such as Expo Go, have no native module. Fall back to the
+// shim so importing the package never throws.
+export default requireOptionalNativeModule<ExpoAppMetricsModuleType>('ExpoAppMetrics') ??
+  new ExpoAppMetricsShim();

--- a/packages/expo-app-metrics/src/module.web.ts
+++ b/packages/expo-app-metrics/src/module.web.ts
@@ -1,71 +1,7 @@
-import { NativeModule, registerWebModule, SharedObject } from 'expo';
+import { registerWebModule } from 'expo';
 
-import type { Session } from './Session';
-import type {
-  ExpoAppMetricsModuleType,
-  LogAttributeValue,
-  LogEventOptions,
-  LogRecord,
-  Metric,
-  MetricAttributes,
-  NetworkRequestObserverEvents,
-  MetricInput,
-  SessionType,
-} from './types';
+import { ExpoAppMetricsShim } from './ExpoAppMetricsShim';
 
 export * from './types';
 
-class NetworkRequestObserverWeb extends SharedObject<NetworkRequestObserverEvents> {
-  // Web has no native interceptor, so this never emits. Kept as a no-op so cross-platform code
-  // can construct it without guarding on Platform.OS.
-}
-
-class WebSession extends globalThis.expo.SharedObject {
-  readonly id = 'web-session';
-  readonly startDate = new Date().toISOString();
-
-  constructor(readonly type: SessionType = 'main') {
-    super();
-  }
-
-  async isActive(): Promise<boolean> {
-    return true;
-  }
-  async getEndDate(): Promise<string | null> {
-    return null;
-  }
-  async getMetrics(): Promise<Metric[]> {
-    return [];
-  }
-  async getLogs(): Promise<LogRecord[]> {
-    return [];
-  }
-  async addMetric(_metric: MetricInput): Promise<void> {}
-}
-
-class ExpoAppMetricsModule extends NativeModule implements ExpoAppMetricsModuleType {
-  NetworkRequestObserver =
-    NetworkRequestObserverWeb as unknown as ExpoAppMetricsModuleType['NetworkRequestObserver'];
-  Session = WebSession as unknown as typeof Session;
-
-  private mainSession: WebSession | null = null;
-
-  async markFirstRender() {}
-  async markInteractive(attributes?: MetricAttributes) {}
-  logEvent(name: string, options?: LogEventOptions) {}
-  setGlobalAttributes(attributes?: Record<string, LogAttributeValue> | null) {}
-  async clearStoredEntries() {}
-  async getInactiveSessions() {
-    return [];
-  }
-  reportError() {}
-  getMainSession(): Session {
-    this.mainSession ??= new WebSession('main');
-    return this.mainSession as unknown as Session;
-  }
-  async getForegroundSession() {
-    return null;
-  }
-}
-
-export default registerWebModule(ExpoAppMetricsModule, 'ExpoAppMetrics');
+export default registerWebModule(ExpoAppMetricsShim, 'ExpoAppMetrics');


### PR DESCRIPTION
# Why
Expo Go excludes `expo-app-metrics` but the package resolves its native module with `requireNativeModule`, which throws when the module is missing. Because of this I can't run NCL in Expo Go.

# How
Resolve the module with `requireOptionalNativeModule` and substitute an implementation.

# Test Plan
Expo go

