### PR TITLE
[router] remove navigation ready state

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Remove the `onReady` container prop and the `ready` container event. ([#49845](https://github.com/expo/expo/pull/49845) by [@Ubax](https://github.com/Ubax))
 - Remove `UNSTABLE_UnhandledLinkingContext` from `expo-router/react-navigation`. ([#49616](https://github.com/expo/expo/pull/49616) by [@Ubax](https://github.com/Ubax))
 - Remove `BaseNavigationContainer` export from `expo-router/react-navigation`. ([#49587](https://github.com/expo/expo/pull/49587) by [@Ubax](https://github.com/Ubax))
 - Dispatch queued navigation actions in React transitions. The current screen stays visible while the destination suspends, so `SuspenseFallback` no longer renders for navigation-triggered suspense. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type PropsWithChildren, Fragment, type ComponentType, useMemo } from 'react';
+import { type PropsWithChildren, Fragment, type ComponentType, useEffect, useMemo } from 'react';
 import { Platform } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -91,11 +91,6 @@ const initialUrl =
     ? new URL(window.location.href)
     : undefined;
 
-function onNavigationReady() {
-  maybeHideSplashScreen();
-}
-
-// TODO(@ubax): Refactor onReady logic and use listeners pattern
 function ContextNavigator({
   context,
   location: initialLocation = initialUrl,
@@ -145,8 +140,7 @@ function ContextNavigator({
         <RemovalPreventionProvider>
           <UpstreamNavigationContainer
             ref={navigationRef}
-            linking={linkingConfig as LinkingOptions<any>}
-            onReady={onNavigationReady}>
+            linking={linkingConfig as LinkingOptions<any>}>
             <WrapperComponent>
               <Content rootComponent={rootComponent} />
             </WrapperComponent>
@@ -169,6 +163,10 @@ function Content({ rootComponent }: { rootComponent: ComponentType<any> }) {
     children,
     id: INTERNAL_SLOT_NAME,
   });
+
+  useEffect(() => {
+    maybeHideSplashScreen();
+  }, []);
 
   return (
     <NavigationContent>{descriptors[state.routes[state.index]!.key]!.render()}</NavigationContent>

--- a/packages/expo-router/src/__tests__/ExpoRoot.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/ExpoRoot.test.ios.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react-native';
+import type { PropsWithChildren } from 'react';
+import { Text } from 'react-native';
+
+import { ExpoRoot } from '../ExpoRoot';
+import { getMockContext } from '../testing-library';
+import { maybeHideSplashScreen } from '../utils/splash';
+
+jest.mock('../utils/splash', () => ({
+  maybeHideSplashScreen: jest.fn(),
+}));
+
+const mockMaybeHideSplashScreen = maybeHideSplashScreen as jest.MockedFunction<
+  typeof maybeHideSplashScreen
+>;
+
+it('waits for the root navigator to commit before hiding the splash screen', () => {
+  let renderChildren = false;
+
+  function Wrapper({ children }: PropsWithChildren) {
+    return renderChildren ? children : null;
+  }
+
+  const context = getMockContext({
+    _layout: () => <Text>Layout</Text>,
+    index: () => <Text>Index</Text>,
+  });
+  const result = render(<ExpoRoot context={context} location="/" wrapper={Wrapper} />);
+
+  expect(mockMaybeHideSplashScreen).not.toHaveBeenCalled();
+
+  renderChildren = true;
+  result.rerender(<ExpoRoot context={context} location="/" wrapper={Wrapper} />);
+
+  expect(mockMaybeHideSplashScreen).toHaveBeenCalledTimes(1);
+});

--- a/packages/expo-router/src/fork/NavigationContainer.tsx
+++ b/packages/expo-router/src/fork/NavigationContainer.tsx
@@ -43,7 +43,6 @@ type Props<ParamList extends object> = Omit<NavigationContainerProps, 'initialSt
  * Container component which holds the navigation state designed for React Native apps.
  * This should be rendered at the root wrapping the whole app.
  *
- * @param props.onReady Callback which is called after the navigation tree mounts.
  * @param props.onUnhandledAction Callback which is called when an action is not handled. TODO(@ubax): restore this callback. https://linear.app/expo/issue/ENG-26123
  * @param props.direction Text direction of the components. Defaults to `'ltr'`.
  * @param props.theme Theme object for the UI elements.

--- a/packages/expo-router/src/global-state/RoutingQueueDrainer.tsx
+++ b/packages/expo-router/src/global-state/RoutingQueueDrainer.tsx
@@ -6,17 +6,16 @@ import type { RoutingIntent } from './routingQueue';
 import { PendingIntentsContext, RoutingQueueApiContext } from './routingQueueContext';
 
 type Props = {
-  ready: boolean;
   processIntent: (intent: RoutingIntent) => void;
 };
 
-export function RoutingQueueDrainer({ ready, processIntent }: Props) {
+export function RoutingQueueDrainer({ processIntent }: Props) {
   const intents = React.use(PendingIntentsContext);
   const { dequeue, startTransition } = React.use(RoutingQueueApiContext)!;
   const lastProcessed = React.useRef<RoutingIntent[] | undefined>(undefined);
 
   React.useEffect(() => {
-    if (!ready || intents.length === 0 || lastProcessed.current === intents) {
+    if (intents.length === 0 || lastProcessed.current === intents) {
       return;
     }
     // Strict Mode re-runs the mount effect with the same array before `dequeue` updates state.
@@ -47,7 +46,7 @@ export function RoutingQueueDrainer({ ready, processIntent }: Props) {
         }
       }
     });
-  }, [dequeue, intents, processIntent, ready, startTransition]);
+  }, [dequeue, intents, processIntent, startTransition]);
 
   return null;
 }

--- a/packages/expo-router/src/global-state/__tests__/RoutingQueueDrainer.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/RoutingQueueDrainer.test.ios.tsx
@@ -16,7 +16,7 @@ function actionType(intent: RoutingIntent): string {
   return intent.payload.action.type;
 }
 
-function renderDrainer(ready: boolean, processIntent: (intent: RoutingIntent) => void) {
+function renderDrainer(processIntent: (intent: RoutingIntent) => void) {
   let enqueue: ReturnType<typeof useEnqueueRoutingIntent>;
 
   function CaptureEnqueue() {
@@ -27,7 +27,7 @@ function renderDrainer(ready: boolean, processIntent: (intent: RoutingIntent) =>
   const result = render(
     <RoutingQueueProvider>
       <CaptureEnqueue />
-      <RoutingQueueDrainer ready={ready} processIntent={processIntent} />
+      <RoutingQueueDrainer processIntent={processIntent} />
     </RoutingQueueProvider>
   );
 
@@ -41,7 +41,7 @@ it('isolates queue notifications from its parent', () => {
 
   function Consumer() {
     enqueue = useEnqueueRoutingIntent();
-    return <RoutingQueueDrainer ready processIntent={processIntent} />;
+    return <RoutingQueueDrainer processIntent={processIntent} />;
   }
 
   function Parent() {
@@ -60,37 +60,11 @@ it('isolates queue notifications from its parent', () => {
   expect(processIntent).toHaveBeenCalledWith(actionIntent('TEST'));
 });
 
-it('keeps intents queued until ready', () => {
-  const processIntent = jest.fn();
-  let enqueue: ReturnType<typeof useEnqueueRoutingIntent>;
-
-  function Tree({ ready }: { ready: boolean }) {
-    enqueue = useEnqueueRoutingIntent();
-    return <RoutingQueueDrainer ready={ready} processIntent={processIntent} />;
-  }
-
-  const result = render(
-    <RoutingQueueProvider>
-      <Tree ready={false} />
-    </RoutingQueueProvider>
-  );
-  act(() => enqueue(actionIntent('TEST')));
-  expect(processIntent).not.toHaveBeenCalled();
-
-  result.rerender(
-    <RoutingQueueProvider>
-      <Tree ready />
-    </RoutingQueueProvider>
-  );
-
-  expect(processIntent).toHaveBeenCalledWith(actionIntent('TEST'));
-});
-
 it('processes a queued batch in FIFO order', () => {
   const calls: string[] = [];
   const processIntent = jest.fn((intent: RoutingIntent) => calls.push(actionType(intent)));
   const onDispatch = jest.fn(() => calls.push('onDispatch'));
-  const result = renderDrainer(true, processIntent);
+  const result = renderDrainer(processIntent);
 
   act(() => {
     result.enqueue(actionIntent('FIRST'));
@@ -122,7 +96,7 @@ it('does not process a batch twice in Strict Mode', () => {
     <React.StrictMode>
       <RoutingQueueProvider>
         <CaptureEnqueue />
-        <RoutingQueueDrainer ready processIntent={processIntent} />
+        <RoutingQueueDrainer processIntent={processIntent} />
       </RoutingQueueProvider>
     </React.StrictMode>
   );
@@ -139,23 +113,12 @@ it('processes intents added while draining in a later batch', () => {
       enqueue(actionIntent('SECOND'));
     }
   });
-  const result = renderDrainer(true, processIntent);
+  const result = renderDrainer(processIntent);
   enqueue = result.enqueue;
 
   act(() => enqueue(actionIntent('FIRST')));
 
   expect(processed).toEqual(['FIRST', 'SECOND']);
-});
-
-it('drops pending intents when the provider unmounts', () => {
-  const processIntent = jest.fn();
-  const first = renderDrainer(false, processIntent);
-  act(() => first.enqueue(actionIntent('TEST')));
-
-  first.unmount();
-  renderDrainer(true, processIntent);
-
-  expect(processIntent).not.toHaveBeenCalled();
 });
 
 it('continues after processIntent throws synchronously', () => {
@@ -165,7 +128,7 @@ it('continues after processIntent throws synchronously', () => {
       throw new Error('failed');
     }
   });
-  const result = renderDrainer(true, processIntent);
+  const result = renderDrainer(processIntent);
 
   act(() => {
     result.enqueue(actionIntent('FIRST'));

--- a/packages/expo-router/src/global-state/__tests__/router.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/router.test.ios.ts
@@ -22,7 +22,6 @@ import {
 
 jest.mock('../navigationRef', () => ({
   navigationRef: {
-    isReady: jest.fn(() => true),
     getRootState: jest.fn(),
     current: {
       canGoBack: jest.fn(),
@@ -58,9 +57,10 @@ const mockAdd = jest.fn();
 const mockEmitDomDismiss = emitDomDismiss as jest.Mock;
 const mockEmitDomDismissAll = emitDomDismissAll as jest.Mock;
 const mockEmitDomGoBack = emitDomGoBack as jest.Mock;
+const mountedNavigation = navigationRef.current;
 beforeEach(() => {
   jest.clearAllMocks();
-  (navigationRef.isReady as jest.Mock).mockReturnValue(true);
+  navigationRef.current = mountedNavigation;
   (navigationRef.getRootState as jest.Mock).mockReturnValue(undefined);
 });
 
@@ -71,8 +71,12 @@ it('throws before the module-level router is installed', () => {
 });
 
 describe('canDismiss', () => {
+  it('returns false when the container is not mounted', () => {
+    navigationRef.current = null;
+    expect(canDismiss()).toBe(false);
+  });
+
   it('returns false when state is undefined', () => {
-    (navigationRef.isReady as jest.Mock).mockReturnValue(false);
     expect(canDismiss()).toBe(false);
   });
 
@@ -329,10 +333,10 @@ describe('router action functions', () => {
     });
   });
 
-  it('goBack enqueues GO_BACK without requiring the container to be ready', () => {
+  it('goBack enqueues GO_BACK without requiring a mounted container', () => {
+    navigationRef.current = null;
     goBack();
 
-    expect(navigationRef.isReady).not.toHaveBeenCalled();
     expect(mockAdd).toHaveBeenCalledWith({
       type: 'ACTION',
       payload: { action: { type: 'GO_BACK' } },
@@ -343,9 +347,8 @@ describe('router action functions', () => {
     expect(() => reload()).toThrow('not implemented');
   });
 
-  it('canGoBack returns false when navigation not ready', () => {
-    (navigationRef.isReady as jest.Mock).mockReturnValueOnce(false);
-
+  it('canGoBack returns false when the container is not mounted', () => {
+    navigationRef.current = null;
     expect(canGoBack()).toBe(false);
   });
 
@@ -356,11 +359,16 @@ describe('router action functions', () => {
     expect(navigationRef.current!.canGoBack).toHaveBeenCalled();
   });
 
-  it('setParams checks navigation readiness', () => {
+  it('setParams forwards when the container is mounted', () => {
     setParams({ name: 'test' });
 
-    expect(navigationRef.isReady).toHaveBeenCalled();
     expect(navigationRef.current!.setParams).toHaveBeenCalledWith({ name: 'test' });
+  });
+
+  it('setParams throws when the container is not mounted', () => {
+    navigationRef.current = null;
+
+    expect(() => setParams({ name: 'test' })).toThrow('before mounting the Root Layout');
   });
 });
 
@@ -390,6 +398,5 @@ describe('DOM short-circuit paths', () => {
 
     expect(mockEmitDomGoBack).toHaveBeenCalled();
     expect(mockAdd).not.toHaveBeenCalled();
-    expect(navigationRef.isReady).not.toHaveBeenCalled();
   });
 });

--- a/packages/expo-router/src/global-state/__tests__/routingQueueContext.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/routingQueueContext.test.ios.tsx
@@ -4,6 +4,7 @@ import { use, type ContextType } from 'react';
 import { router } from '../router';
 import type { RoutingIntent } from '../routingQueue';
 import {
+  ImperativeRoutingQueueBridge,
   NavigationPendingContext,
   PendingIntentsContext,
   RoutingQueueApiContext,
@@ -15,7 +16,18 @@ function actionIntent(type: string): RoutingIntent {
   return { type: 'ACTION', payload: { action: { type } } };
 }
 
-it('installs the module-level router after the provider commits', () => {
+function RouterBridge() {
+  const api = use(RoutingQueueApiContext)!;
+  return <ImperativeRoutingQueueBridge enqueue={api.enqueue} />;
+}
+
+it('does not install the module-level router from the provider', () => {
+  render(<RoutingQueueProvider />);
+
+  expect(() => router.push('/test')).toThrow('first render');
+});
+
+it('installs the module-level router after the bridge commits', () => {
   let pending: RoutingIntent[] = [];
 
   function Consumer() {
@@ -28,6 +40,7 @@ it('installs the module-level router after the provider commits', () => {
   render(
     <RoutingQueueProvider>
       <Consumer />
+      <RouterBridge />
     </RoutingQueueProvider>
   );
   act(() => router.push('/test'));
@@ -41,7 +54,11 @@ it('installs the module-level router after the provider commits', () => {
 });
 
 it('restores the throwing router after the provider unmounts', () => {
-  const { unmount } = render(<RoutingQueueProvider />);
+  const { unmount } = render(
+    <RoutingQueueProvider>
+      <RouterBridge />
+    </RoutingQueueProvider>
+  );
 
   expect(() => act(() => router.push('/test'))).not.toThrow();
   unmount();
@@ -52,8 +69,16 @@ it('restores the throwing router after the provider unmounts', () => {
 it('warns when a second root binds the imperative router', () => {
   const error = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-  const firstRoot = render(<RoutingQueueProvider />);
-  const secondRoot = render(<RoutingQueueProvider />);
+  const firstRoot = render(
+    <RoutingQueueProvider>
+      <RouterBridge />
+    </RoutingQueueProvider>
+  );
+  const secondRoot = render(
+    <RoutingQueueProvider>
+      <RouterBridge />
+    </RoutingQueueProvider>
+  );
 
   expect(error).toHaveBeenCalledTimes(1);
   expect(error).toHaveBeenCalledWith(expect.stringContaining('multiple'));

--- a/packages/expo-router/src/global-state/router.ts
+++ b/packages/expo-router/src/global-state/router.ts
@@ -17,9 +17,8 @@ import { navigationRef } from './navigationRef';
 import type { RoutingIntent } from './routingQueue';
 import type { LinkToOptions, NavigationOptions } from './types';
 
-function assertIsReady() {
-  // TODO(@ubax): check whether this is still needed
-  if (!navigationRef.isReady()) {
+function assertIsMounted() {
+  if (navigationRef.current == null) {
     throw new Error(
       'Attempted to navigate before mounting the Root Layout component. Ensure the Root Layout component is rendering a Slot, or other navigator on the first render.'
     );
@@ -109,11 +108,10 @@ export function canGoBack(): boolean {
   // before mounting a navigator. This behavior exists due to React Navigation being dynamically
   // constructed at runtime. We can get rid of this in the future if we use
   // the static configuration internally.
-  // TODO(@ubax): check whether this is still needed
-  if (!navigationRef.isReady()) {
+  if (navigationRef.current == null) {
     return false;
   }
-  return navigationRef.current?.canGoBack() ?? false;
+  return navigationRef.current.canGoBack();
 }
 
 export function canDismiss(): boolean {
@@ -122,8 +120,7 @@ export function canDismiss(): boolean {
       'canDismiss imperative method is not supported. Pass the property to the DOM component instead.'
     );
   }
-  // TODO(@ubax): check whether this is still needed
-  if (!navigationRef.isReady()) {
+  if (navigationRef.current == null) {
     return false;
   }
   // TODO(@ubax): check whether this is still needed
@@ -150,8 +147,8 @@ export function setParams(
   if (emitDomSetParams(params)) {
     return;
   }
-  assertIsReady();
-  return (navigationRef.current?.setParams as any)(params);
+  assertIsMounted();
+  return (navigationRef.current!.setParams as any)(params);
 }
 
 function linkToImpl(

--- a/packages/expo-router/src/global-state/routingQueueContext.tsx
+++ b/packages/expo-router/src/global-state/routingQueueContext.tsx
@@ -49,10 +49,7 @@ export function RoutingQueueProvider({ children }: PropsWithChildren) {
   return (
     <RoutingQueueApiContext.Provider value={api}>
       <NavigationPendingContext.Provider value={isPending || queue.length > 0}>
-        <PendingIntentsContext.Provider value={queue}>
-          {children}
-          <ImperativeRoutingQueueBridge enqueue={api.enqueue} />
-        </PendingIntentsContext.Provider>
+        <PendingIntentsContext.Provider value={queue}>{children}</PendingIntentsContext.Provider>
       </NavigationPendingContext.Provider>
     </RoutingQueueApiContext.Provider>
   );
@@ -66,7 +63,7 @@ export function useEnqueueRoutingIntent() {
   return api.enqueue;
 }
 
-function ImperativeRoutingQueueBridge({ enqueue }: Pick<RoutingQueueApi, 'enqueue'>) {
+export function ImperativeRoutingQueueBridge({ enqueue }: Pick<RoutingQueueApi, 'enqueue'>) {
   useClientLayoutEffect(() => {
     if (__DEV__ && boundBridges > 0) {
       console.error(

--- a/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
@@ -13,7 +13,10 @@ import { GlobalRoutesWithRemovalPreventedContext } from '../../global-state/remo
 import { RouteInfoContext } from '../../global-state/routeInfoContext';
 import { RouterConfigContext } from '../../global-state/routerConfigContext';
 import { RouterRegistryContext } from '../../global-state/routerRegistry';
-import { RoutingQueueApiContext } from '../../global-state/routingQueueContext';
+import {
+  ImperativeRoutingQueueBridge,
+  RoutingQueueApiContext,
+} from '../../global-state/routingQueueContext';
 import { useNavigationTreeReducer } from '../../global-state/useNavigationTreeReducer';
 import { useNavigationTreeReportEvents } from '../../global-state/useNavigationTreeReportEvents';
 import useLatestCallback from '../../utils/useLatestCallback';
@@ -57,14 +60,13 @@ const duplicateNameWarnings: string[] = [];
  * This should be rendered at the root wrapping the whole app.
  *
  * @param props.initialState Initial state object for the navigation tree.
- * @param props.onReady Callback which is called after the navigation tree mounts.
  * @param props.onUnhandledAction Callback which is called when an action is not handled. TODO(@ubax): restore this callback. https://linear.app/expo/issue/ENG-26123
  * @param props.theme Theme object for the UI elements.
  * @param props.children Child elements to render the content.
  * @param props.ref Ref object which refers to the navigation object containing helper methods.
  */
 export function BaseNavigationContainer(props: InternalNavigationContainerProps) {
-  const { ref, initialState, onReady, UNSTABLE_routeNode, theme, children } = props;
+  const { ref, initialState, UNSTABLE_routeNode, theme, children } = props;
   const parent = use(NavigationStateContext);
   const inheritedRouteInfo = use(RouteInfoContext);
   const routerConfig = use(RouterConfigContext);
@@ -147,9 +149,6 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
     return route as Route<string> | undefined;
   });
 
-  // TODO(@ubax): check if this is still needed anywhere
-  const isReady = useLatestCallback(() => listeners.focus[0] != null && registry.has(state.key));
-
   const { addOptionsGetter, getCurrentOptions } = useOptionsGetters({});
 
   const navigation: NavigationContainerRef<ParamListBase> = React.useMemo(
@@ -170,21 +169,13 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
       getRootState,
       getCurrentRoute,
       getCurrentOptions,
-      isReady,
+      // Kept for compatibility. There is no ready state to report.
+      isReady: () => true,
       setOptions: () => {
         throw new Error('Cannot call setOptions outside a screen');
       },
     }),
-    [
-      canGoBack,
-      dispatch,
-      dispatchSync,
-      emitter,
-      getCurrentOptions,
-      getCurrentRoute,
-      getRootState,
-      isReady,
-    ]
+    [canGoBack, dispatch, dispatchSync, emitter, getCurrentOptions, getCurrentRoute, getRootState]
   );
 
   React.useImperativeHandle(ref, () => navigation, [navigation]);
@@ -215,17 +206,6 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
   if (!areUrlObjectsEqual(routeInfo, nextRouteInfo)) {
     setRouteInfo(nextRouteInfo);
   }
-
-  const onReadyCalledRef = React.useRef(false);
-  const notifyReady = React.useEffectEvent(() => onReady?.());
-
-  React.useEffect(() => {
-    if (!onReadyCalledRef.current && isReady()) {
-      onReadyCalledRef.current = true;
-      notifyReady();
-      emitter.emit({ type: 'ready' });
-    }
-  }, [state, registry, isReady, emitter]);
 
   React.useEffect(() => {
     const hydratedState = getRootState();
@@ -306,7 +286,8 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
               <EnsureSingleNavigator>
                 <ThemeProvider value={theme}>{children}</ThemeProvider>
               </EnsureSingleNavigator>
-              <RoutingQueueDrainer ready={registry.has(state.key)} processIntent={processIntent} />
+              <ImperativeRoutingQueueBridge enqueue={routingQueue.enqueue} />
+              <RoutingQueueDrainer processIntent={processIntent} />
             </RootNavigationStateContext.Provider>
           </RouteInfoContext.Provider>
         </NavigationStateContext.Provider>

--- a/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
@@ -444,77 +444,6 @@ test('handles getRootState', () => {
   });
 });
 
-test('emits ready event when the container is ready with synchronous content', () => {
-  const TestNavigator = (props: any) => {
-    const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
-    return (
-      <NavigationContent>
-        {state.routes.map((route) => descriptors[route.key]!.render())}
-      </NavigationContent>
-    );
-  };
-
-  const ref = createNavigationContainerRef<ParamListBase>();
-
-  const listener = jest.fn();
-
-  ref.addListener('ready', () => {
-    listener(ref.isReady(), ref.getCurrentRoute()?.name);
-  });
-
-  expect(listener).not.toHaveBeenCalled();
-
-  render(
-    <BaseNavigationContainer ref={ref}>
-      <TestNavigator>
-        <Screen name="foo">{() => null}</Screen>
-      </TestNavigator>
-    </BaseNavigationContainer>
-  );
-
-  expect(listener).toHaveBeenCalledTimes(1);
-  expect(listener).toHaveBeenCalledWith(true, 'foo');
-});
-
-// TODO(@ubax): restore when actions dispatched before registration are deferred.
-// https://linear.app/expo/issue/ENG-26123/fix-event-emission-from-global-store
-test.skip('emits ready event when the container is ready with asynchronous content', async () => {
-  const TestNavigator = (props: any) => {
-    const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
-    return (
-      <NavigationContent>
-        {state.routes.map((route) => descriptors[route.key]!.render())}
-      </NavigationContent>
-    );
-  };
-
-  const ref = createNavigationContainerRef<ParamListBase>();
-
-  const listener = jest.fn();
-
-  ref.addListener('ready', () => {
-    listener(ref.isReady(), ref.getCurrentRoute()?.name);
-  });
-
-  const wrapper = render(<BaseNavigationContainer ref={ref}>{null}</BaseNavigationContainer>);
-
-  expect(listener).not.toHaveBeenCalled();
-
-  await Promise.resolve();
-
-  wrapper.update(
-    <BaseNavigationContainer ref={ref}>
-      <TestNavigator>
-        <Screen name="foo">{() => null}</Screen>
-        <Screen name="bar">{() => null}</Screen>
-      </TestNavigator>
-    </BaseNavigationContainer>
-  );
-
-  expect(listener).toHaveBeenCalledTimes(1);
-  expect(listener).toHaveBeenCalledWith(true, 'foo');
-});
-
 test('emits state events when the state changes', () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
@@ -790,7 +719,7 @@ test("throws if the ref hasn't finished initializing", () => {
   render(element);
 });
 
-test('fires onReady after navigator is rendered', () => {
+test('isReady always returns true', () => {
   const ref = createNavigationContainerRef<ParamListBase>();
 
   const TestNavigator = (props: any) => {
@@ -801,52 +730,25 @@ test('fires onReady after navigator is rendered', () => {
     );
   };
 
-  const initialOnReady = jest.fn();
-  const latestOnReady = jest.fn();
-  const changedAfterReady = jest.fn();
-
   const element = (
-    <BaseNavigationContainer
-      ref={ref}
-      onReady={initialOnReady}
-      initialState={{ routes: [{ name: 'foo' }] }}>
+    <BaseNavigationContainer ref={ref} initialState={{ routes: [{ name: 'foo' }] }}>
       {null}
     </BaseNavigationContainer>
   );
 
   const root = render(element);
 
-  expect(initialOnReady).not.toHaveBeenCalled();
-  expect(ref.current?.isReady()).toBe(false);
-
-  root.rerender(
-    <BaseNavigationContainer
-      ref={ref}
-      onReady={latestOnReady}
-      initialState={{ routes: [{ name: 'foo' }] }}>
-      <TestNavigator>
-        <Screen name="foo">{() => null}</Screen>
-      </TestNavigator>
-    </BaseNavigationContainer>
-  );
-
-  expect(initialOnReady).not.toHaveBeenCalled();
-  expect(latestOnReady).toHaveBeenCalledTimes(1);
   expect(ref.current?.isReady()).toBe(true);
 
   root.rerender(
-    <BaseNavigationContainer
-      ref={ref}
-      onReady={changedAfterReady}
-      initialState={{ routes: [{ name: 'foo' }] }}>
+    <BaseNavigationContainer ref={ref} initialState={{ routes: [{ name: 'foo' }] }}>
       <TestNavigator>
         <Screen name="foo">{() => null}</Screen>
       </TestNavigator>
     </BaseNavigationContainer>
   );
 
-  expect(latestOnReady).toHaveBeenCalledTimes(1);
-  expect(changedAfterReady).not.toHaveBeenCalled();
+  expect(ref.current?.isReady()).toBe(true);
 });
 
 // TODO(@ubax): restore when unhandled actions are wired to the reducer. https://linear.app/expo/issue/ENG-26123

--- a/packages/expo-router/src/react-navigation/core/__tests__/createNavigationContainerRef.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/createNavigationContainerRef.test.ios.tsx
@@ -11,6 +11,12 @@ beforeEach(() => {
   MockRouterKey.current = 0;
 });
 
+test('isReady returns false before the container mounts', () => {
+  const ref = createNavigationContainerRef<ParamListBase>();
+
+  expect(ref.isReady()).toBe(false);
+});
+
 test('adds the listener even if container is mounted later', () => {
   const ref = createNavigationContainerRef<ParamListBase>();
   const listener = jest.fn();

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -400,10 +400,6 @@ export type NavigationContainerProps = {
    */
   initialState?: InitialState;
   /**
-   * Callback which is called after the navigation tree mounts.
-   */
-  onReady?: () => void;
-  /**
    * Callback which is called when an action is not handled.
    * TODO(@ubax): restore this callback. https://linear.app/expo/issue/ENG-26123
    */
@@ -730,12 +726,6 @@ export type RouteGroupConfig<
 };
 
 export type NavigationContainerEventMap = {
-  /**
-   * Event that fires when the navigation container is ready to be used.
-   */
-  ready: {
-    data: undefined;
-  };
   /**
    * Event that fires when the navigation state changes.
    */


### PR DESCRIPTION
# Why

Setting navigation `ready` state in effect caused unnecessary render

# How

1. Remove `ready` event and `onReady` prop from `NavigationContainer`
2. Changed the `navigationRef.isReady` to be always true after first container render

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

## Accepted breaking changes

- Remove the `onReady` container prop and `ready` container event.
- Deprecate `NavigationContainerRef.isReady()` and make it always return `true`.