### PR TITLE
[router] preserve streamed suspense content

### DIFF
--- a/apps/router-e2e/__e2e__/static-rendering/app/streaming.tsx
+++ b/apps/router-e2e/__e2e__/static-rendering/app/streaming.tsx
@@ -1,0 +1,111 @@
+import { useLocalSearchParams } from 'expo-router';
+import { Suspense, use, useEffect, useState } from 'react';
+
+// Streaming SSR store page: two Suspense boundaries the server completes after `?delay=<ms>` and
+// `delay + 1500`. The client promises never resolve, so streamed content can only come from the server.
+
+const PRODUCT = { title: 'Aeropress Go Travel Press', price: '$39.95', stock: 12 };
+const REVIEWS = [
+  { id: 'r1', author: 'Dana K.', body: 'Packs smaller than my mug.' },
+  { id: 'r2', author: 'Marco P.', body: 'Great on flights. Stiff plunger.' },
+  { id: 'r3', author: 'Yuki T.', body: 'Three years of daily use.' },
+];
+const RELATED = [
+  { id: 'p1', title: 'Burr Hand Grinder', price: '$59.00' },
+  { id: 'p2', title: 'Metal Filter Disc', price: '$14.50' },
+];
+
+function resolveOnServerAfter<T>(value: T, delayMs: number): Promise<T> {
+  if (typeof window === 'undefined') {
+    return new Promise((resolve) => setTimeout(() => resolve(value), delayMs));
+  }
+  return new Promise(() => {});
+}
+
+export default function StreamingStorePage() {
+  const { delay } = useLocalSearchParams<{ delay?: string }>();
+  const reviewsDelay = Number(delay) || 1000;
+  // Created in the parent, which never suspends, so each promise is made once per request.
+  const [reviews] = useState(() => resolveOnServerAfter(REVIEWS, reviewsDelay));
+  const [related] = useState(() => resolveOnServerAfter(RELATED, reviewsDelay + 1500));
+
+  return (
+    <main data-testid="streaming-page">
+      <header>
+        <h1 data-testid="streaming-header">{PRODUCT.title}</h1>
+        <p>{PRODUCT.price}</p>
+        <p>{PRODUCT.stock} in stock</p>
+        {/* Not next to a boundary: a pending update beside one hides the failure this page tests. */}
+        <HydrationMarker />
+      </header>
+
+      <section>
+        <h2>Reviews</h2>
+        <Suspense fallback={<ReviewsSkeleton />}>
+          <Reviews promise={reviews} />
+        </Suspense>
+      </section>
+
+      <section>
+        <h2>Related products</h2>
+        <Suspense fallback={<RelatedSkeleton />}>
+          <Related promise={related} />
+        </Suspense>
+      </section>
+    </main>
+  );
+}
+
+function HydrationMarker() {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+  return hydrated ? <span data-testid="streaming-hydrated">Hydrated</span> : null;
+}
+
+function Reviews({ promise }: { promise: Promise<typeof REVIEWS> }) {
+  const reviews = use(promise);
+  return (
+    <ul data-testid="streaming-reviews">
+      {reviews.map((review) => (
+        <li key={review.id}>
+          <strong>{review.author}</strong> {review.body}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function Related({ promise }: { promise: Promise<typeof RELATED> }) {
+  const related = use(promise);
+  return (
+    <ul data-testid="streaming-related">
+      {related.map((item) => (
+        <li key={item.id}>
+          {item.title} {item.price}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ReviewsSkeleton() {
+  return (
+    <ul data-testid="streaming-reviews-skeleton">
+      {REVIEWS.map((review) => (
+        <li key={review.id}>…</li>
+      ))}
+    </ul>
+  );
+}
+
+function RelatedSkeleton() {
+  return (
+    <ul data-testid="streaming-related-skeleton">
+      {RELATED.map((item) => (
+        <li key={item.id}>…</li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/@expo/cli/e2e/__tests__/export/static-splitting.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-splitting.test.ts
@@ -100,6 +100,7 @@ describe('exports static with bundle splitting', () => {
         'about',
         'asset',
         'links',
+        'streaming',
         'styled',
         'metadata',
         '\\[id\\]',

--- a/packages/@expo/cli/e2e/playwright/prod/server-rendering.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/server-rendering.test.ts
@@ -71,4 +71,60 @@ test.describe('server rendering in production', () => {
     ).toBe('alive');
     expect(pageErrors.all).toEqual([]);
   });
+
+  test('streams two pending Suspense boundaries and completes them later', async ({ page }) => {
+    const response = await page.request.get(new URL('/streaming?delay=300', expoServe.url).href);
+    const html = await response.text();
+
+    expect(html.match(/<!--\$\?-->/g)).toHaveLength(2);
+    expect(html.match(/\$RC\(/g)).toHaveLength(2);
+    expect(html).toContain('Dana K.');
+    expect(html).toContain('Burr Hand Grinder');
+  });
+
+  test('adopts streamed Suspense content during hydration', async ({ page }) => {
+    const pageErrors = pageCollectErrors(page);
+
+    // Runs before the client bundle, so the flag marks the server-rendered node.
+    await page.addInitScript(() => {
+      const observer = new MutationObserver(() => {
+        const header = document.querySelector('[data-testid="streaming-header"]');
+        if (header) {
+          (header as any).__fromServer = true;
+          observer.disconnect();
+        }
+      });
+      observer.observe(document, { childList: true, subtree: true });
+    });
+
+    // `load` fires only when the stream ends; `commit` lets us observe hydration while pending.
+    await page.goto(new URL('/streaming?delay=4000', expoServe.url).href, {
+      waitUntil: 'commit',
+    });
+    await page.waitForSelector('[data-testid="streaming-hydrated"]');
+
+    // Hydration must happen while both are pending, or the test proves nothing.
+    await expect(page.getByTestId('streaming-reviews-skeleton')).toHaveCount(1);
+    await expect(page.getByTestId('streaming-related-skeleton')).toHaveCount(1);
+    await expect(page.getByTestId('streaming-reviews')).toHaveCount(0);
+    await expect(page.getByTestId('streaming-related')).toHaveCount(0);
+
+    // The client promises never resolve, so this content can only come from the server stream.
+    await expect(page.getByTestId('streaming-reviews')).toContainText('Dana K.', {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId('streaming-reviews-skeleton')).toHaveCount(0);
+    await expect(page.getByTestId('streaming-related')).toContainText('Burr Hand Grinder', {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId('streaming-related-skeleton')).toHaveCount(0);
+
+    const headerFromServer = await page.evaluate(
+      () =>
+        (document.querySelector('[data-testid="streaming-header"]') as any)?.__fromServer === true
+    );
+    expect(headerFromServer).toBe(true);
+
+    expect(pageErrors.all).toEqual([]);
+  });
 });

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -20,6 +20,7 @@ import type { LinkingOptions } from './react-navigation/native';
 import { StackRouter, useNavigationBuilder } from './react-navigation/native';
 import { initScreensFeatureFlags } from './screensFeatureFlags';
 import type { RequireContext } from './types';
+import { getInitialSafeAreaMetrics } from './utils/safeAreaMetrics';
 import { maybeHideSplashScreen } from './utils/splash';
 import { parseUrlUsingCustomBase } from './utils/url';
 import { RootUnmatched } from './views/RootUnmatched';
@@ -42,13 +43,10 @@ export type NativeIntent = {
 
 const isTestEnv = process.env.NODE_ENV === 'test';
 
+// NOTE(@hassankhan): Web is seeded with its own measurement so a context value
+// change doesn't occur during hydration. Native measures itself.
 const INITIAL_METRICS =
-  Platform.OS === 'web' || isTestEnv
-    ? {
-        frame: { x: 0, y: 0, width: 0, height: 0 },
-        insets: { top: 0, left: 0, right: 0, bottom: 0 },
-      }
-    : undefined;
+  Platform.OS === 'web' || isTestEnv ? getInitialSafeAreaMetrics() : undefined;
 
 /**
  * @hidden

--- a/packages/expo-router/src/utils/safeAreaMetrics.ts
+++ b/packages/expo-router/src/utils/safeAreaMetrics.ts
@@ -1,0 +1,68 @@
+import type { Metrics } from 'react-native-safe-area-context';
+
+const ZERO_METRICS: Metrics = {
+  frame: { x: 0, y: 0, width: 0, height: 0 },
+  insets: { top: 0, left: 0, right: 0, bottom: 0 },
+};
+
+/**
+ * Web has no `initialWindowMetrics`, so this measures what the web
+ * `SafeAreaProvider` will measure on mount. Seeding it keeps it stable through
+ * hydration; unstable values cause a re-render which drops streamed `Suspense`
+ * boundaries that are still pending. Values are set to zero on the server or
+ * when measuring fails.
+ *
+ * @privateRemarks This is pretty hacky and subject to change in the next
+ * version of `react-native-safe-area-context`
+ *
+ * @see https://github.com/AppAndFlow/react-native-safe-area-context/blob/e0b35d24cfe72812f5d32e4576195693abbcda20/src/NativeSafeAreaProvider.web.tsx#L36
+ */
+export function getInitialSafeAreaMetrics(): Metrics {
+  if (typeof document === 'undefined' || typeof window === 'undefined' || !document.body) {
+    return ZERO_METRICS;
+  }
+
+  try {
+    const element = document.createElement('div');
+    const { style } = element;
+    style.position = 'fixed';
+    style.left = '0';
+    style.top = '0';
+    style.width = '0';
+    style.height = '0';
+    style.zIndex = '-1';
+    style.overflow = 'hidden';
+    style.visibility = 'hidden';
+    const env = getSupportedEnv();
+    style.paddingTop = `${env}(safe-area-inset-top)`;
+    style.paddingBottom = `${env}(safe-area-inset-bottom)`;
+    style.paddingLeft = `${env}(safe-area-inset-left)`;
+    style.paddingRight = `${env}(safe-area-inset-right)`;
+    document.body.appendChild(element);
+    const { paddingTop, paddingBottom, paddingLeft, paddingRight } =
+      window.getComputedStyle(element);
+    document.body.removeChild(element);
+
+    return {
+      insets: {
+        top: paddingTop ? parseInt(paddingTop, 10) : 0,
+        bottom: paddingBottom ? parseInt(paddingBottom, 10) : 0,
+        left: paddingLeft ? parseInt(paddingLeft, 10) : 0,
+        right: paddingRight ? parseInt(paddingRight, 10) : 0,
+      },
+      frame: {
+        x: 0,
+        y: 0,
+        width: document.documentElement.offsetWidth,
+        height: document.documentElement.offsetHeight,
+      },
+    };
+  } catch {
+    return ZERO_METRICS;
+  }
+}
+
+function getSupportedEnv(): 'constant' | 'env' {
+  const { CSS } = window;
+  return CSS?.supports?.('top: constant(safe-area-inset-top)') ? 'constant' : 'env';
+}


### PR DESCRIPTION
# Why

Based on https://github.com/expo/expo/pull/49684

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
