### PR TITLE
[expo-image] Fix useImage not releasing loaded images

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed useImage not releasing loaded images when the source changes or the component unmounts.
+- Fixed useImage not releasing loaded images when the source changes or the component unmounts. ([#49857](https://github.com/expo/expo/pull/49857) by [@hirbod](https://github.com/hirbod))
 - [Android] Fixed a URL staying permanently broken after the server answered an image request with `200 OK` and a non-image body, such as an HTML error page. ([#48442](https://github.com/expo/expo/issues/48442) by [@julian-dueck](https://github.com/julian-dueck), [#48456](https://github.com/expo/expo/pull/48456) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [web] Fixed Expo Image's internal `dataSet` marker being overwritten by a user-provided `dataSet`. ([#48821](https://github.com/expo/expo/pull/48821) by [@Brentlok](https://github.com/Brentlok))
 - [iOS] Fixed `generateThumbhashAsync` crashing on images with extreme aspect ratios. ([#47189](https://github.com/expo/expo/issues/47189) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed useImage not releasing loaded images when the source changes or the component unmounts.
 - [Android] Fixed a URL staying permanently broken after the server answered an image request with `200 OK` and a non-image body, such as an HTML error page. ([#48442](https://github.com/expo/expo/issues/48442) by [@julian-dueck](https://github.com/julian-dueck), [#48456](https://github.com/expo/expo/pull/48456) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [web] Fixed Expo Image's internal `dataSet` marker being overwritten by a user-provided `dataSet`. ([#48821](https://github.com/expo/expo/pull/48821) by [@Brentlok](https://github.com/Brentlok))
 - [iOS] Fixed `generateThumbhashAsync` crashing on images with extreme aspect ratios. ([#47189](https://github.com/expo/expo/issues/47189) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-image/package.json
+++ b/packages/expo-image/package.json
@@ -43,6 +43,7 @@
     "sf-symbols-typescript": "^2.2.0"
   },
   "devDependencies": {
+    "@testing-library/react-native": "^13.3.0",
     "@types/jest": "^29.2.1",
     "@types/node": "^22.14.0",
     "@types/react": "~19.2.0",

--- a/packages/expo-image/src/__tests__/useImage-test.native.ts
+++ b/packages/expo-image/src/__tests__/useImage-test.native.ts
@@ -1,0 +1,89 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { Image } from '../Image';
+import type { ImageRef } from '../Image.types';
+import { useImage } from '../useImage';
+
+jest.mock('../Image', () => ({ Image: { loadAsync: jest.fn() } }));
+
+function createImageLoad() {
+  const image = { release: jest.fn() } as unknown as ImageRef;
+  const { promise, resolve } = Promise.withResolvers<ImageRef>();
+  return { image, promise, finish: () => resolve(image) };
+}
+
+afterEach(() => jest.resetAllMocks());
+
+it('releases the loaded image on unmount', async () => {
+  const load = createImageLoad();
+  jest.mocked(Image.loadAsync).mockReturnValueOnce(load.promise);
+  const { result, unmount } = renderHook(() => useImage('first.jpg'));
+
+  await act(async () => load.finish());
+  expect(result.current).toBe(load.image);
+  expect(load.image.release).not.toHaveBeenCalled();
+
+  unmount();
+  expect(load.image.release).toHaveBeenCalledTimes(1);
+});
+
+it('releases an image that finishes loading after unmount', async () => {
+  const load = createImageLoad();
+  jest.mocked(Image.loadAsync).mockReturnValueOnce(load.promise);
+  const { unmount } = renderHook(() => useImage('first.jpg'));
+
+  unmount();
+  expect(load.image.release).not.toHaveBeenCalled();
+  await act(async () => load.finish());
+  expect(load.image.release).toHaveBeenCalledTimes(1);
+});
+
+it('releases each loaded image when its source is replaced or unmounted', async () => {
+  const first = createImageLoad();
+  const second = createImageLoad();
+  jest
+    .mocked(Image.loadAsync)
+    .mockReturnValueOnce(first.promise)
+    .mockReturnValueOnce(second.promise);
+  const { result, rerender, unmount } = renderHook<ImageRef | null, { uri: string }>(
+    ({ uri }) => useImage(uri),
+    {
+      initialProps: { uri: 'first.jpg' },
+    }
+  );
+
+  await act(async () => first.finish());
+  rerender({ uri: 'second.jpg' });
+  expect(first.image.release).toHaveBeenCalledTimes(1);
+
+  await act(async () => second.finish());
+  expect(result.current).toBe(second.image);
+  expect(second.image.release).not.toHaveBeenCalled();
+  unmount();
+  expect(first.image.release).toHaveBeenCalledTimes(1);
+  expect(second.image.release).toHaveBeenCalledTimes(1);
+});
+
+it('releases a stale load without replacing the current image', async () => {
+  const first = createImageLoad();
+  const second = createImageLoad();
+  jest
+    .mocked(Image.loadAsync)
+    .mockReturnValueOnce(first.promise)
+    .mockReturnValueOnce(second.promise);
+  const { result, rerender, unmount } = renderHook<ImageRef | null, { uri: string }>(
+    ({ uri }) => useImage(uri),
+    {
+      initialProps: { uri: 'first.jpg' },
+    }
+  );
+
+  rerender({ uri: 'second.jpg' });
+  await act(async () => second.finish());
+  await act(async () => first.finish());
+  expect(result.current).toBe(second.image);
+  expect(first.image.release).toHaveBeenCalledTimes(1);
+  expect(second.image.release).not.toHaveBeenCalled();
+  unmount();
+  expect(second.image.release).toHaveBeenCalledTimes(1);
+});

--- a/packages/expo-image/src/useImage.ts
+++ b/packages/expo-image/src/useImage.ts
@@ -61,12 +61,16 @@ export function useImage(
     // We're doing some asynchronous action in this effect, so we should keep track
     // if the effect was already cleaned up. In that case, the async action shouldn't change the state.
     let isEffectValid = true;
+    let loadedImage: ImageRef | null = null;
 
     function loadImage() {
       Image.loadAsync(resolvedSource, options)
         .then((image) => {
           if (isEffectValid) {
+            loadedImage = image;
             setImage(image);
+          } else {
+            image.release();
           }
         })
         .catch((error) => {
@@ -90,7 +94,7 @@ export function useImage(
     return () => {
       // Invalidate the effect and release the shared object to free up memory.
       isEffectValid = false;
-      image?.release();
+      loadedImage?.release();
     };
   }, [resolvedSource.uri, ...dependencies]);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4781,6 +4781,9 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
     devDependencies:
+      '@testing-library/react-native':
+        specifier: ^13.3.0
+        version: 13.3.3(jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.20.1)(typescript@6.0.3)))(react-native@0.87.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/jest':
         specifier: ^29.2.1
         version: 29.5.14


### PR DESCRIPTION
## Why

`useImage` cleanup captures the initial `null`, so loaded images aren't released when the component unmounts. Loads that finish after cleanup also miss `release()`.

## How

Keep the image returned by each effect for cleanup, and release late results immediately.

## Test plan

Run the new `useImage` tests on iOS and Android. They check unmounts, source changes, and late results, with each image released exactly once.
