### PR TITLE
[ios][core] Read the status bar from its scene

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Quote script-phase paths so iOS builds work from a project path containing a space. ([#48747](https://github.com/expo/expo/pull/48747) by [@expo-bot](https://github.com/expo-bot))
+- [iOS] Read the status bar from its scene, so `statusBarHeight` isn't NaN in apps built with the iOS 27 SDK. ([#49851](https://github.com/expo/expo/pull/49851) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-constants/ios/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstantsService.m
@@ -11,6 +11,31 @@
 NSString * const EXConstantsExecutionEnvironmentBare = @"bare";
 NSString * const EXConstantsExecutionEnvironmentStoreClient = @"storeClient";
 
+#if TARGET_OS_IOS
+/**
+ The status bar belongs to a scene, so it has to be read from one. The `UIApplication` accessors
+ return NaN in apps built with the iOS 27 SDK, and they can't describe a resizable window anyway.
+ Mirrors `SceneGeometry` in ExpoModulesCore, which this file can't reach from Objective-C.
+ */
+static UIWindowScene *EXConstantsForegroundWindowScene(void)
+{
+  UIWindowScene *fallbackScene = nil;
+  for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+    if (![scene isKindOfClass:[UIWindowScene class]]) {
+      continue;
+    }
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+      return windowScene;
+    }
+    if (fallbackScene == nil) {
+      fallbackScene = windowScene;
+    }
+  }
+  return fallbackScene;
+}
+#endif
+
 @interface EXConstantsService ()
 
 @property (nonatomic, strong) NSString *sessionId;
