### PR TITLE
[sqlite] add co-located skill

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Ship an agent skill for SQLite queries, migrations, storage, and platform configuration in the npm package.
+- Ship an agent skill for SQLite queries, migrations, storage, and platform configuration in the npm package. ([#49867](https://github.com/expo/expo/pull/49867) by [@Kudo](https://github.com/Kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Ship an agent skill for SQLite queries, migrations, storage, and platform configuration in the npm package.
+
 ### 🐛 Bug fixes
 
 - [Android][iOS] Fix `deleteDatabaseAsync` and `deleteDatabaseSync` leaving `-journal`, `-wal` and `-shm` sidecar files behind. ([#49125](https://github.com/expo/expo/pull/49125) by [@sbaiahmed1](https://github.com/sbaiahmed1))

--- a/packages/expo-sqlite/skills/expo-sqlite/SKILL.md
+++ b/packages/expo-sqlite/skills/expo-sqlite/SKILL.md
@@ -156,7 +156,9 @@ async function insertTodos(db: SQLiteDatabase, titles: string[]) {
 
 For an atomic batch, call this helper with the database or `txn` belonging to a surrounding transaction. `executeAsync<T>()` returns metadata and a cursor with `getFirstAsync()`, `getAllAsync()`, and async iteration. Call `resetAsync()` before reading the same result from the beginning again. Consuming a cursor and then calling `getAllAsync()` without resetting is not a fresh query.
 
-## Key-value storage
+## Key-value storage and localStorage
+
+### AsyncStorage-compatible storage
 
 For AsyncStorage-compatible string storage:
 
@@ -169,7 +171,19 @@ const saved = await Storage.getItem('settings'); // string | null
 
 Synchronous methods such as `getItemSync()` are also available. Changing an AsyncStorage import changes the backend; it **does not migrate existing data**. For an existing app, explicitly copy needed keys from the old store, verify the copy, and make the migration safe to retry before removing that dependency. Preserve the user's choice of backend when a migration was not requested.
 
-For shared web-style code, `import 'expo-sqlite/localStorage/install'` installs SQLite-backed `globalThis.localStorage` on native platforms. It is a no-op on web, where browser storage remains in use. Plain SQLite and the key-value store are not encrypted secret storage.
+### localStorage
+
+For shared web-style code, import the polyfill once in the app's entry point before code that uses `localStorage`:
+
+```ts
+import 'expo-sqlite/localStorage/install';
+
+globalThis.localStorage.setItem('settings', JSON.stringify({ theme: 'dark' }));
+const saved = globalThis.localStorage.getItem('settings'); // string | null
+globalThis.localStorage.removeItem('settings');
+```
+
+This installs SQLite-backed `globalThis.localStorage` on native platforms. The import is a no-op on web and is excluded from production web bundles, where the browser's existing `localStorage` remains in use. The API is synchronous and stores strings; serialize objects explicitly. Plain SQLite, the key-value store, and this polyfill are not encrypted secret storage.
 
 ## Debugging and verification
 

--- a/packages/expo-sqlite/skills/expo-sqlite/SKILL.md
+++ b/packages/expo-sqlite/skills/expo-sqlite/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: expo-sqlite
+description: Persist and query local data with expo-sqlite in Expo or React Native apps. Use for SQLite setup, SQL queries, schema migrations, transactions, SQLiteProvider, expo-sqlite/kv-store, or the localStorage polyfill.
+license: MIT
+---
+
+# expo-sqlite
+
+Use SQLite for structured local data, offline queues, and persistent caches. For simple string key-value storage, use `expo-sqlite/kv-store`. Preserve an existing ORM or storage architecture unless the task calls for changing it.
+
+## Setup and API selection
+
+Install with `npx expo install expo-sqlite`. Check the installed package version and its types before using newer APIs such as `db.sql`. Use the [SQLite documentation](https://docs.expo.dev/versions/latest/sdk/sqlite/) for the app's SDK version; use [unversioned docs](https://docs.expo.dev/versions/unversioned/sdk/sqlite/) only when working with unreleased code.
+
+The package supports Android, iOS, macOS, tvOS, and web. Standard SQLite is included in Expo Go; custom native build options require rebuilding the app. Web requires additional setup in [references/web-and-config.md](references/web-and-config.md).
+
+| Task                                             | API                                   |
+| ------------------------------------------------ | ------------------------------------- |
+| Static DDL or multiple SQL statements            | `db.execAsync(source)`                |
+| Write and receive `{ lastInsertRowId, changes }` | `db.runAsync(source, params)`         |
+| Read one row, or `null` if absent                | `db.getFirstAsync<T>(source, params)` |
+| Read a bounded result set                        | `db.getAllAsync<T>(source, params)`   |
+| Iterate rows without collecting the full result  | `db.getEachAsync<T>(source, params)`  |
+| Concise parameterized queries                    | `` db.sql<T>`SELECT ...` ``           |
+| Reuse a compiled statement                       | `db.prepareAsync(source)`             |
+
+Prefer asynchronous methods for application work. Synchronous database methods can block the JavaScript thread, especially for large queries or migrations.
+
+## Bind values, not SQL syntax
+
+`execAsync()` does not bind or escape values. Use it for trusted, static SQL. For data, use variadic arguments, arrays, or named parameters:
+
+```ts
+import type { SQLiteDatabase } from 'expo-sqlite';
+
+async function addTodo(db: SQLiteDatabase, title: string) {
+  const result = await db.runAsync('INSERT INTO todos (title) VALUES (?)', title);
+  return result.lastInsertRowId;
+}
+
+async function setCompleted(db: SQLiteDatabase, id: number, completed: boolean) {
+  await db.runAsync('UPDATE todos SET completed = $completed WHERE id = $id', {
+    $completed: completed ? 1 : 0,
+    $id: id,
+  });
+}
+```
+
+Bindings represent values, not table names, column names, or SQL fragments. Use fixed SQL or an allowlist for dynamic identifiers. Bind `null` for SQL NULL; serialize objects explicitly. `Uint8Array` and `ArrayBuffer` can be bound to BLOB columns in the current package.
+
+The `db.sql` tag replaces interpolations with bound parameters. Do not put quotes around `${value}` or interpolate an array expecting an expanded `IN` list:
+
+```ts
+import type { SQLiteDatabase } from 'expo-sqlite';
+
+type Todo = { id: number; title: string; completed: number };
+
+async function findTodo(db: SQLiteDatabase, id: number) {
+  const sql = db.sql;
+  return await sql<Todo>`SELECT * FROM todos WHERE id = ${id}`.first();
+}
+```
+
+Awaiting a tagged `SELECT` returns rows; `.first()` returns a row or `null`, `.each()` iterates rows, and `.values()` returns arrays of column values. Writes without `RETURNING` normally return `SQLiteRunResult`; prefer `runAsync()` when you need unambiguous write metadata. A generic type describes the expected row shape; it does not validate stored data or transform SQLite integers into JavaScript booleans.
+
+## React integration and migrations
+
+Mount one stable `SQLiteProvider` above the consumers of a database. Descendants call `useSQLiteContext()` to obtain it. Put initialization in `onInit`, which completes before the children render. Keep `onInit` and options stable so a render does not reopen the database.
+
+This example migrates a new database through versions 1 and 2, and upgrades an existing version 1 database without deleting its rows:
+
+```tsx
+import { SQLiteProvider, type SQLiteDatabase } from 'expo-sqlite';
+import type { PropsWithChildren } from 'react';
+
+export function DatabaseProvider({ children }: PropsWithChildren) {
+  return (
+    <SQLiteProvider databaseName="app.db" onInit={initializeDatabase}>
+      {children}
+    </SQLiteProvider>
+  );
+}
+
+async function initializeDatabase(db: SQLiteDatabase) {
+  // Connection settings must be applied outside the migration transaction.
+  await db.execAsync('PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;');
+
+  const version = await db.getFirstAsync<{ user_version: number }>('PRAGMA user_version');
+  if (version === null) {
+    throw new Error('Could not read the database schema version');
+  }
+  if (version.user_version > 2) {
+    throw new Error('Database schema is newer than this app supports');
+  }
+  if (version.user_version === 2) {
+    return;
+  }
+
+  // onInit gates consumers; no other database work should run during initialization.
+  await db.withTransactionAsync(async () => {
+    if (version.user_version < 1) {
+      await db.execAsync(`
+        CREATE TABLE todos (id INTEGER PRIMARY KEY NOT NULL, title TEXT NOT NULL);
+      `);
+    }
+    if (version.user_version < 2) {
+      await db.execAsync('ALTER TABLE todos ADD COLUMN completed INTEGER NOT NULL DEFAULT 0');
+    }
+    await db.execAsync('PRAGMA user_version = 2');
+  });
+}
+```
+
+Keep schema changes and their `user_version` update in the same transaction so failure rolls both back. WAL generally improves database performance; enable foreign keys on each connection that relies on them. Do not delete an existing database to work around a migration error.
+
+For Suspense, wrap a provider with `useSuspense` in `<Suspense fallback={...}>` and handle failures with an error boundary. `onError` cannot be combined with `useSuspense`. Outside React, share an `openDatabaseAsync()` initialization promise and close the database when its owner is done; do not close the provider's database from a child.
+
+`useSQLiteContext()` exposes the database, not reactive query results. Refresh local state or invalidate the app's query cache after writes. For external changes, see the listener guidance in [references/web-and-config.md](references/web-and-config.md).
+
+## Transactions and concurrent work
+
+`withTransactionAsync()` commits on success and rolls back on a rejected callback. Queries started elsewhere on the same connection while it is active also join the transaction. Await every operation; do not launch unrelated work during initialization.
+
+On native platforms, use `withExclusiveTransactionAsync()` when unrelated queries must stay outside a transaction. Run all transaction queries through `txn`, including queries in helper functions:
+
+```ts
+import type { SQLiteDatabase } from 'expo-sqlite';
+
+async function completeTodo(db: SQLiteDatabase, id: number) {
+  await db.withExclusiveTransactionAsync(async (txn) => {
+    await txn.runAsync('UPDATE todos SET completed = ? WHERE id = ?', 1, id);
+  });
+}
+```
+
+This API is **not supported on web**. It opens a separate connection; competing writes can fail with `database is locked`, rather than being automatically queued. On web, serialize access through the app's database owner and use `withTransactionAsync()`; a platform switch alone does not provide equivalent isolation. Avoid nested transaction helpers.
+
+## Prepared statements
+
+Prepare once for repeated execution and always finalize, including on failure:
+
+```ts
+import type { SQLiteDatabase } from 'expo-sqlite';
+
+async function insertTodos(db: SQLiteDatabase, titles: string[]) {
+  const statement = await db.prepareAsync('INSERT INTO todos (title) VALUES ($title)');
+  try {
+    for (const title of titles) {
+      await statement.executeAsync({ $title: title });
+    }
+  } finally {
+    await statement.finalizeAsync();
+  }
+}
+```
+
+For an atomic batch, call this helper with the database or `txn` belonging to a surrounding transaction. `executeAsync<T>()` returns metadata and a cursor with `getFirstAsync()`, `getAllAsync()`, and async iteration. Call `resetAsync()` before reading the same result from the beginning again. Consuming a cursor and then calling `getAllAsync()` without resetting is not a fresh query.
+
+## Key-value storage
+
+For AsyncStorage-compatible string storage:
+
+```ts
+import Storage from 'expo-sqlite/kv-store';
+
+await Storage.setItem('settings', JSON.stringify({ theme: 'dark' }));
+const saved = await Storage.getItem('settings'); // string | null
+```
+
+Synchronous methods such as `getItemSync()` are also available. Changing an AsyncStorage import changes the backend; it **does not migrate existing data**. For an existing app, explicitly copy needed keys from the old store, verify the copy, and make the migration safe to retry before removing that dependency. Preserve the user's choice of backend when a migration was not requested.
+
+For shared web-style code, `import 'expo-sqlite/localStorage/install'` installs SQLite-backed `globalThis.localStorage` on native platforms. It is a no-op on web, where browser storage remains in use. Plain SQLite and the key-value store are not encrypted secret storage.
+
+## Debugging and verification
+
+In development, press **Shift+M** in the Expo CLI terminal and select **Open expo-sqlite** to inspect tables and run queries. Treat edits there as writes to the app's actual database.
+
+For storage changes, verify a fresh install, reopening with persisted data, upgrading an older schema, and rollback after a deliberately failed migration. Check empty query results and strings containing quotes. Test concurrent writes when changing transaction handling, and test web in its configured browser environment when web is a target.
+
+Read [references/web-and-config.md](references/web-and-config.md) for web setup, native build options, SQLCipher, bundled databases, App Groups, change listeners, and database backups.

--- a/packages/expo-sqlite/skills/expo-sqlite/references/web-and-config.md
+++ b/packages/expo-sqlite/skills/expo-sqlite/references/web-and-config.md
@@ -1,0 +1,128 @@
+# Web setup and native configuration
+
+## Web and Metro
+
+Metro must bundle `.wasm` files, and the browser needs `SharedArrayBuffer`. Merge the following into the existing Metro configuration, preserving other customizations and middleware:
+
+```js
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+if (!config.resolver.assetExts.includes('wasm')) {
+  config.resolver.assetExts.push('wasm');
+}
+
+const enhanceMiddleware = config.server.enhanceMiddleware;
+config.server.enhanceMiddleware = (middleware, metroServer) => {
+  const enhancedMiddleware = enhanceMiddleware
+    ? enhanceMiddleware(middleware, metroServer)
+    : middleware;
+  return (req, res, next) => {
+    res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    return enhancedMiddleware(req, res, next);
+  };
+};
+
+module.exports = config;
+```
+
+Development middleware does not configure production hosting. Serve the same `Cross-Origin-Embedder-Policy: credentialless` and `Cross-Origin-Opener-Policy: same-origin` headers from the deployed web server. On EAS Hosting, merge these headers into the existing `expo-router` plugin entry:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "headers": {
+            "Cross-Origin-Embedder-Policy": "credentialless",
+            "Cross-Origin-Opener-Policy": "same-origin"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+Verify in a secure context (HTTPS or localhost) that `crossOriginIsolated` is true, `SharedArrayBuffer` is available, and the WASM asset loads. Test third-party resources affected by these headers. `withExclusiveTransactionAsync()` and the custom database `directory` parameter are not supported on web.
+
+## Native build options
+
+Configure the `expo-sqlite` plugin only when custom build options are needed. These settings require a new native binary; they do not change Expo Go or an existing binary through an OTA update.
+
+| Property                 | Default | Purpose                                      |
+| ------------------------ | ------- | -------------------------------------------- |
+| `enableFTS`              | `true`  | Enable FTS3, FTS4, and FTS5 full-text search |
+| `useSQLCipher`           | `false` | Build with SQLCipher encryption support      |
+| `withSQLiteVecExtension` | `false` | Bundle the sqlite-vec extension              |
+| `customBuildFlags`       | Unset   | Pass additional SQLite compile flags         |
+
+The `android` and `ios` objects override shared values per platform. For example, to bundle sqlite-vec:
+
+```json
+{
+  "expo": {
+    "plugins": [["expo-sqlite", { "withSQLiteVecExtension": true }]]
+  }
+}
+```
+
+After rebuilding, load the bundled extension on a native connection before using it:
+
+```ts
+import * as SQLite from 'expo-sqlite';
+
+async function loadVectorExtension(db: SQLite.SQLiteDatabase) {
+  const extension = SQLite.bundledExtensions['sqlite-vec'];
+  if (!extension) {
+    throw new Error('Rebuild the app with withSQLiteVecExtension enabled');
+  }
+  await db.loadExtensionAsync(extension.libPath, extension.entryPoint);
+}
+```
+
+Use the project's existing prebuild or native configuration workflow. Do not regenerate committed native projects just to install the standard package. The current package has removed libSQL support: `syncLibSQL()` and `libSQLOptions` are gone, and `useLibSQL` is deprecated and has no effect. Check the installed version when maintaining an older app.
+
+## SQLCipher
+
+SQLCipher is supported on Android, iOS, and macOS, and requires `useSQLCipher: true` and a custom native build. It is unavailable in Expo Go and on web.
+
+Set `PRAGMA key` immediately after opening an encrypted database, before schema reads or migrations. Obtain the key from the app's secure key-management flow; do not hardcode or log it. PRAGMA assignments do not accept ordinary bound parameters, so use SQLCipher's documented key format and validate or escape it explicitly instead of interpolating arbitrary input into `execAsync()`.
+
+Enabling SQLCipher does not encrypt an existing plaintext database. Plan an explicit data migration for that case. Also account for APIs that open new connections: `withExclusiveTransactionAsync()` creates a separate connection and does not apply a key configured with SQL on the original connection. Do not assume it works with an encrypted database without arranging and testing connection initialization.
+
+## Bundled databases and App Groups
+
+To seed a database, pass `assetSource={{ assetId: require('./assets/app.db') }}` to `SQLiteProvider`. Add `db` to Metro's `resolver.assetExts` if absent. By default the asset is imported only when the destination database does not exist. `forceOverwrite: true` replaces an existing database, so do not use it as a migration mechanism for user data.
+
+For an iOS App Group, configure `ios.entitlements['com.apple.security.application-groups']` with the intended group, and pass that group's shared container to the provider:
+
+```ts
+import { Paths } from 'expo-file-system';
+
+const directory = Paths.appleSharedContainers['group.com.example.app']?.uri;
+if (!directory) {
+  throw new Error('App Group container is unavailable; check the entitlement and native build');
+}
+```
+
+Use this lookup on iOS and pass `directory` to `SQLiteProvider` or the third argument of `openDatabaseAsync()`. Select the specific group rather than the first container returned. Verify that both the app and extension use the same group and database name. On tvOS the default database location is the caches directory, so do not assume its contents are permanent.
+
+## Change listeners
+
+Open with `enableChangeListener: true` (or provider `options={{ enableChangeListener: true }}`) before subscribing with `addDatabaseChangeListener()`. The event includes `databaseName`, `databaseFilePath`, `tableName`, and `rowId`. Filter for the relevant database and table and remove the subscription on cleanup.
+
+These are SQLite update-hook events, not reactive query results or transaction-commit notifications. Re-query or invalidate cached data as appropriate, account for rollbacks, and refresh after successful writes. Do not assume listeners on one connection observe changes from every other connection or process.
+
+## Backups and serialization
+
+- `backupDatabaseAsync({ sourceDatabase, destDatabase })` copies between open databases. Use a separate destination when preserving existing data.
+- `db.serializeAsync()` returns `Uint8Array`; `deserializeDatabaseAsync(bytes)` opens a separate in-memory database, not a persistent file. Back it up to a file-backed database if persistence is needed.
+- Close owned connections and finish active statements before deleting a database with `deleteDatabaseAsync(name, directory?)`.
+- Avoid copying only the `.db` file from a live WAL database; committed data may still be in its WAL. Prefer the backup API for a consistent database copy.
+
+For exact signatures and platform support, consult the installed `expo-sqlite` types and the [SQLite documentation for the app's SDK](https://docs.expo.dev/versions/latest/sdk/sqlite/).

--- a/packages/expo-sqlite/skills/expo-sqlite/references/web-and-config.md
+++ b/packages/expo-sqlite/skills/expo-sqlite/references/web-and-config.md
@@ -103,14 +103,20 @@ For an iOS App Group, configure `ios.entitlements['com.apple.security.applicatio
 
 ```ts
 import { Paths } from 'expo-file-system';
+import { defaultDatabaseDirectory } from 'expo-sqlite';
+import { Platform } from 'react-native';
 
-const directory = Paths.appleSharedContainers['group.com.example.app']?.uri;
-if (!directory) {
-  throw new Error('App Group container is unavailable; check the entitlement and native build');
+let directory = defaultDatabaseDirectory;
+if (Platform.OS === 'ios') {
+  const sharedDirectory = Paths.appleSharedContainers['group.com.example.app']?.uri;
+  if (!sharedDirectory) {
+    throw new Error('App Group container is unavailable; check the entitlement and native build');
+  }
+  directory = sharedDirectory;
 }
 ```
 
-Use this lookup on iOS and pass `directory` to `SQLiteProvider` or the third argument of `openDatabaseAsync()`. Select the specific group rather than the first container returned. Verify that both the app and extension use the same group and database name. On tvOS the default database location is the caches directory, so do not assume its contents are permanent.
+Pass `directory` to `SQLiteProvider` or the third argument of `openDatabaseAsync()`. The snippet selects the specific App Group on iOS and keeps SQLite's default directory on other platforms. Verify that both the app and extension use the same group and database name. On tvOS the default database location is the caches directory, so do not assume its contents are permanent.
 
 ## Change listeners
 


### PR DESCRIPTION
# Why

co-located module and skill
close ENG-25661

# How

ask codex to write the skill. sources from:
- https://github.com/expo/expo/pull/48796
- https://docs.expo.dev/versions/unversioned/sdk/sqlite/
- expo-sqlite source code

# Test Plan

- sorry no eval in the mean time. will pair with agent-cli and update our eval harness to support the co-located skills later

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)