### PR TITLE
[bare-expo][ncl] Add agent-device e2e scripts for screen orientation, video fullscreen, and image manipulator

### DIFF
--- a/apps/bare-expo/e2e/expo-image-manipulator/resize-crop-rotate.ios.ad
+++ b/apps/bare-expo/e2e/expo-image-manipulator/resize-crop-rotate.ios.ad
@@ -1,0 +1,16 @@
+# expo-image-manipulator: resize, crop, and rotate a bundled image and check the result size.
+# iOS only for now: in the Android Release build the bundled example image resolves to a missing
+# /android_res/drawable path (Glide FileNotFoundException), so no operation applies there.
+open ${APP_ID} --relaunch
+wait text "Expo Test Suite" 20000
+open "bareexpo://apis/imagemanipulator"
+wait text "Resize both to square" 20000
+press label="Resize both to square"
+wait text "size = 300 x 300" 15000
+press label="Crop - half image"
+wait text "size = 150 x 300" 15000
+press label="-90"
+wait text "size = 300 x 150" 15000
+press label="Reset photo"
+wait text "size = 800 x 533" 15000
+close

--- a/apps/bare-expo/e2e/expo-screen-orientation/lock-and-rotate.ad
+++ b/apps/bare-expo/e2e/expo-screen-orientation/lock-and-rotate.ad
@@ -1,0 +1,14 @@
+# expo-screen-orientation: lock to landscape, observe the orientation change, lock back.
+open ${APP_ID} --relaunch
+wait text "Expo Test Suite" 20000
+open "bareexpo://apis/screenorientation"
+wait text "OrientationLock:" 20000
+press label="LANDSCAPE_LEFT"
+wait text "OrientationLock: LANDSCAPE_LEFT" 10000
+wait text "Orientation: LANDSCAPE_LEFT" 10000
+press label="PORTRAIT_UP"
+wait text "OrientationLock: PORTRAIT_UP" 10000
+wait text "Orientation: PORTRAIT_UP" 10000
+press label="DEFAULT"
+wait text "OrientationLock: DEFAULT" 10000
+close

--- a/apps/bare-expo/e2e/expo-video/fullscreen.android.ad
+++ b/apps/bare-expo/e2e/expo-video/fullscreen.android.ad
@@ -1,0 +1,15 @@
+# expo-video: enter and leave fullscreen and check the fullscreen events. Native port of
+# fullscreen-test.yaml. Android: reveal the player controls, then press the fullscreen toggle.
+# The toggle keeps the label "Enter fullscreen" while in fullscreen.
+open ${APP_ID} --relaunch
+wait text "Expo Test Suite" 20000
+open "bareexpo://components/video/fullscreen"
+wait text "Enter Fullscreen" 20000
+press "role=button label=\"Enter Fullscreen\""
+wait "label=\"Show player controls\"" 10000
+press label="Show player controls"
+press label="Enter fullscreen"
+wait text "Enter Fullscreen" 10000
+wait text "0 = onFullscreenEnter" 10000
+wait text "1 = onFullscreenExit" 10000
+close

--- a/apps/bare-expo/e2e/expo-video/fullscreen.ios.ad
+++ b/apps/bare-expo/e2e/expo-video/fullscreen.ios.ad
@@ -1,0 +1,14 @@
+# expo-video: enter and leave fullscreen and check the fullscreen events. Native port of
+# fullscreen-test.yaml. iOS: the system player hides its controls until the video is tapped.
+open ${APP_ID} --relaunch
+wait text "Expo Test Suite" 20000
+open "bareexpo://components/video/fullscreen"
+wait text "Enter Fullscreen" 20000
+press "role=button label=\"Enter Fullscreen\""
+wait 2500
+press label="Video"
+press "role=button label=\"Close\""
+wait text "Enter Fullscreen" 10000
+wait text "0 = onFullscreenEnter" 10000
+wait text "1 = onFullscreenExit" 10000
+close

--- a/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
+++ b/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
@@ -37,6 +37,7 @@ export default function ImageManipulatorScreen() {
     return (
       <View style={styles.imageContainer}>
         <Image source={{ uri: image.uri }} style={[styles.image, { height, width }]} />
+        <Text>{`size = ${image.width} x ${image.height}`}</Text>
       </View>
     );
   };


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)