### PR TITLE
[router] Order tabs by `.Trigger` order during initial render

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -98,6 +98,7 @@ jobs:
             "packages/expo-image/**/android/**",
             "packages/expo-keep-awake/**/android/**",
             "packages/expo-localization/**/android/**",
+            "packages/expo-router/**/android/**",
             "packages/expo-sqlite/**/android/**",
             "packages/expo-video/**/android/**",
             "apps/bare-expo/**/android/**"
@@ -114,6 +115,7 @@ jobs:
             "packages/expo-image/**/ios/**",
             "packages/expo-keep-awake/**/ios/**",
             "packages/expo-localization/**/ios/**",
+            "packages/expo-router/**/ios/**",
             "packages/expo-sqlite/**/ios/**",
             "packages/expo-video/**/ios/**",
             "apps/bare-expo/**/ios/**"
@@ -135,6 +137,7 @@ jobs:
             "packages/expo-image/**",
             "packages/expo-keep-awake/**",
             "packages/expo-localization/**",
+            "packages/expo-router/**",
             "packages/expo-sqlite/**",
             "packages/expo-video/**",
             pnpm-lock.yaml,

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -71,6 +71,7 @@
 
 ### 🐛 Bug fixes
 
+- Oder tabs by `.Trigger` order during initial render ([#49848](https://github.com/expo/expo/pull/49848) by [@Ubax](https://github.com/Ubax))
 - Prevent Native Tabs from remounting the focused tab while preloading other tabs after a cold-start deep link. (by [@Ubax](https://github.com/Ubax)) ([#49811](https://github.com/expo/expo/pull/49811) by [@Ubax](https://github.com/Ubax))
 - Re-export the vendored JavaScript stack API from `expo-router/js-stack`. ([#49657](https://github.com/expo/expo/pull/49657) by [@davidmokos](https://github.com/davidmokos))
 - Fix `useLoaderData()` throwing "Update hook called on initial render" when React replays a suspended route after its loader settles during a transition. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/hmr-route-changes.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/hmr-route-changes.test.ios.tsx
@@ -245,10 +245,7 @@ it('repairs top tabs state when all screen files are replaced', () => {
   const state = result.getRouterState()!.routes[0]!.state!;
   expect(state.routeNames).toStrictEqual(['third', 'fourth']);
   expect(state.routes.map((route) => route.name)).toStrictEqual(['third', 'fourth']);
-  // TODO: Assert that this warning is not called once HMR state and descriptors reconcile together.
-  expect(warn).toHaveBeenCalledWith(
-    'No screens are declared in ./_layout.js, so the navigator renders nothing. Only screens declared in the layout become visible. Declare each screen you want to show, for example <Tabs.Screen name="index" /> or <NativeTabs.Trigger name="index" />. Undeclared routes: index, second.'
-  );
+  expect(warn).not.toHaveBeenCalled();
   warn.mockRestore();
 });
 

--- a/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.android.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.android.tsx
@@ -7,7 +7,13 @@ import { renderRouter } from '../../testing-library';
 import { NativeTabs } from '../NativeTabs';
 import type { NativeTabsProps } from '../types';
 
+const mockTabsHostMount = jest.fn();
+const mockTabsHostUnmount = jest.fn();
+const mockScreenMount = jest.fn();
+const mockScreenUnmount = jest.fn();
+
 jest.mock('react-native-screens', () => {
+  const React: typeof import('react') = jest.requireActual('react');
   const { View }: typeof import('react-native') = jest.requireActual('react-native');
   const actualModule = jest.requireActual(
     'react-native-screens'
@@ -16,7 +22,13 @@ jest.mock('react-native-screens', () => {
     ...actualModule,
     Tabs: {
       ...actualModule.Tabs,
-      Host: jest.fn(({ children }) => <View testID="TabsHost">{children}</View>),
+      Host: jest.fn(({ children }) => {
+        React.useEffect(() => {
+          mockTabsHostMount();
+          return () => mockTabsHostUnmount();
+        }, []);
+        return <View testID="TabsHost">{children}</View>;
+      }),
       Screen: jest.fn(({ children }) => <View testID="TabsScreen">{children}</View>),
     },
   };
@@ -24,6 +36,52 @@ jest.mock('react-native-screens', () => {
 
 const TabsHost = Tabs.Host as jest.MockedFunction<typeof Tabs.Host>;
 const TabsScreen = Tabs.Screen as jest.MockedFunction<typeof Tabs.Screen>;
+
+it('mounts deep-linked tabs in Trigger order without remounting', () => {
+  function TrackedScreen({ name }: { name: string }) {
+    React.useEffect(() => {
+      mockScreenMount(name);
+      return () => mockScreenUnmount(name);
+    }, [name]);
+    return <View testID={name} />;
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <NativeTabs>
+          <NativeTabs.Trigger name="test-suite" />
+          <NativeTabs.Trigger name="playground" />
+          <NativeTabs.Trigger name="apis" />
+          <NativeTabs.Trigger name="components" />
+        </NativeTabs>
+      ),
+      'test-suite': () => <TrackedScreen name="test-suite" />,
+      playground: () => <TrackedScreen name="playground" />,
+      apis: () => <TrackedScreen name="apis" />,
+      components: () => <TrackedScreen name="components" />,
+    },
+    { initialUrl: '/apis' }
+  );
+
+  expect(mockTabsHostMount).toHaveBeenCalledTimes(1);
+  expect(mockTabsHostUnmount).not.toHaveBeenCalled();
+  expect(TabsScreen.mock.calls.slice(0, 4).map(([props]) => props.screenKey)).toEqual([
+    'test-suite',
+    'playground',
+    'apis',
+    'components',
+  ]);
+  expect(mockScreenMount.mock.calls.map(([name]) => name)).toEqual([
+    // The deep-linked route has real content before the other tabs finish preloading.
+    'apis',
+    'test-suite',
+    'playground',
+    'components',
+  ]);
+  expect(mockScreenUnmount).not.toHaveBeenCalled();
+  expect(TabsHost.mock.calls[0][0].navStateRequest?.selectedScreenKey).toBe('apis');
+});
 
 it.each([
   { value: undefined, expected: false },

--- a/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.android.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.android.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, screen } from '@testing-library/react-native';
 import React from 'react';
 import { Button, View } from 'react-native';
-import { Tabs, type TabsHostProps } from 'react-native-screens';
+import { Tabs, type TabsHostProps, type TabsScreenProps } from 'react-native-screens';
 
 import { renderRouter } from '../../testing-library';
 import { NativeTabs } from '../NativeTabs';
@@ -66,12 +66,9 @@ it('mounts deep-linked tabs in Trigger order without remounting', () => {
 
   expect(mockTabsHostMount).toHaveBeenCalledTimes(1);
   expect(mockTabsHostUnmount).not.toHaveBeenCalled();
-  expect(TabsScreen.mock.calls.slice(0, 4).map(([props]) => props.screenKey)).toEqual([
-    'test-suite',
-    'playground',
-    'apis',
-    'components',
-  ]);
+  expect(
+    TabsScreen.mock.calls.slice(0, 4).map(([props]: [TabsScreenProps]) => props.screenKey)
+  ).toEqual(['test-suite', 'playground', 'apis', 'components']);
   expect(mockScreenMount.mock.calls.map(([name]) => name)).toEqual([
     // The deep-linked route has real content before the other tabs finish preloading.
     'apis',

--- a/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
@@ -245,8 +245,8 @@ describe('First focused tab', () => {
     expect(screen.getByTestId('index')).toBeVisible();
     expect(screen.getByTestId('second')).toBeVisible();
     expect(TabsScreen).toHaveBeenCalledTimes(4);
-    expect(TabsScreen.mock.calls[0][0].screenKey).toBe('index');
-    expect(TabsScreen.mock.calls[1][0].screenKey).toBe('second');
+    expect(TabsScreen.mock.calls[0][0].screenKey).toBe('second');
+    expect(TabsScreen.mock.calls[1][0].screenKey).toBe('index');
     expect(TabsHost).toHaveBeenCalledTimes(2);
     expect(TabsHost.mock.calls[0][0].navStateRequest.selectedScreenKey).toBe('index');
   });

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -347,10 +347,13 @@ export function useNavigationBuilder<
   const committedState = (
     isForeignType ? resetNavigatorState(treeState, router.type) : treeState
   ) as State;
-  const state = React.useMemo(
-    () => router.getStateForDeclaredRoutes(committedState, routeNames),
-    [committedState, routeNamesKey, router]
-  );
+  const state = React.useMemo(() => {
+    const declaredState = router.getStateForDeclaredRoutes(committedState, routeNames);
+    // The seeded state cannot know the order declared by mounted screens yet.
+    return isArrayEqual(declaredState.routeNames, routeNames)
+      ? declaredState
+      : { ...declaredState, routeNames };
+  }, [committedState, routeNamesKey, router]);
   const reduce = useLatestCallback<RouterRegistryEntry['reduce']>((registryState, action) =>
     // The registry stores states from different router types; this entry only receives its own state key.
     router.getStateForAction(registryState as State, action, {


### PR DESCRIPTION
# Why

At the moment native tabs are ordered using routes order during the initial render. This breaks the tabs on Android when `.Trigger` order is different then the filesystem one.

# How

1. Use user-defined order of `routeNames` during initial render

# Test Plan

1. CI
2. bare-expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
