### PR TITLE
[router] resolve routing with render-time state

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -93,6 +93,7 @@
 
 ### 💡 Others
 
+- Resolve queued navigation actions against render-time state. ([#49846](https://github.com/expo/expo/pull/49846) by [@Ubax](https://github.com/Ubax))
 - Replace latest-value refs with `useLatestCallback` and `useEffectEvent`. ([#49643](https://github.com/expo/expo/pull/49643) by [@Ubax](https://github.com/Ubax))
 - Remove the root `options` event, `DocumentTitleOptions`, and the `documentTitle` prop from `expo-router/react-navigation`. ([#49590](https://github.com/expo/expo/pull/49590) by [@Ubax](https://github.com/Ubax))
 - Remove `onStateChange` from `BaseNavigationContainer` and `NavigationContainerProps` in `expo-router/react-navigation` ([#49588](https://github.com/expo/expo/pull/49588) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -11,7 +11,6 @@ import type { ExpoLinkingOptions } from './getLinkingConfig';
 import { navigationRef } from './global-state/navigationRef';
 import { RemovalPreventionProvider } from './global-state/removalPrevention';
 import { RouterConfigContext } from './global-state/routerConfigContext';
-import { RouterRegistryProvider } from './global-state/routerRegistry';
 import { RoutingQueueProvider } from './global-state/routingQueueContext';
 import { useRouterConfig } from './global-state/useStore';
 import { shouldAppendNotFound, shouldAppendSitemap } from './global-state/utils';
@@ -136,17 +135,15 @@ function ContextNavigator({
 
   return (
     <RouterConfigContext.Provider value={routerConfig}>
-      <RouterRegistryProvider>
-        <RemovalPreventionProvider>
-          <UpstreamNavigationContainer
-            ref={navigationRef}
-            linking={linkingConfig as LinkingOptions<any>}>
-            <WrapperComponent>
-              <Content rootComponent={rootComponent} />
-            </WrapperComponent>
-          </UpstreamNavigationContainer>
-        </RemovalPreventionProvider>
-      </RouterRegistryProvider>
+      <RemovalPreventionProvider>
+        <UpstreamNavigationContainer
+          ref={navigationRef}
+          linking={linkingConfig as LinkingOptions<any>}>
+          <WrapperComponent>
+            <Content rootComponent={rootComponent} />
+          </WrapperComponent>
+        </UpstreamNavigationContainer>
+      </RemovalPreventionProvider>
     </RouterConfigContext.Provider>
   );
 }

--- a/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
@@ -4,6 +4,7 @@ import React, { forwardRef, useEffect, useState } from 'react';
 import type { ViewProps } from 'react-native';
 import { View, Text, Button } from 'react-native';
 
+import { unstable_useIsNavigating } from '../exports';
 import { useLocalSearchParams } from '../hooks';
 import { router } from '../imperative-api';
 import { useGuardRedirect } from '../layouts/GuardContext';
@@ -18,6 +19,14 @@ import { useNavigation } from '../useNavigation';
 import { useNavigatorContext } from '../views/Navigator';
 import type { PressableProps } from '../views/Pressable';
 import { Pressable } from '../views/Pressable';
+
+function createDeferred() {
+  let resolve!: (value: string) => void;
+  const promise = new Promise<string>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 const renderFruitApp = (options: RenderRouterOptions = {}) =>
   renderRouter(
@@ -90,6 +99,51 @@ const renderFruitApp = (options: RenderRouterOptions = {}) =>
     },
     options
   );
+
+it('keeps the current tab visible while a queued tab switch suspends', async () => {
+  const deferred = createDeferred();
+
+  function Layout() {
+    const isNavigating = unstable_useIsNavigating();
+    return (
+      <>
+        <Text testID="is-navigating">{String(isNavigating)}</Text>
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" href="/" testID="goto-index" />
+            <TabTrigger name="slow" href="/slow" testID="goto-slow" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      </>
+    );
+  }
+
+  function SlowScreen() {
+    return <Text testID="slow">{React.use(deferred.promise)}</Text>;
+  }
+
+  renderRouter({
+    _layout: Layout,
+    index: () => <Text testID="index">Index</Text>,
+    slow: {
+      default: SlowScreen,
+      SuspenseFallback: () => <Text testID="fallback">Fallback</Text>,
+    },
+  });
+
+  const navigationAct = act(() => fireEvent.press(screen.getByTestId('goto-slow')));
+
+  expect(screen.getByTestId('is-navigating')).toHaveTextContent('true');
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen.queryByTestId('fallback')).toBeNull();
+
+  deferred.resolve('Slow');
+  await navigationAct;
+
+  await waitFor(() => expect(screen.getByTestId('is-navigating')).toHaveTextContent('false'));
+  expect(screen.getByTestId('slow')).toBeVisible();
+});
 
 it('should render the correct screen with nested navigators', () => {
   renderFruitApp({ initialUrl: '/apple' });

--- a/packages/expo-router/src/fork/__tests__/__fixtures__/store.tsx
+++ b/packages/expo-router/src/fork/__tests__/__fixtures__/store.tsx
@@ -14,7 +14,6 @@ import { defaultRouteInfo, getRouteInfoFromState } from '../../../global-state/g
 import { RouteInfoContext } from '../../../global-state/routeInfoContext';
 import { RemovalPreventionProvider } from '../../../global-state/removalPrevention';
 import { RouterConfigContext } from '../../../global-state/routerConfigContext';
-import { RouterRegistryProvider } from '../../../global-state/routerRegistry';
 import type { NavigationState } from '../../../react-navigation/routers';
 
 let routeNode: RouteNode | null = null;
@@ -47,11 +46,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   return (
     <RoutingQueueProvider>
       <RouterConfigContext.Provider value={{ linking: undefined, redirects: [], routeNode }}>
-        <RouterRegistryProvider>
-          <RemovalPreventionProvider>
-            <RouteInfoContext.Provider value={routeInfo}>{children}</RouteInfoContext.Provider>
-          </RemovalPreventionProvider>
-        </RouterRegistryProvider>
+        <RemovalPreventionProvider>
+          <RouteInfoContext.Provider value={routeInfo}>{children}</RouteInfoContext.Provider>
+        </RemovalPreventionProvider>
         <PendingIntentsProbe />
       </RouterConfigContext.Provider>
     </RoutingQueueProvider>

--- a/packages/expo-router/src/fork/__tests__/useLinking.test.web.tsx
+++ b/packages/expo-router/src/fork/__tests__/useLinking.test.web.tsx
@@ -5,7 +5,6 @@ import { expectCompleteStateToMatch } from '../../__tests__/assertCompleteState'
 import { node } from '../../global-state/__tests__/__fixtures__/routeNode';
 import { completeParsedState } from '../../global-state/createSeededNavigationState';
 import { getRouteInfoFromState } from '../../global-state/getRouteInfoFromState';
-import { RouterRegistryProvider } from '../../global-state/routerRegistry';
 import { getRootStackRouteNames } from '../../global-state/utils';
 import { getStateFromPath } from '../../link/linking';
 import { Screen } from '../../react-navigation/core/Screen';
@@ -344,21 +343,19 @@ test('does not add browser history when preloading a stack route', async () => {
   const onStateChange = jest.fn();
 
   render(
-    <RouterRegistryProvider>
-      <NavigationContainer
-        ref={ref}
-        linking={{
-          prefixes: [],
-          config: { screens: { home: 'home', details: 'details' } },
-          getInitialURL: () => 'http://localhost/home',
-          getStateFromPath: () => ({ routes: [{ name: 'home' }] }),
-        }}>
-        <Stack>
-          <Screen name="home" component={EmptyScreen} />
-          <Screen name="details" component={EmptyScreen} />
-        </Stack>
-      </NavigationContainer>
-    </RouterRegistryProvider>
+    <NavigationContainer
+      ref={ref}
+      linking={{
+        prefixes: [],
+        config: { screens: { home: 'home', details: 'details' } },
+        getInitialURL: () => 'http://localhost/home',
+        getStateFromPath: () => ({ routes: [{ name: 'home' }] }),
+      }}>
+      <Stack>
+        <Screen name="home" component={EmptyScreen} />
+        <Screen name="details" component={EmptyScreen} />
+      </Stack>
+    </NavigationContainer>
   );
 
   await waitFor(() => expect(ref.current).not.toBeNull());

--- a/packages/expo-router/src/global-state/__tests__/RoutingQueueDrainer.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/RoutingQueueDrainer.test.ios.tsx
@@ -10,7 +10,7 @@ function actionIntent(type: string): RoutingIntent {
 }
 
 function actionType(intent: RoutingIntent): string {
-  if (intent.type === 'NAVIGATE_TO_HREF') {
+  if (intent.type !== 'ACTION') {
     throw new Error('Expected an action intent.');
   }
   return intent.payload.action.type;

--- a/packages/expo-router/src/global-state/__tests__/routerRegistry.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/routerRegistry.test.ios.tsx
@@ -1,41 +1,181 @@
 import { jest } from '@jest/globals';
 import { act, render } from '@testing-library/react-native';
-import { StrictMode, use, useEffect, useState, type ReactNode } from 'react';
+import {
+  StrictMode,
+  use,
+  useEffect,
+  useState,
+  type ContextType,
+  type ReactNode,
+  type RefObject,
+} from 'react';
 import { Text } from 'react-native';
 
 import { ExpoRoot } from '../../ExpoRoot';
 import { router } from '../../imperative-api';
 import Stack from '../../layouts/Stack';
-import { StackActions, type NavigationState } from '../../react-navigation/native';
-import { getMockContext, renderRouter } from '../../testing-library';
+import { BaseNavigationContainer } from '../../react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer';
+import type {
+  NavigationContainerRef,
+  NavigationState,
+  ParamListBase,
+} from '../../react-navigation/native';
+import { getMockContext } from '../../testing-library';
 import { navigationRef } from '../navigationRef';
 import {
-  RouterRegistryProvider,
-  RouterRegistryContext,
-  type RouterRegistry,
+  RouterRegistrySettersContext,
   type RouterRegistryEntry,
   useRegisterRouter,
 } from '../routerRegistry';
+import { node } from './__fixtures__/routeNode';
 
-const state: NavigationState = {
-  stale: false,
-  routeKeySeq: 0,
-  type: 'stack',
-  key: 'stack-key',
-  index: 0,
-  routeNames: ['index'],
-  routes: [{ key: 'index-key', name: 'index' }],
-};
+const firstEntry: RouterRegistryEntry = { reduce: () => null };
 
-const firstEntry: RouterRegistryEntry = {
-  reduce: () => ({ state, affectedRouteKey: state.routes[state.index]?.key }),
-};
+function Registrant({ entry }: { entry: RouterRegistryEntry }) {
+  useRegisterRouter('root', entry);
+  return null;
+}
 
-const secondEntry: RouterRegistryEntry = {
-  reduce: () => ({ state, affectedRouteKey: state.routes[state.index]?.key }),
-};
+it('warns when registering outside the container', () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-function collectStateKeys(state: NavigationState): string[] {
+  render(<Registrant entry={firstEntry} />);
+
+  expect(warn).toHaveBeenCalledWith(
+    'Router registry is unavailable. This is most likely a bug in expo-router. Please report it at https://github.com/expo/expo/issues.'
+  );
+  warn.mockRestore();
+});
+
+it('replaces entries and ignores stale-owner cleanup', () => {
+  const ref = { current: null } as RefObject<NavigationContainerRef<ParamListBase> | null>;
+  const firstReduce = jest.fn(() => null);
+  const secondReduce = jest.fn((state: NavigationState) => ({
+    state: { ...state, index: state.index },
+    affectedRouteKey: state.routes[state.index]?.key,
+  }));
+  const routeNode = node('root', [node('index')]);
+  const first = { reduce: firstReduce, routeNode };
+  const second = { reduce: secondReduce, routeNode };
+  let setters = undefined as ContextType<typeof RouterRegistrySettersContext>;
+
+  function CaptureSetters() {
+    setters = use(RouterRegistrySettersContext);
+    return null;
+  }
+
+  render(
+    <BaseNavigationContainer
+      ref={ref}
+      initialState={{
+        stale: false,
+        routeKeySeq: 0,
+        key: 'root',
+        index: 1,
+        routeNames: ['index', 'second'],
+        routes: [
+          { key: 'index', name: 'index' },
+          { key: 'second', name: 'second' },
+        ],
+      }}>
+      <CaptureSetters />
+    </BaseNavigationContainer>
+  );
+
+  act(() => {
+    setters!.register('root', first);
+    setters!.register('root', first);
+    setters!.register('root', second);
+    setters!.unregister('root', first);
+  });
+  act(() => ref.current!.dispatchSync({ type: 'TEST' }));
+
+  expect(firstReduce).not.toHaveBeenCalled();
+  expect(secondReduce).toHaveBeenCalledTimes(1);
+  expect(ref.current!.getRootState().routes).toEqual([
+    { key: 'index', name: 'index' },
+    { key: 'second', name: 'second' },
+  ]);
+});
+
+it('does not rerender descendants when the registry changes', () => {
+  let setters = undefined as ContextType<typeof RouterRegistrySettersContext>;
+  const renders = jest.fn();
+  const child = <Probe />;
+
+  function Probe() {
+    setters = use(RouterRegistrySettersContext);
+    renders();
+    return null;
+  }
+
+  render(<BaseNavigationContainer>{child}</BaseNavigationContainer>);
+  const initialRenders = renders.mock.calls.length;
+
+  act(() => setters!.register('root', firstEntry));
+
+  expect(renders).toHaveBeenCalledTimes(initialRenders);
+});
+
+it('keeps committed keys and screen instances stable across a StrictMode rerender', () => {
+  let rerenderLayout: () => void;
+  let mounts = 0;
+  function Layout() {
+    const [, setRenderCount] = useState(0);
+    rerenderLayout = () => setRenderCount((count) => count + 1);
+    return <Stack />;
+  }
+  function Screen() {
+    useEffect(() => {
+      mounts++;
+    }, []);
+    return <Text testID="screen" />;
+  }
+  const context = getMockContext({ _layout: Layout, index: Screen });
+
+  render(
+    <StrictMode>
+      <ExpoRoot context={context} location="/" />
+    </StrictMode>
+  );
+  const initialKeys = collectStateKeys(navigationRef.current!.getRootState());
+  const initialMounts = mounts;
+
+  act(() => rerenderLayout());
+
+  expect(collectStateKeys(navigationRef.current!.getRootState())).toEqual(initialKeys);
+  expect(mounts).toBe(initialMounts);
+});
+
+it('uses the latest screen config when screens change', () => {
+  const routes: Record<string, () => ReactNode> = {
+    _layout: () => <Stack />,
+    index: () => <Text testID="index" />,
+  };
+  const context = getMockContext(routes);
+  const previousImportMode = process.env.EXPO_ROUTER_IMPORT_MODE;
+  process.env.EXPO_ROUTER_IMPORT_MODE = 'sync';
+
+  try {
+    const result = render(<ExpoRoot context={context} location="/" />);
+    routes.second = () => <Text testID="second" />;
+    result.rerender(<ExpoRoot context={context} location="/" />);
+
+    act(() => router.push('/second'));
+
+    expect(collectRouteNames(navigationRef.current!.getRootState())).toContain('second');
+  } finally {
+    if (previousImportMode === undefined) {
+      delete process.env.EXPO_ROUTER_IMPORT_MODE;
+    } else {
+      process.env.EXPO_ROUTER_IMPORT_MODE = previousImportMode;
+    }
+  }
+});
+
+function collectStateKeys(
+  state: ReturnType<NavigationContainerRef<ParamListBase>['getRootState']>
+): string[] {
   return [
     state.key,
     ...state.routes.flatMap((route) => [
@@ -45,286 +185,11 @@ function collectStateKeys(state: NavigationState): string[] {
   ];
 }
 
-function getLayoutState(): NavigationState {
-  const layoutState = navigationRef.current!.getRootState().routes[0]!.state;
-
-  if (layoutState?.stale !== false) {
-    throw new Error('Expected initialized layout state');
-  }
-
-  return layoutState;
+function collectRouteNames(
+  state: ReturnType<NavigationContainerRef<ParamListBase>['getRootState']>
+): string[] {
+  return state.routes.flatMap((route) => [
+    route.name,
+    ...(route.state?.stale === false ? collectRouteNames(route.state) : []),
+  ]);
 }
-
-function Registrant({
-  children,
-  entry,
-  stateKey = state.key,
-}: {
-  children?: ReactNode;
-  entry: RouterRegistryEntry;
-  stateKey?: string;
-}) {
-  useRegisterRouter(stateKey, entry);
-  return children;
-}
-
-function RegistryProbe({ onRender }: { onRender: (registry: RouterRegistry) => void }) {
-  const registry = use(RouterRegistryContext);
-  if (registry === undefined) {
-    throw new Error('Expected RouterRegistryProvider');
-  }
-  onRender(registry);
-  return null;
-}
-
-describe(RouterRegistryProvider, () => {
-  it('warns when registering outside the provider', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    try {
-      render(<Registrant entry={firstEntry} />);
-
-      expect(warn).toHaveBeenCalledWith(
-        'Router registry is unavailable. This is most likely a bug in expo-router. Please report it at https://github.com/expo/expo/issues.'
-      );
-    } finally {
-      warn.mockRestore();
-    }
-  });
-
-  it('registers and unregisters entries', () => {
-    const registries: RouterRegistry[] = [];
-    const result = render(
-      <RouterRegistryProvider>
-        <RegistryProbe onRender={(registry) => registries.push(registry)} />
-        <Registrant entry={firstEntry} />
-      </RouterRegistryProvider>
-    );
-
-    expect(registries.at(-1)?.get(state.key)).toBe(firstEntry);
-
-    result.rerender(
-      <RouterRegistryProvider>
-        <RegistryProbe onRender={(registry) => registries.push(registry)} />
-      </RouterRegistryProvider>
-    );
-
-    expect(registries.at(-1)?.size).toBe(0);
-  });
-
-  it('keeps a newer registration when an older owner unmounts', () => {
-    const registries: RouterRegistry[] = [];
-    const result = render(
-      <RouterRegistryProvider>
-        <RegistryProbe onRender={(registry) => registries.push(registry)} />
-        <Registrant entry={firstEntry} />
-        <Registrant entry={secondEntry} />
-      </RouterRegistryProvider>
-    );
-
-    expect(registries.at(-1)?.get(state.key)).toBe(secondEntry);
-
-    result.rerender(
-      <RouterRegistryProvider>
-        <RegistryProbe onRender={(registry) => registries.push(registry)} />
-        <Registrant entry={secondEntry} />
-      </RouterRegistryProvider>
-    );
-
-    expect(registries.at(-1)?.get(state.key)).toBe(secondEntry);
-  });
-
-  it('handles StrictMode effect replay', () => {
-    const registries: RouterRegistry[] = [];
-
-    render(
-      <StrictMode>
-        <RouterRegistryProvider>
-          <RegistryProbe onRender={(registry) => registries.push(registry)} />
-          <Registrant entry={firstEntry} />
-        </RouterRegistryProvider>
-      </StrictMode>
-    );
-
-    expect(registries.at(-1)?.get(state.key)).toBe(firstEntry);
-  });
-
-  it('preserves map identity when registration does not change', () => {
-    const registries: RouterRegistry[] = [];
-
-    render(
-      <RouterRegistryProvider>
-        <RegistryProbe onRender={(registry) => registries.push(registry)} />
-        <Registrant entry={firstEntry} />
-        <Registrant entry={firstEntry} />
-      </RouterRegistryProvider>
-    );
-
-    expect(new Set(registries).size).toBe(2);
-    expect(registries.at(-1)?.get(state.key)).toBe(firstEntry);
-  });
-});
-
-describe('navigation builder registration', () => {
-  let registry: RouterRegistry;
-  let registryRenders: number;
-
-  function Probe() {
-    const currentRegistry = use(RouterRegistryContext);
-    if (currentRegistry === undefined) {
-      throw new Error('Expected RouterRegistryProvider');
-    }
-    registry = currentRegistry;
-    registryRenders++;
-    return <Text testID="probe" />;
-  }
-
-  beforeEach(() => {
-    registry = new Map();
-    registryRenders = 0;
-  });
-
-  it('registers each mounted navigator by its state key', () => {
-    renderRouter({
-      _layout: () => <Stack />,
-      index: Probe,
-    });
-
-    const rootState = navigationRef.current!.getRootState();
-    const layoutState = rootState.routes[0]!.state!;
-
-    expect([...registry.keys()]).toEqual(expect.arrayContaining([rootState.key, layoutState.key]));
-    expect(registry.size).toBe(2);
-  });
-
-  it('registers an inactive nested navigator only after its screen mounts', () => {
-    renderRouter({
-      _layout: () => <Stack />,
-      index: Probe,
-      'nested/_layout': () => <Stack />,
-      'nested/index': () => <Text testID="nested" />,
-    });
-
-    expect(registry.size).toBe(2);
-
-    act(() => router.push('/nested'));
-
-    expect(registry.size).toBe(3);
-  });
-
-  it('notifies consumers when a navigator mounts and unmounts', () => {
-    renderRouter({
-      _layout: () => <Stack />,
-      index: Probe,
-      'nested/_layout': () => <Stack />,
-      'nested/index': () => <Text testID="nested" />,
-    });
-    const initialRenders = registryRenders;
-
-    act(() => router.push('/nested'));
-    expect(registryRenders).toBeGreaterThan(initialRenders);
-
-    const mountedRenders = registryRenders;
-    act(() => router.back());
-    expect(registryRenders).toBeGreaterThan(mountedRenders);
-    expect(registry.size).toBe(2);
-  });
-
-  it('reduces actions with the registered router configuration', () => {
-    renderRouter({
-      _layout: () => <Stack />,
-      index: Probe,
-      second: () => <Text testID="second" />,
-    });
-    const layoutState = getLayoutState();
-    const entry = registry.get(layoutState.key)!;
-
-    const result = entry.reduce(layoutState, StackActions.push('second'));
-
-    expect(result?.state.routes.map((route) => route.name)).toEqual(['index', 'second']);
-    expect(result?.affectedRouteKey).toBe(result?.state.routes[1]!.key);
-  });
-
-  it('preserves registry identity when screens do not change', () => {
-    let rerenderLayout: () => void;
-    function Layout() {
-      const [, setRenderCount] = useState(0);
-      rerenderLayout = () => setRenderCount((count) => count + 1);
-      return <Stack />;
-    }
-
-    renderRouter({
-      _layout: Layout,
-      index: Probe,
-    });
-    const initialRegistry = registry;
-    const initialEntry = registry.get(getLayoutState().key);
-    const initialRenders = registryRenders;
-
-    act(() => rerenderLayout());
-
-    expect(registry).toBe(initialRegistry);
-    expect(registry.get(getLayoutState().key)).toBe(initialEntry);
-    expect(registryRenders).toBe(initialRenders);
-  });
-
-  it('keeps committed keys and screen instances stable across a StrictMode rerender', () => {
-    let rerenderLayout: () => void;
-    let mounts = 0;
-    function Layout() {
-      const [, setRenderCount] = useState(0);
-      rerenderLayout = () => setRenderCount((count) => count + 1);
-      return <Stack />;
-    }
-    function Screen() {
-      useEffect(() => {
-        mounts++;
-      }, []);
-      return <Text testID="screen" />;
-    }
-    const context = getMockContext({ _layout: Layout, index: Screen });
-
-    render(
-      <StrictMode>
-        <ExpoRoot context={context} location="/" />
-      </StrictMode>
-    );
-    const initialKeys = collectStateKeys(navigationRef.current!.getRootState());
-    const initialMounts = mounts;
-
-    act(() => rerenderLayout());
-
-    expect(collectStateKeys(navigationRef.current!.getRootState())).toEqual(initialKeys);
-    expect(mounts).toBe(initialMounts);
-  });
-
-  it('replaces the entry when screens change', () => {
-    const routes: Record<string, () => ReactNode> = {
-      _layout: () => <Stack />,
-      index: Probe,
-    };
-    const context = getMockContext(routes);
-    const previousImportMode = process.env.EXPO_ROUTER_IMPORT_MODE;
-    process.env.EXPO_ROUTER_IMPORT_MODE = 'sync';
-
-    try {
-      const result = render(<ExpoRoot context={context} location="/" />);
-      const initialEntry = registry.get(getLayoutState().key)!;
-
-      routes.second = () => <Text testID="second" />;
-      result.rerender(<ExpoRoot context={context} location="/" />);
-
-      const updatedEntry = registry.get(getLayoutState().key)!;
-      expect(updatedEntry).not.toBe(initialEntry);
-      expect(
-        updatedEntry.reduce(getLayoutState(), StackActions.push('second'))?.state.routes
-      ).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'second' })]));
-    } finally {
-      if (previousImportMode === undefined) {
-        delete process.env.EXPO_ROUTER_IMPORT_MODE;
-      } else {
-        process.env.EXPO_ROUTER_IMPORT_MODE = previousImportMode;
-      }
-    }
-  });
-});

--- a/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react-native';
+import { useLayoutEffect } from 'react';
 
 import type { NavigationAction, NavigationState } from '../../react-navigation/routers';
 import { getNavigateAction } from '../getNavigationAction';
@@ -37,6 +38,7 @@ function renderReducer({
   routesWithRemovalPrevented?: ReadonlySet<string>;
 }) {
   const reports: NonNullable<ReturnType<typeof useNavigationTreeReducer>['report']>[] = [];
+  const committedStates: NavigationState[] = [];
   const result = renderHook<
     ReturnType<typeof useNavigationTreeReducer>,
     {
@@ -53,11 +55,14 @@ function renderReducer({
       if (reducer.report) {
         reports.push(reducer.report);
       }
+      useLayoutEffect(() => {
+        committedStates.push(reducer.state);
+      });
       return reducer;
     },
     { initialProps: { registry, routesWithRemovalPrevented } }
   );
-  return { ...result, reports };
+  return { ...result, committedStates, reports };
 }
 
 test('reports and vetoes removal of a prevented route', () => {
@@ -360,6 +365,113 @@ it('reduces consecutive queued intents against accumulated state', () => {
   expect(result.result.current.state.index).toBe(2);
 });
 
+it('uses the registry from the render that reduces an operation', () => {
+  const firstReduce = jest.fn(() => null);
+  const secondReduce = jest.fn((state: NavigationState) => ({
+    state: { ...state, index: 1 },
+    affectedRouteKey: state.routes[1]!.key,
+  }));
+  const result = renderReducer({ registry: new Map([['root', entry(firstReduce)]]) });
+  const processIntent = result.result.current.processIntent;
+
+  result.rerender({
+    registry: new Map([['root', entry(secondReduce)]]),
+    routesWithRemovalPrevented: new Set(),
+  });
+  act(() =>
+    processIntent({ type: 'ACTION', payload: { action: { type: 'USE_CURRENT_REGISTRY' } } })
+  );
+
+  expect(result.result.current.processIntent).toBe(processIntent);
+  expect(firstReduce).not.toHaveBeenCalled();
+  expect(secondReduce).toHaveBeenCalledTimes(1);
+  expect(result.result.current.state.index).toBe(1);
+});
+
+it('uses removal prevention from the render that reduces an operation', () => {
+  const reduce = jest.fn((state: NavigationState) => ({
+    state: { ...state, routes: state.routes.slice(0, 1) },
+    affectedRouteKey: state.routes[0]!.key,
+  }));
+  const result = renderReducer({ registry: new Map([['root', entry(reduce)]]) });
+  const processIntent = result.result.current.processIntent;
+
+  result.rerender({
+    registry: new Map([['root', entry(reduce)]]),
+    routesWithRemovalPrevented: new Set(['third']),
+  });
+  act(() => processIntent({ type: 'ACTION', payload: { action: { type: 'REMOVE' } } }));
+
+  expect(result.result.current.state).toBe(initialState);
+  expect(result.result.current.report?.events).toEqual([
+    expect.objectContaining({ type: 'prevented-routes', routeKeys: ['third'] }),
+  ]);
+});
+
+it('computes a queued action from accumulated state', () => {
+  const tabState: NavigationState = {
+    ...initialState,
+    type: 'tab',
+    routeNames: ['first', 'second'],
+    routes: [
+      { key: 'first', name: 'first', state: { ...initialState, key: 'first-stack' } },
+      { key: 'second', name: 'second', state: { ...initialState, key: 'second-stack' } },
+    ],
+  };
+  const reduce = jest.fn((state: NavigationState, action: NavigationAction) => {
+    if (action.type === 'FOCUS_SECOND') {
+      return { state: { ...state, index: 1 }, affectedRouteKey: state.routes[1]!.key };
+    }
+    if (action.type === 'JUMP_TO' || action.type === 'NAVIGATE') {
+      return { state: { ...state, index: 0 }, affectedRouteKey: state.routes[0]!.key };
+    }
+    return null;
+  });
+  const result = renderReducer({ state: tabState, registry: new Map([['root', entry(reduce)]]) });
+
+  act(() => {
+    result.result.current.processIntent({
+      type: 'ACTION',
+      payload: { action: { type: 'FOCUS_SECOND' } },
+    });
+    result.result.current.processIntent({
+      type: 'COMPUTED_ACTION',
+      payload: {
+        originKey: 'root',
+        compute: (state) => ({
+          type: state.index === 1 ? 'JUMP_TO' : 'NAVIGATE',
+          payload: { name: 'first' },
+        }),
+      },
+    });
+  });
+
+  expect(reduce).toHaveBeenCalledTimes(2);
+  expect(reduce.mock.calls[1]![0].index).toBe(1);
+  expect(reduce.mock.calls[1]![1].type).toBe('JUMP_TO');
+  expect(result.result.current.state.index).toBe(0);
+});
+
+it('warns and keeps the state when computing a queued action throws', () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const result = renderReducer({ registry: new Map([['root', entry(() => null)]]) });
+
+  act(() =>
+    result.result.current.processIntent({
+      type: 'COMPUTED_ACTION',
+      payload: {
+        compute() {
+          throw new Error('boom');
+        },
+      },
+    })
+  );
+
+  expect(warn).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  expect(result.result.current.state).toBe(initialState);
+  warn.mockRestore();
+});
+
 it('warns for direct navigation actions carrying a screen param', () => {
   const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
   const result = renderReducer({
@@ -427,6 +539,7 @@ it('resets a state slice when its router unregisters', () => {
   const result = renderReducer({
     registry: new Map([['root', registryEntry]]),
   });
+  result.committedStates.length = 0;
 
   result.rerender({
     registry: new Map(),
@@ -438,6 +551,7 @@ it('resets a state slice when its router unregisters', () => {
     routeNames: ['second', 'first', 'third'],
     routes: [{ name: 'second' }],
   });
+  expect(result.committedStates).toEqual([result.result.current.state]);
 });
 
 it('resets a state slice when its router type changes', () => {

--- a/packages/expo-router/src/global-state/routerRegistry.tsx
+++ b/packages/expo-router/src/global-state/routerRegistry.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, use, useMemo, useState, type PropsWithChildren } from 'react';
+import { createContext, use } from 'react';
 
 import type { RouteNode } from '../Route';
 import { useClientLayoutEffect } from '../react-navigation/core/useClientLayoutEffect';
@@ -23,49 +23,14 @@ export type RouterRegistryEntry = {
 // Entries appear after the first commit and state keys can change when navigation state is reset.
 export type RouterRegistry = ReadonlyMap<string, RouterRegistryEntry>;
 
-type RouterRegistrySetters = {
+export type RouterRegistrySetters = {
   register: (stateKey: string, entry: RouterRegistryEntry) => void;
   unregister: (stateKey: string, entry: RouterRegistryEntry) => void;
 };
 
-// React components read this map during render, so React state is intentional.
-export const RouterRegistryContext = createContext<RouterRegistry | undefined>(undefined);
-const RouterRegistrySettersContext = createContext<RouterRegistrySetters | undefined>(undefined);
-
-export function RouterRegistryProvider({ children }: PropsWithChildren) {
-  const [registry, setRegistry] = useState<RouterRegistry>(() => new Map());
-  const setters = useMemo<RouterRegistrySetters>(
-    () => ({
-      register(stateKey, entry) {
-        setRegistry((previous) => {
-          if (previous.get(stateKey) === entry) {
-            return previous;
-          }
-
-          return new Map(previous).set(stateKey, entry);
-        });
-      },
-      unregister(stateKey, entry) {
-        setRegistry((previous) => {
-          if (previous.get(stateKey) !== entry) {
-            return previous;
-          }
-
-          const next = new Map(previous);
-          next.delete(stateKey);
-          return next;
-        });
-      },
-    }),
-    []
-  );
-
-  return (
-    <RouterRegistrySettersContext.Provider value={setters}>
-      <RouterRegistryContext.Provider value={registry}>{children}</RouterRegistryContext.Provider>
-    </RouterRegistrySettersContext.Provider>
-  );
-}
+export const RouterRegistrySettersContext = createContext<RouterRegistrySetters | undefined>(
+  undefined
+);
 
 export function useRegisterRouter(stateKey: string, entry: RouterRegistryEntry): void {
   const setters = use(RouterRegistrySettersContext);

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -1,4 +1,5 @@
-import type { NavigationAction } from '../react-navigation/native';
+import type { NavigationAction, NavigationState } from '../react-navigation/native';
+import type { RouterRegistry } from './routerRegistry';
 import type { LinkToOptions } from './types';
 
 interface NavigateToHrefIntent {
@@ -20,6 +21,15 @@ interface RoutingIntentMetadata {
 
 export type RoutingIntent =
   | NavigateToHrefIntent
+  | {
+      type: 'COMPUTED_ACTION';
+      payload: {
+        compute: (state: NavigationState, registry: RouterRegistry) => NavigationAction | undefined;
+        originKey?: string;
+      };
+      metadata?: RoutingIntentMetadata;
+      onDispatch?: (metadata: RoutingIntentMetadata | undefined) => void;
+    }
   | {
       type: 'ACTION';
       payload: { action: NavigationAction; originKey?: string };

--- a/packages/expo-router/src/global-state/stateUtils.ts
+++ b/packages/expo-router/src/global-state/stateUtils.ts
@@ -2,6 +2,21 @@ import type { ResultState } from '../fork/getStateFromPath';
 import { matchDynamicName } from '../matchers';
 import type { PartialRoute, NavigationState, PartialState } from '../react-navigation/native';
 
+export function findStateByKey(root: NavigationState, key: string): NavigationState | undefined {
+  if (root.key === key) {
+    return root;
+  }
+  for (const route of root.routes) {
+    if (route.state?.stale === false) {
+      const state = findStateByKey(route.state, key);
+      if (state) {
+        return state;
+      }
+    }
+  }
+  return undefined;
+}
+
 export function resetNavigatorState(
   state: NavigationState,
   routerType: string | undefined

--- a/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
+++ b/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
@@ -6,7 +6,6 @@ import type { RouteNode } from '../Route';
 import type { ExpoLinkingOptions } from '../getLinkingConfig';
 import { warnIfScreenParam } from '../navigationParams';
 import { deepFreeze } from '../react-navigation/core/deepFreeze';
-import { useClientLayoutEffect } from '../react-navigation/core/useClientLayoutEffect';
 import type { InitialState, NavigationAction, NavigationState } from '../react-navigation/routers';
 import { getChainFromStateKey } from '../react-navigation/routers/stateKeys';
 import useLatestCallback from '../utils/useLatestCallback';
@@ -18,7 +17,7 @@ import { getNavigateAction } from './getNavigationAction';
 import { indexNavigationTree, reduceNavigationTree, resolveOrigin } from './reduceNavigationTree';
 import type { RouterRegistry } from './routerRegistry';
 import type { RoutingIntent } from './routingQueue';
-import { resetNavigatorState } from './stateUtils';
+import { findStateByKey, resetNavigatorState } from './stateUtils';
 import type { StoreRedirects } from './types';
 
 type ReducerConfig = {
@@ -146,7 +145,8 @@ function warnUnhandledAction(action: NavigationAction) {
 
 function navigationTreeReducer(
   result: NavigationTreeResult,
-  { operation, config }: { operation: TreeOperation; config: ReducerConfig }
+  operation: TreeOperation,
+  config: ReducerConfig
 ): NavigationTreeResult {
   const state = result.state;
 
@@ -182,10 +182,33 @@ function navigationTreeReducer(
         );
         return result;
       }
-      return navigationTreeReducer(result, {
-        operation: { type: 'ACTION', payload: { action: resolution.action } },
-        config,
-      });
+      return navigationTreeReducer(
+        result,
+        { type: 'ACTION', payload: { action: resolution.action } },
+        config
+      );
+    }
+    case 'COMPUTED_ACTION': {
+      let action: NavigationAction | undefined;
+      try {
+        action = operation.payload.compute(state, config.registry);
+      } catch (error) {
+        const message =
+          typeof error === 'object' && error != null && 'message' in error ? error.message : error;
+        // TODO(@ubax): move console side effects out of the reducer.
+        console.warn(
+          `An error occurred when trying to handle navigation action ${JSON.stringify(operation)}: ${message}`
+        );
+        return result;
+      }
+      if (!action) {
+        return result;
+      }
+      return navigationTreeReducer(
+        result,
+        { type: 'ACTION', payload: { action, originKey: operation.payload.originKey } },
+        config
+      );
     }
     case 'ACTION': {
       const tree = indexNavigationTree(state);
@@ -265,7 +288,8 @@ function navigationTreeReducer(
       };
     }
     case 'NAVIGATOR_UNMOUNTED': {
-      if (!findStateByKey(state, operation.stateKey)) {
+      // A still-registered key re-registered before this operation reduced, so it did not unmount.
+      if (config.registry.has(operation.stateKey) || !findStateByKey(state, operation.stateKey)) {
         return result;
       }
       const replacement = createSeededNavigationState(
@@ -313,8 +337,16 @@ export function useNavigationTreeReducer({
   linking,
   redirects,
 }: Options) {
+  const config: ReducerConfig = {
+    registry,
+    routesWithRemovalPrevented,
+    routeNode,
+    linking,
+    redirects,
+  };
   const [result, reactDispatch] = React.useReducer(
-    navigationTreeReducer,
+    (result: NavigationTreeResult, operation: TreeOperation) =>
+      navigationTreeReducer(result, operation, config),
     initialState,
     (value): NavigationTreeResult => {
       validateInitialState(value);
@@ -327,27 +359,20 @@ export function useNavigationTreeReducer({
       return { state: deepFreeze(value), report: undefined, eventSeq: 0 };
     }
   );
-  const previousRegistryRef = React.useRef(registry);
-
-  const processAction = React.useCallback(
-    (operation: TreeOperation) =>
-      reactDispatch({
-        operation,
-        config: {
-          registry,
-          routesWithRemovalPrevented,
-          routeNode,
-          linking,
-          redirects,
-        },
-      }),
-    [linking, redirects, registry, routeNode, routesWithRemovalPrevented]
-  );
-  const process = React.useEffectEvent(processAction);
-  const processIntent = React.useCallback(
-    (intent: RoutingIntent) => processAction(intent),
-    [processAction]
-  );
+  const [previousRegistry, setPreviousRegistry] = React.useState(registry);
+  if (previousRegistry !== registry) {
+    setPreviousRegistry(registry);
+    // Reconcile before commit so registry membership and navigation state stay in sync.
+    for (const [stateKey, entry] of previousRegistry) {
+      if (!registry.has(stateKey) && entry.routeNode) {
+        reactDispatch({
+          type: 'NAVIGATOR_UNMOUNTED',
+          stateKey,
+          routeNode: entry.routeNode,
+        });
+      }
+    }
+  }
   const handleAction = useLatestCallback((action: NavigationAction, originKey?: string) => {
     const payload =
       typeof action.payload === 'object' && action.payload !== null ? action.payload : undefined;
@@ -359,35 +384,18 @@ export function useNavigationTreeReducer({
         ? payload.params
         : undefined;
     warnIfScreenParam(params);
-    processAction({ type: 'ACTION', payload: { action, originKey } });
+    reactDispatch({ type: 'ACTION', payload: { action, originKey } });
   });
   const resetNavigator = useLatestCallback((stateKey: string, routerType: string | undefined) => {
-    processAction({ type: 'NAVIGATOR_CHANGED', stateKey, routerType });
+    reactDispatch({ type: 'NAVIGATOR_CHANGED', stateKey, routerType });
   });
   const consumeReportEvents = useLatestCallback((eventIds: readonly number[]) => {
-    processAction({ type: 'REPORT_CONSUMED', eventIds });
+    reactDispatch({ type: 'REPORT_CONSUMED', eventIds });
   });
 
   React.useInsertionEffect(() => {
     warnIfStaleState(result.state);
   }, [result.state]);
-
-  useClientLayoutEffect(() => {
-    const previousRegistry = previousRegistryRef.current;
-    previousRegistryRef.current = registry;
-    for (const [stateKey, entry] of previousRegistry) {
-      if (!registry.has(stateKey) && entry.routeNode) {
-        // This runs inside an effect; the rule doesn't recognize the `useClientLayoutEffect`
-        // wrapper as one.
-        // oxlint-disable-next-line react-hooks/rules-of-hooks
-        process({
-          type: 'NAVIGATOR_UNMOUNTED',
-          stateKey,
-          routeNode: entry.routeNode,
-        });
-      }
-    }
-  }, [registry]);
 
   return {
     state: result.state,
@@ -395,7 +403,7 @@ export function useNavigationTreeReducer({
     consumeReportEvents,
     resetNavigator,
     handleAction,
-    processIntent,
+    processIntent: reactDispatch,
   };
 }
 
@@ -466,21 +474,6 @@ function validateInitialState(
   for (const route of state.routes) {
     validateInitialState(route.state);
   }
-}
-
-export function findStateByKey(root: NavigationState, key: string): NavigationState | undefined {
-  if (root.key === key) {
-    return root;
-  }
-  for (const route of root.routes) {
-    if (route.state?.stale === false) {
-      const state = findStateByKey(route.state, key);
-      if (state) {
-        return state;
-      }
-    }
-  }
-  return undefined;
 }
 
 export function replaceNavigationState(

--- a/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.android.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.android.tsx
@@ -67,7 +67,7 @@ it('mounts deep-linked tabs in Trigger order without remounting', () => {
   expect(mockTabsHostMount).toHaveBeenCalledTimes(1);
   expect(mockTabsHostUnmount).not.toHaveBeenCalled();
   expect(
-    TabsScreen.mock.calls.slice(0, 4).map(([props]: [TabsScreenProps]) => props.screenKey)
+    TabsScreen.mock.calls.slice(0, 4).map((call: [TabsScreenProps]) => call[0].screenKey)
   ).toEqual(['test-suite', 'playground', 'apis', 'components']);
   expect(mockScreenMount.mock.calls.map(([name]) => name)).toEqual([
     // The deep-linked route has real content before the other tabs finish preloading.

--- a/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
@@ -12,7 +12,11 @@ import {
 import { GlobalRoutesWithRemovalPreventedContext } from '../../global-state/removalPrevention';
 import { RouteInfoContext } from '../../global-state/routeInfoContext';
 import { RouterConfigContext } from '../../global-state/routerConfigContext';
-import { RouterRegistryContext } from '../../global-state/routerRegistry';
+import {
+  RouterRegistrySettersContext,
+  type RouterRegistry,
+  type RouterRegistrySetters,
+} from '../../global-state/routerRegistry';
 import {
   ImperativeRoutingQueueBridge,
   RoutingQueueApiContext,
@@ -71,7 +75,6 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
   const inheritedRouteInfo = use(RouteInfoContext);
   const routerConfig = use(RouterConfigContext);
   const routingQueue = use(RoutingQueueApiContext);
-  const registry = use(RouterRegistryContext);
   const routesWithRemovalPrevented = use(GlobalRoutesWithRemovalPreventedContext);
 
   if (!parent.isDefault) {
@@ -80,17 +83,14 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
     );
   }
 
-  if (
-    routingQueue === undefined ||
-    registry === undefined ||
-    routesWithRemovalPrevented === undefined
-  ) {
+  if (routingQueue === undefined || routesWithRemovalPrevented === undefined) {
     throw new Error(
       'The navigation container requires the shared routing state provided by `ExpoRoot`. Render the navigation container inside `ExpoRoot`.'
     );
   }
 
   const emitter = useEventEmitter<NavigationContainerEventMap>();
+  const [registry, setRegistry] = React.useState<RouterRegistry>(() => new Map());
 
   // TODO(@ubax): consider moving this state to ExpoRoot.
   const { state, report, consumeReportEvents, resetNavigator, handleAction, processIntent } =
@@ -103,6 +103,29 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
       redirects: routerConfig?.redirects,
     });
   useNavigationTreeReportEvents(report, consumeReportEvents);
+  const registrySetters = React.useMemo<RouterRegistrySetters>(
+    () => ({
+      register(stateKey, entry) {
+        setRegistry((previous) => {
+          if (previous.get(stateKey) === entry) {
+            return previous;
+          }
+          return new Map(previous).set(stateKey, entry);
+        });
+      },
+      unregister(stateKey, entry) {
+        setRegistry((previous) => {
+          if (previous.get(stateKey) !== entry) {
+            return previous;
+          }
+          const next = new Map(previous);
+          next.delete(stateKey);
+          return next;
+        });
+      },
+    }),
+    []
+  );
 
   const { listeners, addListener } = useChildListeners();
 
@@ -283,9 +306,11 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
         <NavigationStateContext.Provider value={context}>
           <RouteInfoContext.Provider value={routeInfo}>
             <RootNavigationStateContext.Provider value={state}>
-              <EnsureSingleNavigator>
-                <ThemeProvider value={theme}>{children}</ThemeProvider>
-              </EnsureSingleNavigator>
+              <RouterRegistrySettersContext.Provider value={registrySetters}>
+                <EnsureSingleNavigator>
+                  <ThemeProvider value={theme}>{children}</ThemeProvider>
+                </EnsureSingleNavigator>
+              </RouterRegistrySettersContext.Provider>
               <ImperativeRoutingQueueBridge enqueue={routingQueue.enqueue} />
               <RoutingQueueDrainer processIntent={processIntent} />
             </RootNavigationStateContext.Provider>

--- a/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
@@ -2,7 +2,6 @@ import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
 import { RemovalPreventionProvider } from '../../../global-state/removalPrevention';
-import { RouterRegistryProvider } from '../../../global-state/routerRegistry';
 import { RoutingQueueProvider } from '../../../global-state/routingQueueContext';
 import {
   CommonActions,
@@ -35,9 +34,7 @@ beforeEach(() => {
 function RootProviders({ children }: React.PropsWithChildren) {
   return (
     <RoutingQueueProvider>
-      <RouterRegistryProvider>
-        <RemovalPreventionProvider>{children}</RemovalPreventionProvider>
-      </RouterRegistryProvider>
+      <RemovalPreventionProvider>{children}</RemovalPreventionProvider>
     </RoutingQueueProvider>
   );
 }
@@ -169,15 +166,13 @@ test('preserves a complete initial state by identity', () => {
 
   render(
     <RoutingQueueProvider>
-      <RouterRegistryProvider>
-        <RemovalPreventionProvider>
-          <RawBaseNavigationContainer ref={ref} initialState={initialState}>
-            <Stack>
-              <Screen name="home">{() => null}</Screen>
-            </Stack>
-          </RawBaseNavigationContainer>
-        </RemovalPreventionProvider>
-      </RouterRegistryProvider>
+      <RemovalPreventionProvider>
+        <RawBaseNavigationContainer ref={ref} initialState={initialState}>
+          <Stack>
+            <Screen name="home">{() => null}</Screen>
+          </Stack>
+        </RawBaseNavigationContainer>
+      </RemovalPreventionProvider>
     </RoutingQueueProvider>
   );
 
@@ -240,18 +235,16 @@ test('handle dispatching with ref', () => {
 
   const element = (
     <RoutingQueueProvider>
-      <RouterRegistryProvider>
-        <RemovalPreventionProvider>
-          <RawBaseNavigationContainer ref={ref} initialState={initialState}>
-            <RootNavigator>
-              <Screen name="foo">{() => null}</Screen>
-              <Screen name="foo2">{() => null}</Screen>
-              <Screen name="bar">{() => null}</Screen>
-              <Screen name="baz">{() => null}</Screen>
-            </RootNavigator>
-          </RawBaseNavigationContainer>
-        </RemovalPreventionProvider>
-      </RouterRegistryProvider>
+      <RemovalPreventionProvider>
+        <RawBaseNavigationContainer ref={ref} initialState={initialState}>
+          <RootNavigator>
+            <Screen name="foo">{() => null}</Screen>
+            <Screen name="foo2">{() => null}</Screen>
+            <Screen name="bar">{() => null}</Screen>
+            <Screen name="baz">{() => null}</Screen>
+          </RootNavigator>
+        </RawBaseNavigationContainer>
+      </RemovalPreventionProvider>
     </RoutingQueueProvider>
   );
 
@@ -818,8 +811,7 @@ test('warns for duplicate route names nested inside each other', () => {
         </Screen>
         <Screen name="bar" component={TestScreen} />
       </TestNavigator>
-    </BaseNavigationContainer>,
-    { wrapper: RouterRegistryProvider }
+    </BaseNavigationContainer>
   );
 
   expect(spy.mock.calls[0]![0]).toMatch(
@@ -846,8 +838,7 @@ test('warns for duplicate route names nested inside each other', () => {
           )}
         </Screen>
       </TestNavigator>
-    </BaseNavigationContainer>,
-    { wrapper: RouterRegistryProvider }
+    </BaseNavigationContainer>
   );
 
   expect(spy.mock.calls[1]![0]).toMatch(
@@ -868,8 +859,7 @@ test('warns for duplicate route names nested inside each other', () => {
           )}
         </Screen>
       </TestNavigator>
-    </BaseNavigationContainer>,
-    { wrapper: RouterRegistryProvider }
+    </BaseNavigationContainer>
   );
 
   expect(spy).toHaveBeenCalledTimes(2);

--- a/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { nanoid } from 'nanoid/non-secure';
 
 import { RemovalPreventionProvider } from '../../../../global-state/removalPrevention';
-import { RouterRegistryProvider } from '../../../../global-state/routerRegistry';
 import { RoutingQueueProvider } from '../../../../global-state/routingQueueContext';
 import useLatestCallback from '../../../../utils/useLatestCallback';
 import type { NavigationState, ParamListBase, PartialState } from '../../../routers';
@@ -157,15 +156,13 @@ export function BaseNavigationContainer(props: Props) {
 
   return (
     <RoutingQueueProvider>
-      <RouterRegistryProvider>
-        <RemovalPreventionProvider>
-          <BaseNavigationContainerImpl
-            {...rest}
-            ref={setRef}
-            initialState={completeState(rest.initialState, rest.children)}
-          />
-        </RemovalPreventionProvider>
-      </RouterRegistryProvider>
+      <RemovalPreventionProvider>
+        <BaseNavigationContainerImpl
+          {...rest}
+          ref={setRef}
+          initialState={completeState(rest.initialState, rest.children)}
+        />
+      </RemovalPreventionProvider>
     </RoutingQueueProvider>
   );
 }

--- a/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/NavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/NavigationContainer.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { NavigationContainer as NavigationContainerImpl } from '../../../../fork/NavigationContainer';
 import { getStateFromPath, type ResultState } from '../../../../fork/getStateFromPath';
 import { RemovalPreventionProvider } from '../../../../global-state/removalPrevention';
-import { RouterRegistryProvider } from '../../../../global-state/routerRegistry';
 import { RoutingQueueProvider } from '../../../../global-state/routingQueueContext';
 import type { NavigationState } from '../../../routers';
 
@@ -35,11 +34,9 @@ export const NavigationContainer = React.forwardRef(function NavigationContainer
 
   return (
     <RoutingQueueProvider>
-      <RouterRegistryProvider>
-        <RemovalPreventionProvider>
-          <NavigationContainerImpl {...props} linking={linkingWithInitialState} ref={ref} />
-        </RemovalPreventionProvider>
-      </RouterRegistryProvider>
+      <RemovalPreventionProvider>
+        <NavigationContainerImpl {...props} linking={linkingWithInitialState} ref={ref} />
+      </RemovalPreventionProvider>
     </RoutingQueueProvider>
   );
 });

--- a/packages/expo-router/src/react-navigation/core/__tests__/actionBubbling.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/actionBubbling.test.ios.tsx
@@ -712,10 +712,7 @@ test("prevents removing a screen with 'removePrevented' event", () => {
     setPreventRemove(false);
   });
 
-  expect(onStateChange).toHaveBeenCalledTimes(2);
-
-  act(() => ref.current?.dispatchSync(StackActions.popTo('foo')));
-
+  // The screen re-dispatches the blocked action with this render's removal-prevention state.
   expect(onStateChange).toHaveBeenCalledTimes(3);
   expect(onStateChange).toHaveBeenCalledWith({
     type: 'stack',

--- a/packages/expo-router/src/react-navigation/core/__tests__/removePrevented.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/removePrevented.test.ios.tsx
@@ -1,7 +1,6 @@
 import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
-import { RouterRegistryProvider } from '../../../global-state/routerRegistry';
 import { CommonActions, type ParamListBase, StackActions, StackRouter } from '../../routers';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
@@ -102,8 +101,7 @@ test.skip('blocks synchronous redispatch from removePrevented without re-emittin
         <Screen name="foo">{() => null}</Screen>
         <Screen name="bar" component={TestScreen} />
       </TestNavigator>
-    </BaseNavigationContainer>,
-    { wrapper: RouterRegistryProvider }
+    </BaseNavigationContainer>
   );
 
   act(() => ref.current?.navigate('bar'));

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -8,8 +8,7 @@ import { useRouteNode } from '../../Route';
 import { useComponent } from '../../fork/useComponent';
 import { type RouterRegistryEntry, useRegisterRouter } from '../../global-state/routerRegistry';
 import { useEnqueueRoutingIntent } from '../../global-state/routingQueueContext';
-import { resetNavigatorState } from '../../global-state/stateUtils';
-import { findStateByKey } from '../../global-state/useNavigationTreeReducer';
+import { findStateByKey, resetNavigatorState } from '../../global-state/stateUtils';
 import useLatestCallback from '../../utils/useLatestCallback';
 import {
   type DefaultRouterOptions,
@@ -321,7 +320,7 @@ export function useNavigationBuilder<
     );
   }
 
-  // Screen-list changes invalidate render consumers even though the reducer reads committed config.
+  // Track screen-list changes without recalculating state when only the array identity changes.
   const routeNamesKey = routeNames.join('\0');
 
   const { state: currentState } = use(NavigationStateContext);
@@ -443,7 +442,7 @@ export function useNavigationBuilder<
         router.getStateForRouteFocus(registryState as State, routeKey),
       routeNode: routeNode ?? undefined,
     }),
-    [reduce, routeNode, routeNamesKey, router]
+    [reduce, routeNode, router]
   );
 
   useRegisterRouter(committedState.key, registryEntry);

--- a/packages/expo-router/src/ui/TabTrigger.tsx
+++ b/packages/expo-router/src/ui/TabTrigger.tsx
@@ -5,7 +5,8 @@ import type { View, PressableProps } from 'react-native';
 import { StyleSheet, Pressable } from 'react-native';
 
 import { appendBaseUrl } from '../fork/getPathFromState';
-import { RouterRegistryContext } from '../global-state/routerRegistry';
+import { useEnqueueRoutingIntent } from '../global-state/routingQueueContext';
+import { findStateByKey } from '../global-state/stateUtils';
 import { router } from '../imperative-api';
 import { shouldHandleMouseEvent } from '../link/useLinkToPathProps';
 import { stripGroupSegmentsFromPath } from '../matchers';
@@ -150,7 +151,7 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
   const { name, resetOnFocus, onPress, onLongPress } = options;
   const triggerMap = use(TabTriggerMapContext);
   const navigatorStates = use(TabNavigatorStatesContext);
-  const registry = use(RouterRegistryContext);
+  const enqueue = useEnqueueRoutingIntent();
 
   const getTrigger = useCallback(
     (name: string) => {
@@ -200,30 +201,40 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
         if (config.type === 'external') {
           return router.navigate(config.href);
         } else {
-          if (!registry) {
-            throw new Error('Router registry is unavailable. This is likely a bug in expo-router.');
-          }
           const owningState = navigatorStates[config.contextKey];
           if (!owningState) {
             return;
           }
-          const action = buildTabAction(config, owningState, registry, options?.resetOnFocus);
-          return navigation?.dispatchSync(
-            config.contextKey !== contextKey
-              ? { ...action, target: action.target ?? owningState.key }
-              : action
-          );
+          return enqueue({
+            type: 'COMPUTED_ACTION',
+            payload: {
+              originKey: state.key,
+              compute(rootState, registry) {
+                const currentOwningState = findStateByKey(rootState, owningState.key);
+                if (!currentOwningState) {
+                  return;
+                }
+                const action = buildTabAction(
+                  config,
+                  currentOwningState,
+                  registry,
+                  options?.resetOnFocus
+                );
+                return config.contextKey !== contextKey
+                  ? { ...action, target: action.target ?? currentOwningState.key }
+                  : action;
+              },
+            },
+          });
         }
       } else {
-        return navigation?.dispatchSync({
+        return navigation?.dispatch({
           type: 'JUMP_TO',
-          payload: {
-            name,
-          },
+          payload: { name },
         });
       }
     },
-    [contextKey, navigation, navigatorStates, registry, triggerMap]
+    [contextKey, enqueue, navigation, navigatorStates, state.key, triggerMap]
   );
 
   const handleOnPress = useCallback<NonNullable<PressableProps['onPress']>>(


### PR DESCRIPTION
# Why

At the moment we need to have context to pass data from router registry to reducer. This creates unnecessary re-renders and breaks streaming SSR with suspense. 

# How

1. Remove `RouterRegistryProvider`
2. Move `RouterRegistry` state to `BaseNavigationContainer` and create stable `registrySetters` there as well. This removes the need for context since both the reducer and registry are stored in the same component
4. This move additionally let use use state time set state for when a navigator is unmounted, making the change synchronous and reducing number of renders

# Test Plan

1. CI
2. router-tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)