### PR TITLE
[bare-expo][ncl] Add agent-device e2e scripts for crypto, file-system, audio, and video

### DIFF
--- a/apps/bare-expo/e2e/expo-audio/playback-events.ad
+++ b/apps/bare-expo/e2e/expo-audio/playback-events.ad
@@ -1,0 +1,24 @@
+# expo-audio: play, pause, seek, loop, and finish a bundled track and observe the status rows.
+open ${APP_ID} --relaunch
+wait text "Expo Test Suite" 20000
+open "bareexpo://apis/audio/expo-audio-events"
+wait text "isLoaded = true" 20000
+wait text "playing = false"
+press label="Play"
+wait text "playing = true" 10000
+# Toggle loop while playing. On Android a loop change while paused is not reported until the
+# next playback status event.
+press label="Loop: OFF"
+wait text "loop = true" 10000
+press label="Loop: ON"
+wait text "loop = false" 10000
+press label="Pause"
+wait text "playing = false" 10000
+press label="Seek to Start"
+wait text "currentTime = 0.00" 10000
+wait text "didJustFinishCount = 0"
+press label="Seek Near End (-2s)"
+press label="Play"
+wait text "didJustFinishCount = 1" 15000
+wait text "playing = false" 10000
+close

--- a/apps/bare-expo/e2e/expo-crypto/aes-encrypt-decrypt.ad
+++ b/apps/bare-expo/e2e/expo-crypto/aes-encrypt-decrypt.ad
@@ -1,0 +1,27 @@
+# expo-crypto: AES key generation and a full encrypt/decrypt cycle, including a failing
+# decrypt when the additional authenticated data does not match.
+open ${APP_ID} --relaunch
+wait text "Expo Test Suite" 20000
+open "bareexpo://apis/expo-crypto/aes"
+wait text "AESEncryptionKey.generate" 20000
+press label="AESEncryptionKey.generate: RUN"
+wait text "AESEncryptionKey.generate = " 10000
+scroll bottom
+press label="Full encrypt/decrypt cycle: RUN"
+wait text "Full encrypt/decrypt cycle = {" 10000
+wait text "\"decrypted\": \"Hello, World!\"" 5000
+wait text "\"success\": true" 5000
+# Cycle plaintext to "Secret".
+press label="Full encrypt/decrypt cycle: plaintext"
+press label="Full encrypt/decrypt cycle: RUN"
+wait text "\"decrypted\": \"Secret\"" 10000
+# Matching AAD on both sides still succeeds.
+press label="Full encrypt/decrypt cycle: encryptionAAD"
+press label="Full encrypt/decrypt cycle: decryptionAAD"
+press label="Full encrypt/decrypt cycle: RUN"
+wait text "\"success\": true" 10000
+# Mismatched AAD must fail to decrypt.
+press label="Full encrypt/decrypt cycle: decryptionAAD"
+press label="Full encrypt/decrypt cycle: RUN"
+wait text "Full encrypt/decrypt cycle = Error" 10000
+close

--- a/apps/bare-expo/e2e/expo-crypto/digest-string.ad
+++ b/apps/bare-expo/e2e/expo-crypto/digest-string.ad
@@ -1,0 +1,18 @@
+# expo-crypto: digestString with fixed input across algorithms and encodings.
+# Expected values are the MD5 and SHA-1 digests of "I'm a string".
+open ${APP_ID} --relaunch
+wait text "Expo Test Suite" 20000
+open "bareexpo://apis/expo-crypto/general"
+wait text "digestString" 20000
+scroll bottom
+press label="digestString: RUN"
+wait text "digestString = KrwvTpOiXAQnbyNglGnWxA==" 10000
+# algorithm cycles MD5 -> SHA1
+press label="digestString: algorithm"
+press label="digestString: RUN"
+wait text "digestString = VlWsJMfyE9suMreEvpahsVYkTwY=" 10000
+# encoding cycles BASE64 -> HEX
+press label="digestString: options.encoding"
+press label="digestString: RUN"
+wait text "digestString = 5655ac24c7f213db2e32b784be96a1b156244f06" 10000
+close

--- a/apps/bare-expo/e2e/expo-file-system/file-lifecycle.ad
+++ b/apps/bare-expo/e2e/expo-file-system/file-lifecycle.ad
@@ -1,0 +1,27 @@
+# expo-file-system: create a file, read and overwrite it, then create, check, and delete
+# a second file through the lifecycle demos. Sections are reached through the section index.
+open ${APP_ID} --relaunch
+wait text "Expo Test Suite" 20000
+open "bareexpo://apis/filesystem"
+wait text "File Sources" 20000
+press label="Create local file"
+alert accept
+press label="Jump to Read Operations"
+press label="text()"
+wait text "text() = \"Hello from FileSystem sandbox!" 10000
+# The section index scrolls away with the content, so return to the top before each jump.
+scroll top
+press label="Jump to Write Operations"
+press label="write() base64"
+wait text "write() base64 = \"OK - text() = Hello Base64!\"" 10000
+scroll top
+press label="Jump to File Lifecycle"
+press label="Create new file in cache"
+wait text "Create new file in cache = " 10000
+press label="Check exists"
+wait text "Check exists = {" 10000
+wait text "\"exists\": true" 5000
+press label="Delete current file"
+wait text "Delete current file = {" 10000
+wait text "\"existsAfter\": false" 5000
+close

