### PR TITLE
[ios][glass-effect] Ignore the compatibility flag on the iOS 27 SDK

### DIFF
--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Report `isLiquidGlassAvailable` as `true` in apps built with the iOS 27 SDK, which ignores `UIDesignRequiresCompatibility`. ([#49850](https://github.com/expo/expo/pull/49850) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 57.0.1 - 2026-07-15

--- a/packages/expo-glass-effect/ios/GlassEffectModule.swift
+++ b/packages/expo-glass-effect/ios/GlassEffectModule.swift
@@ -2,6 +2,22 @@
 
 import ExpoModulesCore
 
+/**
+ Major version of the SDK the app was built with, read from the `DTPlatformVersion` that Xcode
+ stamps into the app's Info.plist. Returns 0 for a bundle Xcode didn't stamp, so callers fall back
+ to the behavior of the older SDK.
+
+ Read at runtime rather than through `#if compiler(...)` because the Swift version and the SDK
+ version don't move together: Xcode 26.6 already ships Swift 6.3.
+ */
+private func buildSDKMajorVersion() -> Int {
+  guard let platformVersion = Bundle.main.infoDictionary?["DTPlatformVersion"] as? String,
+    let major = Int(platformVersion.prefix { $0.isNumber }) else {
+    return 0
+  }
+  return major
+}
+
 public final class GlassEffectModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoGlassEffect")
@@ -9,9 +25,13 @@ public final class GlassEffectModule: Module {
     Constant("isLiquidGlassAvailable") {
       #if compiler(>=6.2)  // Xcode 26
       if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *) {  // iOS 26
+        // The system ignores `UIDesignRequiresCompatibility` in apps built with the iOS 27 SDK, so
+        // for those the opt-out below no longer describes what the app renders.
+        if #available(iOS 27.0, tvOS 27.0, macOS 27.0, *), buildSDKMajorVersion() >= 27 {  // iOS 27
+          return true
+        }
         if let infoPlist = Bundle.main.infoDictionary,
           let requiresCompatibility = infoPlist["UIDesignRequiresCompatibility"] as? Bool {
-          // TODO(@uabx): Add a check for maximum SDK version when apple disables this flag
           return !requiresCompatibility  // If the app requires compatibility then it will not use liquid glass
         }
         return true

--- a/packages/expo-glass-effect/ios/GlassEffectModule.swift
+++ b/packages/expo-glass-effect/ios/GlassEffectModule.swift
@@ -2,22 +2,6 @@
 
 import ExpoModulesCore
 
-/**
- Major version of the SDK the app was built with, read from the `DTPlatformVersion` that Xcode
- stamps into the app's Info.plist. Returns 0 for a bundle Xcode didn't stamp, so callers fall back
- to the behavior of the older SDK.
-
- Read at runtime rather than through `#if compiler(...)` because the Swift version and the SDK
- version don't move together: Xcode 26.6 already ships Swift 6.3.
- */
-private func buildSDKMajorVersion() -> Int {
-  guard let platformVersion = Bundle.main.infoDictionary?["DTPlatformVersion"] as? String,
-    let major = Int(platformVersion.prefix { $0.isNumber }) else {
-    return 0
-  }
-  return major
-}
-
 public final class GlassEffectModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoGlassEffect")
@@ -123,4 +107,20 @@ public final class GlassEffectModule: Module {
       }
     }
   }
+}
+
+/**
+ Major version of the SDK the app was built with, read from the `DTPlatformVersion` that Xcode
+ stamps into the app's Info.plist. Returns 0 for a bundle Xcode didn't stamp, so callers fall back
+ to the behavior of the older SDK.
+
+ Read at runtime rather than through `#if compiler(...)` because the Swift version and the SDK
+ version don't move together: Xcode 26.6 already ships Swift 6.3.
+ */
+private func buildSDKMajorVersion() -> Int {
+  guard let platformVersion = Bundle.main.infoDictionary?["DTPlatformVersion"] as? String,
+    let major = Int(platformVersion.prefix { $0.isNumber }) else {
+    return 0
+  }
+  return major
 }


### PR DESCRIPTION
# Why

`expo-glass-effect` reports `isLiquidGlassAvailable` by reading the app's `UIDesignRequiresCompatibility` Info.plist key, which was the iOS 26 opt-out from Liquid Glass. iOS 27 ignores that key: apps built with the iOS 27 SDK get Liquid Glass whether or not they set it.

So an app that opted out under iOS 26 and rebuilds with the iOS 27 SDK renders Liquid Glass while `isLiquidGlassAvailable` returns `false`. Any JS branching on that constant picks the wrong layout.

The code carried a `TODO(@uabx)` for exactly this case.

# How

Return `true` when the app both runs on iOS 27+ and was built with the 27+ SDK. Below that, the flag still describes the runtime, so the existing check is unchanged.

The SDK version is read at runtime from `DTPlatformVersion`, which Xcode stamps into the app's Info.plist, rather than through `#if compiler(...)`. The Swift version and the SDK version don't move together: Xcode 26.6 already ships Swift 6.3, so a `compiler(>=6.4)` gate could start matching on an Xcode 26 point release and misfire. `DTPlatformVersion` names the SDK directly.

An unstamped bundle reads as `0` and falls through to the existing behavior.

# Test Plan

Xcode 27 is not on the build machine, so the iOS 27 path was verified by compiling and running the logic in isolation against the iOS SDK rather than in an app.

`#available(iOS 27.0, tvOS 27.0, macOS 27.0, *)` and the new helper type-check on the current toolchain (Swift 6.3.3, iOS 26.6 SDK):

```
$ xcrun swiftc -typecheck -sdk $(xcrun --sdk iphoneos --show-sdk-path) -target arm64-apple-ios16.4 glasscheck.swift
TYPECHECK OK
```

`DTPlatformVersion` parsing, run natively over the shapes Xcode writes:

```
27.0 -> 27
26.2 -> 26
26.6 -> 26
15.2 -> 15
27 -> 27
(empty) -> 0
abc -> 0
```

The key is present and holds the SDK version in real bundles:

```
$ /usr/libexec/PlistBuddy -c "Print :DTPlatformVersion" /Applications/Safari.app/Contents/Info.plist
26.2
$ /usr/libexec/PlistBuddy -c "Print :DTPlatformVersion" /Applications/Keynote.app/Contents/Info.plist
15.2
```

To reproduce on a machine with Xcode 27: set `UIDesignRequiresCompatibility` to `true` in an app's Info.plist, build against the iOS 27 SDK, run on iOS 27, and read `isLiquidGlassAvailable`. Before this change it is `false` while the app visibly renders Liquid Glass; after, it is `true`.

# Checklist

- [x] Added a `CHANGELOG.md` entry
- [ ] Verified with `et check-packages` (native-only change; no JS surface changed)
- [ ] Built against Xcode 27 (not available on the build machine, see Test Plan)
- [x] Conforms to the documentation style guide
