### PR TITLE
[file-system] Normalize default AbortSignal error message

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `File.downloadFileAsync()` returning a runtime-specific error message when canceled with an `AbortSignal`.
+- Fixed `File.downloadFileAsync()` returning a runtime-specific error message when canceled with an `AbortSignal`. ([#49856](https://github.com/expo/expo/pull/49856) by [@Ubax](https://github.com/Ubax))
 - Fix `File.readableStream()` returning zeroed bytes and writing past the requested region when a BYOB read targets a view that starts at a non-zero offset. ([#49234](https://github.com/expo/expo/pull/49234) by [@dennytosp](https://github.com/dennytosp))
 - [Android][iOS] Fix `File.size` returning `null` for a missing or unreadable file. ([#49086](https://github.com/expo/expo/pull/49086)) by [@ACHP](https://github.com/ACHP))
 - [iOS] Fix wrong permissions for text() and bytes(). ([#42422](https://github.com/expo/expo/pull/42422)) by [@simoneldevig](https://github.com/simoneldevig))

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `File.downloadFileAsync()` returning a runtime-specific error message when canceled with an `AbortSignal`.
 - Fix `File.readableStream()` returning zeroed bytes and writing past the requested region when a BYOB read targets a view that starts at a non-zero offset. ([#49234](https://github.com/expo/expo/pull/49234) by [@dennytosp](https://github.com/dennytosp))
 - [Android][iOS] Fix `File.size` returning `null` for a missing or unreadable file. ([#49086](https://github.com/expo/expo/pull/49086)) by [@ACHP](https://github.com/ACHP))
 - [iOS] Fix wrong permissions for text() and bytes(). ([#42422](https://github.com/expo/expo/pull/42422)) by [@simoneldevig](https://github.com/simoneldevig))

--- a/packages/expo-file-system/src/File.ts
+++ b/packages/expo-file-system/src/File.ts
@@ -361,8 +361,8 @@ export class File extends ExpoFileSystem.FileSystemFile implements Blob {
   }
 }
 
-function createAbortError(reason?: string): Error {
-  const error = new Error(reason ?? 'The operation was aborted.');
+function createAbortError(reason?: unknown): Error {
+  const error = new Error(typeof reason === 'string' ? reason : 'The operation was aborted.');
   error.name = 'AbortError';
   return error;
 }

--- a/packages/expo-file-system/src/__tests__/FSNetworkTasks-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FSNetworkTasks-test.native.ts
@@ -412,6 +412,22 @@ describe('DownloadTask', () => {
 });
 
 describe('AbortSignal integration', () => {
+  it('File.downloadFileAsync uses a stable message for the default reason', async () => {
+    const controller = new AbortController();
+    controller.abort(new DOMException('signal is aborted without reason', 'AbortError'));
+
+    const promise = File.downloadFileAsync(
+      'https://example.com/foo.bin',
+      new File(Paths.cache, 'aborted.bin'),
+      { signal: controller.signal }
+    );
+
+    await expect(promise).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'The operation was aborted.',
+    });
+  });
+
   beforeEach(() => {
     jest
       .spyOn(ExpoFileSystem.FileSystemUploadTask.prototype, 'start')


### PR DESCRIPTION
## Why

React Native 0.87.1 supplies a `DOMException` as the default `AbortSignal.reason`. `File.downloadFileAsync()` passed that object directly to the `Error` constructor, which made the resulting message runtime-specific and caused the three abort-related FileSystem test-suite specs to fail on both Android and iOS.

## How

Use a custom abort reason only when it is a string. Non-string reasons, including the default `DOMException`, now use the existing stable `The operation was aborted.` message.

## Test Plan

- `pnpm test src/__tests__/FSNetworkTasks-test.native.ts --runInBand`
- `pnpm test --runInBand`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint`
- `pnpm format --check`
- `pnpm depscheck`