--- a/apps/bare-expo/e2e/expo-video/playback-events.ad
+++ b/apps/bare-expo/e2e/expo-video/playback-events.ad
@@ -1,0 +1,27 @@
+# expo-video: playback state on the Video Events screen. Native port of playback-test.yaml
+# without the view shot step.
+open ${APP_ID} --relaunch
+wait text "Expo Test Suite" 20000
+open "bareexpo://components/video/events"
+wait text "status = readyToPlay" 20000
+wait text "isPlaying = false"
+wait text "isAtStart = true"
+wait text "duration = 27"
+wait text "currentTime = 0"
+wait text "isSupported = true"
+wait text "volume = 1"
+wait text "playbackRate = 1"
+wait text "error = false"
+# The scroll view inherits the label of its first child, so qualify the button by role.
+press "role=button label=\"Play\""
+wait text "isPlaying = true" 10000
+wait text "isAtStart = false" 10000
+press "role=button label=\"Pause\""
+wait text "isPlaying = false" 10000
+press label="Seek to 20s"
+wait text "currentTime = 20" 10000
+press label="Trigger an Error"
+wait text "status = error" 15000
+wait text "error = true" 10000
+wait text "isPlaying = false"
+close

--- a/apps/native-component-list/src/screens/Audio/AudioEventsScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioEventsScreen.tsx
@@ -33,6 +33,7 @@ function AudioEvents() {
   const player = useAudioPlayer(localSource);
   const status = useAudioPlayerStatus(player);
   const [eventLog, setEventLog] = useState<EventLogEntry[]>([]);
+  const [finishCount, setFinishCount] = useState(0);
   const eventIdRef = useRef(0);
   const scrollViewRef = useRef<FlatList>(null);
   const prevStatusRef = useRef<AudioStatus | null>(null);
@@ -61,6 +62,9 @@ function AudioEvents() {
 
     const hasChanges = Object.keys(changes).length > 0;
     const isDidJustFinish = status.didJustFinish;
+    if (isDidJustFinish && !prevStatus?.didJustFinish) {
+      setFinishCount((count) => count + 1);
+    }
 
     if (hasChanges || isDidJustFinish) {
       const entry: EventLogEntry = {
@@ -114,6 +118,7 @@ function AudioEvents() {
           value={status.didJustFinish}
           highlight={status.didJustFinish}
         />
+        <StatusRow label="didJustFinishCount" value={finishCount} />
         <StatusRow label="isLoaded" value={status.isLoaded} />
         <StatusRow label="loop" value={status.loop} />
         <StatusRow label="currentTime" value={status.currentTime.toFixed(2)} />
@@ -169,10 +174,13 @@ function StatusRow({
   highlight?: boolean;
 }) {
   const displayValue = typeof value === 'boolean' ? (value ? 'true' : 'false') : String(value);
+  // One text node per row so e2e tests can match "label = value" as a single string.
   return (
     <View style={styles.statusRow}>
-      <Text style={styles.statusLabel}>{label}:</Text>
-      <Text style={[styles.statusValue, highlight && styles.highlightedText]}>{displayValue}</Text>
+      <Text style={[styles.statusValue, highlight && styles.highlightedText]}>
+        <Text style={styles.statusLabel}>{label}</Text>
+        {` = ${displayValue}`}
+      </Text>
     </View>
   );
 }

--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -29,9 +29,9 @@ import {
 } from 'react-native';
 
 import { BodyText } from '../components/BodyText';
-import HeadingText from '../components/HeadingText';
 import ListButton from '../components/ListButton';
 import MonoText from '../components/MonoText';
+import { SectionHeading, SectionIndex, SectionIndexScrollView } from '../components/SectionIndex';
 import SimpleActionDemo from '../components/SimpleActionDemo';
 
 FileSystemScreen.navigationOptions = {
@@ -123,8 +123,9 @@ export default function FileSystemScreen() {
   }
 
   return (
-    <ScrollView>
+    <SectionIndexScrollView>
       <View style={styles.container}>
+        <SectionIndex />
         {currentFile && (
           <View style={styles.currentFileBar}>
             <Text style={styles.currentFileText}>Current: {truncate(currentFile.uri, 80)}</Text>
@@ -160,7 +161,7 @@ export default function FileSystemScreen() {
         <UploadSection currentFile={currentFile} />
         <DownloadTaskSection />
       </View>
-    </ScrollView>
+    </SectionIndexScrollView>
   );
 }
 
@@ -169,7 +170,7 @@ export default function FileSystemScreen() {
 function FileSourcesSection({ setCurrentFile }: { setCurrentFile: (f: File) => void }) {
   return (
     <>
-      <HeadingText>File Sources</HeadingText>
+      <SectionHeading title="File Sources" />
       <Text style={styles.note}>Pick or create a file to use in sections below</Text>
 
       <ListButton
@@ -282,7 +283,7 @@ type WithCurrentFile = (fn: (file: File) => Promise<any>) => () => Promise<any>;
 function FileInfoSection({ withCurrentFile }: { withCurrentFile: WithCurrentFile }) {
   return (
     <>
-      <HeadingText>File Info & Properties</HeadingText>
+      <SectionHeading title="File Info & Properties" />
       <SimpleActionDemo
         title="Show file properties"
         action={withCurrentFile(async (file) => ({
@@ -335,7 +336,7 @@ function FilePreviewSection({
 
   return (
     <>
-      <HeadingText>File Preview</HeadingText>
+      <SectionHeading title="File Preview" />
       <Text style={styles.note}>Open local files with the platform file preview flow</Text>
 
       <ListButton
@@ -398,7 +399,7 @@ function FilePreviewSection({
 function ReadWriteSection({ withCurrentFile }: { withCurrentFile: WithCurrentFile }) {
   return (
     <>
-      <HeadingText>Read Operations</HeadingText>
+      <SectionHeading title="Read Operations" />
       <SimpleActionDemo
         title="text()"
         action={withCurrentFile(async (file) => truncate(await file.text()))}
@@ -418,7 +419,7 @@ function ReadWriteSection({ withCurrentFile }: { withCurrentFile: WithCurrentFil
         })}
       />
 
-      <HeadingText>Write Operations</HeadingText>
+      <SectionHeading title="Write Operations" />
       <Text style={styles.note}>Works on local and picked files. Throws on static assets.</Text>
       <SimpleActionDemo
         title="write() text"
@@ -481,7 +482,7 @@ function FileHandleSection({ currentFile }: { currentFile: File | null }) {
 
   return (
     <>
-      <HeadingText>File Handle (Random Access)</HeadingText>
+      <SectionHeading title="File Handle (Random Access)" />
       <Text style={styles.note}>Works on local and picked files</Text>
       {Platform.OS === 'android' && (
         <View style={styles.optionRow}>
@@ -645,7 +646,7 @@ function FileWatcherSection({ currentFile }: { currentFile: File | null }) {
 
   return (
     <>
-      <HeadingText>File System Watcher</HeadingText>
+      <SectionHeading title="File System Watcher" />
       <Text style={styles.note}>Watch files or directories for changes</Text>
 
       <ListButton
@@ -710,7 +711,7 @@ function CopyMoveSection({
 
   return (
     <>
-      <HeadingText>Copy & Move</HeadingText>
+      <SectionHeading title="Copy & Move" />
       <View style={styles.optionRow}>
         <Checkbox value={overwrite} onValueChange={setOverwrite} style={styles.checkbox} />
         <BodyText style={styles.optionLabel}>overwrite</BodyText>
@@ -791,7 +792,7 @@ function DirectoryOperationsSection({
 }) {
   return (
     <>
-      <HeadingText>Picked Directory Operations</HeadingText>
+      <SectionHeading title="Picked Directory Operations" />
       <ListButton
         title="Pick directory"
         onPress={async () => {
@@ -871,7 +872,7 @@ function AndroidIntentsSection({
 }) {
   return (
     <>
-      <HeadingText>Content URI & Intents</HeadingText>
+      <SectionHeading title="Content URI & Intents" />
       <SimpleActionDemo
         title="Get contentUri for current file"
         action={withCurrentFile(async (file) => ({
@@ -925,7 +926,7 @@ function FileLifecycleSection({
 }) {
   return (
     <>
-      <HeadingText>File Lifecycle</HeadingText>
+      <SectionHeading title="File Lifecycle" />
       <SimpleActionDemo
         title="Create new file in cache"
         action={async () => {
@@ -1002,7 +1003,7 @@ function FilePickerSection({ setCurrentFile }: { setCurrentFile: (f: File) => vo
   };
   return (
     <>
-      <HeadingText>File Picker</HeadingText>
+      <SectionHeading title="File Picker" />
       <View style={styles.optionRow}>
         <Checkbox value={multiple} onValueChange={setMultiple} style={styles.checkbox} />
         <BodyText style={styles.optionLabel}>multiple files</BodyText>
@@ -1136,7 +1137,7 @@ function DownloadSection() {
 
   return (
     <>
-      <HeadingText>Large File Download (100 MB)</HeadingText>
+      <SectionHeading title="Large File Download (100 MB)" />
 
       {status === 'idle' && <ListButton title="Start download" onPress={startDownload} />}
 
@@ -1240,7 +1241,7 @@ function UploadSection({ currentFile }: { currentFile: File | null }) {
 
   return (
     <>
-      <HeadingText>Upload Task</HeadingText>
+      <SectionHeading title="Upload Task" />
       <ListButton
         title="Upload binary"
         disabled={!currentFile || uploading}
@@ -1408,7 +1409,7 @@ function DownloadTaskSection() {
 
   return (
     <>
-      <HeadingText>Download Task</HeadingText>
+      <SectionHeading title="Download Task" />
       <ListButton
         title="Start download"
         disabled={status === 'downloading'}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)