### PR TITLE
Add inactive tint color to tab bar options

### DIFF
--- a/docs/pages/tutorial/add-navigation.mdx
+++ b/docs/pages/tutorial/add-navigation.mdx
@@ -285,7 +285,7 @@ Modify the **src/app/(tabs)/\_layout.tsx** file to add tab bar icons:
 
 1. Import `Ionicons` icons set from [`@expo/vector-icons`](/guides/icons/#expovector-icons) — a library that includes popular icon sets.
 2. Add the `tabBarIcon` to both the `index` and `about` routes. This function takes `focused` and `color` as params and renders the icon component. From the icon set, we can provide custom icon names.
-3. Add `screenOptions.tabBarActiveTintColor` to the `Tabs` component and set its value to `#ffd33d`. This will change the color of the tab bar icon and label when active.
+3. Add `screenOptions.tabBarActiveTintColor` and `screenOptions.tabBarInactiveTintColor` to the `Tabs` component and set their values to `#ffd33d` and `#fff`, respectively. These options change the color of the tab bar icon and label when active and inactive.
 
 {/* prettier-ignore */}
 ```tsx src/app/(tabs)/_layout.tsx
@@ -300,6 +300,7 @@ export default function TabLayout() {
       /* @tutinfo There are many `screenOptions` we can use to customize the tab bar. We're changing the active tab color here to custom value which we will also use later in our app. */
       screenOptions={{
         tabBarActiveTintColor: '#ffd33d',
+        tabBarInactiveTintColor: '#fff',
       }}
       /* @end */
     >
@@ -336,6 +337,7 @@ Let's also change the background color of the tab bar and header using `screenOp
 <Tabs
   screenOptions={{
     tabBarActiveTintColor: '#ffd33d',
+    tabBarInactiveTintColor: '#fff',
     headerStyle: {
       backgroundColor: '#25292e',
     },


### PR DESCRIPTION
Adds tabBarInactiveTintColor to make inactive tab icons and labels visible against the dark tab bar background.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