@@ -62,9 +87,9 @@ EX_REGISTER_MODULE();
 - (CGFloat)statusBarHeight
 {
 #if TARGET_OS_IOS
-  __block CGSize statusBarSize;
+  __block CGSize statusBarSize = CGSizeZero;
   [EXUtilities performSynchronouslyOnMainThread:^{
-    statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
+    statusBarSize = EXConstantsForegroundWindowScene().statusBarManager.statusBarFrame.size;
   }];
   return MIN(statusBarSize.width, statusBarSize.height);
 #elif TARGET_OS_OSX || TARGET_OS_TV

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Fix a failed crop resolving with the uncropped original image instead of rejecting when `allowsEditing` is `true`. ([#48524](https://github.com/expo/expo/issues/48524) by [@aashishshrestha5532](https://github.com/aashishshrestha5532), [#48541](https://github.com/expo/expo/pull/48541) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the video `PHAssetResourceManager` fast path rejecting instead of falling back to the slower path that can fetch iCloud assets, and pass `shouldDownloadFromNetwork` through when reading Live Photo resources. As a result, a video whose data is not stored locally is now downloaded through the fallback path even when `shouldDownloadFromNetwork` is `false` and `videoExportPreset` is `Passthrough`. ([#48658](https://github.com/expo/expo/issues/48658) by [@gcampoyf-cloud](https://github.com/gcampoyf-cloud), [#48794](https://github.com/expo/expo/pull/48794) by [@expo-bot](https://github.com/expo-bot))
 - [iOS] Fix picking a video terminating apps that ship no `NSPhotoLibraryUsageDescription` by only taking the `PHAssetResourceManager` fast path when photo library read access has already been granted. ([#49362](https://github.com/expo/expo/pull/49362) by [@OlegBezr](https://github.com/OlegBezr))
+- [iOS] Read status bar visibility from the scene, so hiding and restoring it still works in apps built with the iOS 27 SDK. ([#49851](https://github.com/expo/expo/pull/49851) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/StatusBarVisibilityController.swift
+++ b/packages/expo-image-picker/ios/StatusBarVisibilityController.swift
@@ -1,5 +1,8 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
+import UIKit
+import ExpoModulesCore
+
 /**
  Since iOS 11, launching ImagePicker with `allowsEditing` option makes cropping rectangle
  slightly moved upwards, because of StatusBar visibility.
@@ -10,7 +13,7 @@ internal class StatusBarVisibilityController {
   private var shouldRestoreStatusBarVisibility = false
 
   func maybePreserveVisibilityAndHideStatusBar(_ shouldHideStatusBar: Bool) {
-    guard shouldHideStatusBar && !UIApplication.shared.isStatusBarHidden else {
+    guard shouldHideStatusBar && !SceneGeometry.isStatusBarHidden() else {
       return
     }
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [iOS] Measure hosted React Native views where SwiftUI placed them, instead of at their Yoga box. ([#48969](https://github.com/expo/expo/pull/48969) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Measure hosted React Native views where Jetpack Compose placed them, instead of at their Yoga box. ([#48970](https://github.com/expo/expo/pull/48970) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Bump the Gradle plugin's Kotlin version to 2.2.21. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Read the status bar from its scene, so `Constants.statusBarHeight` isn't NaN in apps built with the iOS 27 SDK. ([#49851](https://github.com/expo/expo/pull/49851) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Tests/SceneGeometryTests.swift
+++ b/packages/expo-modules-core/ios/Tests/SceneGeometryTests.swift
@@ -69,6 +69,34 @@ struct SceneGeometryTests {
     // environment is available.
     #expect(SceneGeometry.displayScale(for: UIView()) > 0)
   }
+
+#if os(iOS)
+  @Test
+  func `status bar frame is never NaN`() {
+    // `UIApplication.statusBarFrame` returns NaN in apps built with the iOS 27 SDK, and the value
+    // reaches JS through `Constants.statusBarHeight`.
+    let size = SceneGeometry.statusBarFrame().size
+    #expect(!size.width.isNaN)
+    #expect(!size.height.isNaN)
+  }
+
+  @Test
+  func `status bar frame is zero while the status bar is hidden`() {
+    guard SceneGeometry.isStatusBarHidden() else {
+      return
+    }
+    #expect(SceneGeometry.statusBarFrame() == .zero)
+  }
+
+  @Test
+  func `status bar reads fall back to hidden when no scene serves them`() {
+    // Callers restore a status bar they hid, so a missing scene has to read as hidden rather
+    // than as shown-with-an-empty-frame.
+    let manager = SceneGeometry.statusBarManager()
+    #expect(SceneGeometry.statusBarFrame() == (manager?.statusBarFrame ?? .zero))
+    #expect(SceneGeometry.isStatusBarHidden() == (manager?.isStatusBarHidden ?? true))
+  }
+#endif
 }
 
 #endif

--- a/packages/expo-modules-core/ios/Utilities/ConstantsProvider.swift
+++ b/packages/expo-modules-core/ios/Utilities/ConstantsProvider.swift
@@ -48,7 +48,7 @@ private func getBuildVersion() -> String? {
 @MainActor
 private func getStatusBarHeight() -> Double {
   #if os(iOS)
-  let statusBarSize = UIApplication.shared.statusBarFrame.size
+  let statusBarSize = SceneGeometry.statusBarFrame().size
   return min(statusBarSize.width, statusBarSize.height)
   #else
   return 0

--- a/packages/expo-modules-core/ios/Utilities/SceneGeometry.swift
+++ b/packages/expo-modules-core/ios/Utilities/SceneGeometry.swift
@@ -79,6 +79,25 @@ public extension SceneGeometry {
   static func interfaceOrientation(for view: UIView? = nil) -> UIInterfaceOrientation {
     return windowScene(for: view)?.effectiveGeometry.interfaceOrientation ?? .unknown
   }
+
+  /**
+   The status bar belongs to a scene, so it has to be read from one. The `UIApplication` accessors
+   return NaN or null in apps built with the iOS 27 SDK, and they can't describe a resizable window
+   anyway. Nil when no scene is connected.
+   */
+  static func statusBarManager(for view: UIView? = nil) -> UIStatusBarManager? {
+    return windowScene(for: view)?.statusBarManager
+  }
+
+  /// `.zero` when the status bar is hidden or no scene is connected.
+  static func statusBarFrame(for view: UIView? = nil) -> CGRect {
+    return statusBarManager(for: view)?.statusBarFrame ?? .zero
+  }
+
+  /// Treats a missing scene as hidden, so callers don't try to restore a status bar that isn't shown.
+  static func isStatusBarHidden(for view: UIView? = nil) -> Bool {
+    return statusBarManager(for: view)?.isStatusBarHidden ?? true
+  }
 }
 #endif
 


### PR DESCRIPTION
# Why

`UIApplication`'s status bar accessors are deprecated, and in apps built with the iOS 27 SDK they return NaN or null. They also can't describe a resizable window, since the status bar belongs to a scene.

Three call sites still read them:

- `ConstantsProvider.getStatusBarHeight()` and `EXConstantsService.statusBarHeight` both feed `Constants.statusBarHeight`, which would reach JS as `NaN`.
- `expo-image-picker`'s `StatusBarVisibilityController` reads `isStatusBarHidden` to decide whether to hide and later restore the status bar. A wrong read there reintroduces the cropping-rectangle displacement the controller exists to prevent (https://forums.developer.apple.com/thread/98274).

This continues the scene work from #48168 and #48319.

# How

Adds `statusBarManager(for:)`, `statusBarFrame(for:)`, and `isStatusBarHidden(for:)` to `SceneGeometry`, alongside the geometry lookups already there, and moves the Swift callers onto them.

A missing scene reads as hidden with a zero frame. That direction matters for image-picker: treating "no scene" as visible would make it try to restore a status bar it never hid.

`EXConstantsService` resolves the scene inline. It's Objective-C and can't reach the Swift `SceneGeometry` enum; the duplication is noted in a comment there.

# Test Plan

Three tests added to `SceneGeometryTests`, the first covering the regression directly:

- status bar frame is never NaN
- status bar frame is zero while the status bar is hidden
- status bar reads fall back to hidden when no scene serves them

The changed files type-check against the iOS SDK:

```
$ xcrun swiftc -typecheck -sdk $(xcrun --sdk iphoneos --show-sdk-path) -target arm64-apple-ios16.4 \
    packages/expo-modules-core/ios/Utilities/SceneGeometry.swift
TYPECHECK OK

$ xcrun clang -fsyntax-only -fobjc-arc -isysroot $(xcrun --sdk iphoneos --show-sdk-path) \
    -target arm64-apple-ios16.4 -Wall -Werror scenecheck.m
OBJC OK
```

Manually: read `Constants.statusBarHeight` in an app built with the iOS 27 SDK, and run image-picker with `allowsEditing` on a device where the status bar is visible.

Run on an iPhone 17 Pro simulator, Xcode 26.6:

```
◇ Test "status bar frame is zero while the status bar is hidden" started.
◇ Test "status bar frame is never NaN" started.
◇ Test "status bar reads fall back to hidden when no scene serves them" started.
✔ Test "status bar frame is zero while the status bar is hidden" passed after 29.612 seconds.
✔ Test "status bar frame is never NaN" passed after 29.612 seconds.
✔ Test "status bar reads fall back to hidden when no scene serves them" passed after 29.612 seconds.
✔ Test run with 790 tests in 106 suites passed after 34.602 seconds.
** TEST SUCCEEDED **
```

Note on what that does and doesn't prove: `status bar frame is never NaN` passes against the old
code too, because the NaN only appears when the app is built with the iOS 27 SDK, which isn't
available on the machine this ran on. The test pins the property for whoever next builds against
that SDK; it is not evidence the bug is fixed. The other two cover the new fallback contract.

`et native-unit-tests --packages expo-modules-core` currently fails on this machine for an
unrelated reason: `ExpoModulesWorklets-Unit-Tests` fails to link with C++ stdlib undefined
symbols under `EXPO_USE_SOURCE=1`, and it shares the generated scheme, so it cancels the run
before the core tests execute. Running the core scheme directly avoids it.

# Checklist

- [x] Added a `CHANGELOG.md` entry
- [x] Added tests
- [x] Verified with `ExpoModulesCore-Unit-Tests`: 790 tests in 106 suites passed, including the three added above
- [x] Conforms to the documentation style guide
