### PR TITLE
[android][core] Extract shared callback context from JavaCallback

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/CallbackContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/CallbackContext.cpp
@@ -1,0 +1,47 @@
+// Copyright © 2026-present 650 Industries, Inc. (aka Expo)
+
+#include "CallbackContext.h"
+
+namespace expo {
+
+CallbackContext::CallbackContext(
+  jsi::Runtime &rt,
+  std::weak_ptr<react::CallInvoker> jsCallInvokerHolder,
+  std::optional<jsi::Function> resolveHolder,
+  std::optional<jsi::Function> rejectHolder
+) : react::LongLivedObject(rt),
+    rt(rt),
+    jsCallInvokerHolder(std::move(jsCallInvokerHolder)),
+    resolveHolder(std::move(resolveHolder)),
+    rejectHolder(std::move(rejectHolder)) {}
+
+void CallbackContext::invalidate() {
+  resolveHolder.reset();
+  rejectHolder.reset();
+  allowRelease();
+}
+
+void scheduleOnJSThread(const std::weak_ptr<CallbackContext> &context, JSThreadTask &&task) {
+  const auto strongContext = context.lock();
+  // The context was deallocated before the callback was invoked.
+  if (strongContext == nullptr) {
+    return;
+  }
+
+  const auto jsInvoker = strongContext->jsCallInvokerHolder.lock();
+  // Call invoker is already released, so we cannot invoke the callback.
+  if (jsInvoker == nullptr) {
+    return;
+  }
+
+  jsInvoker->invokeAsync(
+    [context, task = std::move(task)]() -> void {
+      auto strongContext = context.lock();
+      if (strongContext == nullptr) {
+        return;
+      }
+      task(strongContext->rt, *strongContext);
+    });
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/CallbackContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/CallbackContext.h
@@ -1,0 +1,51 @@
+// Copyright © 2026-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include "ExpoHeader.pch"
+
+#include <ReactCommon/CallInvoker.h>
+#include <react/bridging/LongLivedObject.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
+namespace expo {
+
+/**
+ * State shared by every native-to-JS callback: the runtime, the call invoker that hops onto the
+ * JS thread, and the JS functions to call. Registered in the runtime's `LongLivedObjectCollection`
+ * so a runtime teardown invalidates it before the runtime is destroyed.
+ *
+ * `resolveHolder` is the primary function. `rejectHolder` is only set for promise callbacks.
+ */
+class CallbackContext : public react::LongLivedObject {
+public:
+  CallbackContext(
+    jsi::Runtime &rt,
+    std::weak_ptr<react::CallInvoker> jsCallInvokerHolder,
+    std::optional<jsi::Function> resolveHolder,
+    std::optional<jsi::Function> rejectHolder
+  );
+
+  jsi::Runtime &rt;
+  std::weak_ptr<react::CallInvoker> jsCallInvokerHolder;
+  std::optional<jsi::Function> resolveHolder;
+  std::optional<jsi::Function> rejectHolder;
+
+  void invalidate();
+};
+
+using JSThreadTask = std::function<void(jsi::Runtime &rt, CallbackContext &context)>;
+
+/**
+ * Posts `task` onto the JS thread through the context's call invoker.
+ * Does nothing when the context or the invoker is already gone.
+ */
+void scheduleOnJSThread(const std::weak_ptr<CallbackContext> &context, JSThreadTask &&task);
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -8,23 +8,6 @@
 
 namespace expo {
 
-JavaCallback::CallbackContext::CallbackContext(
-  jsi::Runtime &rt,
-  std::weak_ptr<react::CallInvoker> jsCallInvokerHolder,
-  std::optional<jsi::Function> resolveHolder,
-  std::optional<jsi::Function> rejectHolder
-) : react::LongLivedObject(rt),
-    rt(rt),
-    jsCallInvokerHolder(std::move(jsCallInvokerHolder)),
-    resolveHolder(std::move(resolveHolder)),
-    rejectHolder(std::move(rejectHolder)) {}
-
-void JavaCallback::CallbackContext::invalidate() {
-  resolveHolder.reset();
-  rejectHolder.reset();
-  allowRelease();
-}
-
 JavaCallback::JavaCallback(std::shared_ptr<CallbackContext> callbackContext)
   : callbackContext(std::move(callbackContext)) {}
 
@@ -64,40 +47,17 @@ jni::local_ref<JavaCallback::javaobject> JavaCallback::newInstance(
 void JavaCallback::invokeWithResolver(
   std::function<void(jsi::Runtime &rt, jsi::Function &jsFunction)> resolver
 ) {
-  const auto strongCallbackContext = this->callbackContext.lock();
-  // The context were deallocated before the callback was invoked.
-  if (strongCallbackContext == nullptr) {
-    return;
-  }
-
-  const auto jsInvoker = strongCallbackContext->jsCallInvokerHolder.lock();
-  // Call invoker is already released, so we cannot invoke the callback.
-  if (jsInvoker == nullptr) {
-    return;
-  }
-
-  jsInvoker->invokeAsync(
-    [
-      context = callbackContext,
-      resolver = std::move(resolver)
-    ]() -> void {
-      auto strongContext = context.lock();
-      // The context were deallocated before the callback was invoked.
-      if (strongContext == nullptr) {
-        return;
-      }
-
-      if (!strongContext->resolveHolder.has_value()) {
+  scheduleOnJSThread(
+    callbackContext,
+    [resolver = std::move(resolver)](jsi::Runtime &rt, CallbackContext &context) {
+      if (!context.resolveHolder.has_value()) {
         throw std::runtime_error(
           "JavaCallback was already settled. Cannot invoke it again"
         );
       }
 
-      jsi::Function &jsFunction = strongContext->resolveHolder.value();
-      jsi::Runtime &rt = strongContext->rt;
-
-      resolver(rt, jsFunction);
-      strongContext->invalidate();
+      resolver(rt, context.resolveHolder.value());
+      context.invalidate();
     });
 }
 
@@ -259,38 +219,17 @@ void JavaCallback::invokeFloatArray(jni::alias_ref<jni::JArrayFloat> result) {
 }
 
 void JavaCallback::invokeError(jni::alias_ref<jstring> code, jni::alias_ref<jstring> errorMessage) {
-  const auto strongCallbackContext = this->callbackContext.lock();
-  // The context were deallocated before the callback was invoked.
-  if (strongCallbackContext == nullptr) {
-    return;
-  }
-
-  const auto jsInvoker = strongCallbackContext->jsCallInvokerHolder.lock();
-  // Call invoker is already released, so we cannot invoke the callback.
-  if (jsInvoker == nullptr) {
-    return;
-  }
-
-  jsInvoker->invokeAsync(
+  scheduleOnJSThread(
+    callbackContext,
     [
-      context = callbackContext,
       code = code->toStdString(),
       errorMessage = errorMessage->toStdString()
-    ]() -> void {
-      auto strongContext = context.lock();
-      // The context were deallocated before the callback was invoked.
-      if (strongContext == nullptr) {
-        return;
-      }
-
-      if (!strongContext->rejectHolder.has_value()) {
+    ](jsi::Runtime &rt, CallbackContext &context) {
+      if (!context.rejectHolder.has_value()) {
         throw std::runtime_error(
           "JavaCallback was already settled. Cannot invoke it again"
         );
       }
-
-      jsi::Function &jsFunction = strongContext->rejectHolder.value();
-      jsi::Runtime &rt = strongContext->rt;
 
       auto codedError = makeCodedError(
         rt,
@@ -298,13 +237,13 @@ void JavaCallback::invokeError(jni::alias_ref<jstring> code, jni::alias_ref<jstr
         jsi::String::createFromUtf8(rt, errorMessage)
       );
 
-      jsFunction.call(
+      context.rejectHolder->call(
         rt,
         (const jsi::Value *) &codedError,
         (size_t) 1
       );
 
-      strongContext->invalidate();
+      context.invalidate();
     });
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ExpoHeader.pch"
+#include "CallbackContext.h"
 #include "JNIDeallocator.h"
 #include "JSharedObject.h"
 #include "ArrayBuffer.h"
@@ -10,8 +11,6 @@
 #include "NativeArrayBuffer.h"
 
 #include <fbjni/detail/CoreClasses.h>
-#include <ReactCommon/CallInvoker.h>
-#include <react/bridging/LongLivedObject.h>
 
 namespace jni = facebook::jni;
 namespace react = facebook::react;
@@ -21,28 +20,14 @@ namespace expo {
 
 class JSIContext;
 
+/**
+ * Single-fire callback that settles a JS promise. Resolving or rejecting twice throws.
+ */
 class JavaCallback : public jni::HybridClass<JavaCallback, Destructible> {
 public:
   static auto constexpr
     kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaCallback;";
   static auto constexpr TAG = "JavaCallback";
-
-  class CallbackContext : public react::LongLivedObject {
-  public:
-    CallbackContext(
-      jsi::Runtime &rt,
-      std::weak_ptr<react::CallInvoker> jsCallInvokerHolder,
-      std::optional<jsi::Function> resolveHolder,
-      std::optional<jsi::Function> rejectHolder
-    );
-
-    jsi::Runtime &rt;
-    std::weak_ptr<react::CallInvoker> jsCallInvokerHolder;
-    std::optional<jsi::Function> resolveHolder;
-    std::optional<jsi::Function> rejectHolder;
-
-    void invalidate();
-  };
 
   static void registerNatives();
 

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -4,6 +4,7 @@
 #include "JavaReferencesCache.h"
 #include "Exceptions.h"
 #include "JavaCallback.h"
+#include "CallbackContext.h"
 #include "types/JNIToJSIConverter.h"
 #include "JSReferencesCache.h"
 
@@ -25,7 +26,7 @@ jni::local_ref<JavaCallback::JavaPart> createJavaCallback(
   JSIContext *jsiContext = getJSIContext(rt);
   std::shared_ptr<react::CallInvoker> jsInvoker = jsiContext->runtimeHolder->jsInvoker;
 
-  std::shared_ptr<JavaCallback::CallbackContext> callbackContext = std::make_shared<JavaCallback::CallbackContext>(
+  std::shared_ptr<CallbackContext> callbackContext = std::make_shared<CallbackContext>(
     rt,
     std::move(jsInvoker),
     std::move(resolveFunction),


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)