### PR TITLE
chore(expo-router): Drop `fast-deep-equal` and `shallowequal` deps

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -128,6 +128,7 @@
 - [Internal] Read the development server URL from `expo/internal/bundle-origin` instead of duplicating its accessor ([#48278](https://github.com/expo/expo/pull/48278) by [@kitten](https://github.com/kitten))
 - [Internal] Isolate the loader's Suspense store from `LoaderClient` ([#48563](https://github.com/expo/expo/pull/48563) by [@hassankhan](https://github.com/hassankhan))
 - [Internal] Remove legacy root entrypoint shims ([#49001](https://github.com/expo/expo/pull/49001) by [@hassankhan](https://github.com/hassankhan))
+- Drop `fast-deep-equal` and `shallowequal` dependencies ([#49875](https://github.com/expo/expo/pull/49875) by [@kitten](https://github.com/kitten))
 
 ## 57.0.9 - 2026-07-29
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -292,7 +292,6 @@
     "escape-string-regexp": "^4.0.0",
     "expo-glass-effect": "workspace:^",
     "expo-server": "workspace:^",
-    "fast-deep-equal": "^3.1.3",
     "invariant": "^2.2.4",
     "nanoid": "^3.3.18",
     "query-string": "^7.1.3",
@@ -302,7 +301,6 @@
     "react-native-screens": "^4.27.0",
     "server-only": "^0.0.1",
     "sf-symbols-typescript": "^2.1.0",
-    "shallowequal": "^1.1.0",
     "standard-navigation": "^0.0.5"
   },
   "devDependencies": {

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -1,5 +1,5 @@
-import isEqual from 'fast-deep-equal';
 import { type RefObject, use, useEffect, useEffectEvent, useRef, useState } from 'react';
+import isEqual from 'react-fast-compare';
 
 import {
   completeParsedState,

--- a/packages/expo-router/src/global-state/getRouteInfoFromState.ts
+++ b/packages/expo-router/src/global-state/getRouteInfoFromState.ts
@@ -1,4 +1,4 @@
-import isEqual from 'fast-deep-equal';
+import isEqual from 'react-fast-compare';
 
 import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from '../constants';
 import { appendBaseUrl } from '../fork/getPathFromState-forks';

--- a/packages/expo-router/src/global-state/resolveNavigationDestination.ts
+++ b/packages/expo-router/src/global-state/resolveNavigationDestination.ts
@@ -1,4 +1,4 @@
-import isEqual from 'fast-deep-equal';
+import isEqual from 'react-fast-compare';
 
 import { findRouteNodeByName, getValidInitialRouteName, type RouteNode } from '../Route';
 import { INTERNAL_SLOT_NAME } from '../constants';

--- a/packages/expo-router/src/react-navigation/routers/attachRouteState.tsx
+++ b/packages/expo-router/src/react-navigation/routers/attachRouteState.tsx
@@ -1,4 +1,4 @@
-import isEqual from 'fast-deep-equal';
+import isEqual from 'react-fast-compare';
 
 import type { NavigationState, PartialState, Route } from './types';
 

--- a/packages/expo-router/vendor/react-helmet-async/lib/index.esm.js
+++ b/packages/expo-router/vendor/react-helmet-async/lib/index.esm.js
@@ -454,7 +454,22 @@ var HelmetProvider = class _HelmetProvider extends Component {
 
 // src/Dispatcher.tsx
 import { Component as Component2 } from "react";
-import shallowEqual from "shallowequal";
+var shallowEqual = (objA, objB) => {
+  if (objA === objB) {
+    return true;
+  }
+  if (typeof objA !== "object" || !objA || typeof objB !== "object" || !objB) {
+    return false;
+  }
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+  return keysA.every(
+    (key) => Object.prototype.hasOwnProperty.call(objB, key) && objA[key] === objB[key]
+  );
+};
 
 // src/client.ts
 var updateTags = (type, tags) => {

--- a/packages/expo-router/vendor/react-helmet-async/lib/index.js
+++ b/packages/expo-router/vendor/react-helmet-async/lib/index.js
@@ -490,7 +490,22 @@ var HelmetProvider = class _HelmetProvider extends import_react2.Component {
 
 // src/Dispatcher.tsx
 var import_react3 = require("react");
-var import_shallowequal = __toESM(require("shallowequal"));
+var shallowEqual = (objA, objB) => {
+  if (objA === objB) {
+    return true;
+  }
+  if (typeof objA !== "object" || !objA || typeof objB !== "object" || !objB) {
+    return false;
+  }
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+  return keysA.every(
+    (key) => Object.prototype.hasOwnProperty.call(objB, key) && objA[key] === objB[key]
+  );
+};
 
 // src/client.ts
 var updateTags = (type, tags) => {
@@ -637,7 +652,7 @@ var client_default = handleStateChangeOnClient;
 var HelmetDispatcher = class extends import_react3.Component {
   rendered = false;
   shouldComponentUpdate(nextProps) {
-    return !(0, import_shallowequal.default)(nextProps, this.props);
+    return !shallowEqual(nextProps, this.props);
   }
   componentDidUpdate() {
     this.emitChange();

--- a/packages/expo-router/vendor/react-helmet-async/vendor.md
+++ b/packages/expo-router/vendor/react-helmet-async/vendor.md
@@ -1,3 +1,5 @@
 This library has been vendored to remove the dependency on `react-dom` and allow the peerDependency for `react@19.x` to be satisfied.
 
+The `shallowequal` dependency is inlined because the dispatcher only needs its basic, comparator-free behavior.
+
 This is a fork of `react-helmet-async` https://github.com/staylor/react-helmet-async

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,7 +396,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.4.1
+        version: 1.4.2
       '@types/pngjs':
         specifier: ^6.0.5
         version: 6.0.5
@@ -5588,9 +5588,6 @@ importers:
       expo-server:
         specifier: workspace:^
         version: link:../expo-server
-      fast-deep-equal:
-        specifier: ^3.1.3
-        version: 3.1.3
       invariant:
         specifier: ^2.2.4
         version: 2.2.4
@@ -5627,9 +5624,6 @@ importers:
       sf-symbols-typescript:
         specifier: ^2.1.0
         version: 2.2.0
-      shallowequal:
-        specifier: ^1.1.0
-        version: 1.1.0
       standard-navigation:
         specifier: ^0.0.5
         version: 0.0.5
@@ -9787,8 +9781,8 @@ packages:
   '@types/braces@3.0.5':
     resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
 
-  '@types/bun@1.4.1':
-    resolution: {integrity: sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA==}
+  '@types/bun@1.4.2':
+    resolution: {integrity: sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ==}
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
@@ -10750,8 +10744,8 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  bun-types@1.4.1:
-    resolution: {integrity: sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA==}
+  bun-types@1.4.2:
+    resolution: {integrity: sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -13273,10 +13267,6 @@ packages:
     resolution: {integrity: sha512-Dc57t8jsINwA90bbVlqaeDlxf1rVGgj5SmOEnOMbaHNUM/HCYYTJxPV8SRdOBwh7qTz/biO9vaQvBTjRBgbbsg==}
     engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
 
-  metro-minify-terser@0.84.5:
-    resolution: {integrity: sha512-BJoFwCEDsYnagPqarayInv2+diCDNDdLlaof/p6s9w4gh+gc9HXYM+pDvsKGKKUumpZswNF3Z/ftTMqKl/5IBg==}
-    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
-
   metro-minify-terser@0.84.6:
     resolution: {integrity: sha512-SqhB/Kxrw0XfyW0k8mEscqX/CQopm6Fp3EpdSIPzvKfGgQp9bTMahg9PAdVsXUmIWwErbmFw1VqB+VFBOKksUw==}
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
@@ -14626,9 +14616,6 @@ packages:
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
-
-  shallowequal@1.1.0:
-    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
   sharp-cli@5.2.0:
     resolution: {integrity: sha512-0DQyABFTWkla4FYvjguCQloSgm2htOPfGFur88HXiGu8BPfhb77frWn+E87w8Oog0eSHF4/uMt5AFhpvfY/Zrg==}
@@ -18582,9 +18569,9 @@ snapshots:
 
   '@types/braces@3.0.5': {}
 
-  '@types/bun@1.4.1':
+  '@types/bun@1.4.2':
     dependencies:
-      bun-types: 1.4.1
+      bun-types: 1.4.2
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -19643,7 +19630,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bun-types@1.4.1:
+  bun-types@1.4.2:
     dependencies:
       '@types/node': 22.20.1
 
@@ -22603,11 +22590,6 @@ snapshots:
       nullthrows: 1.1.1
       walker: 1.0.8
 
-  metro-minify-terser@0.84.5:
-    dependencies:
-      flow-enums-runtime: 0.0.6
-      terser: 5.49.0
-
   metro-minify-terser@0.84.6:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -24163,8 +24145,6 @@ snapshots:
   shallow-clone@3.0.1:
     dependencies:
       kind-of: 6.0.3
-
-  shallowequal@1.1.0: {}
 
   sharp-cli@5.2.0:
     dependencies:


### PR DESCRIPTION
# Why

Drop `fast-deep-equal` and `shallowequal` deps. The latter is used in `react-helmet-async` which we'll eventually replace but for now we can replace that function with a simple inlined version. It also uses `react-fast-compare` which is also a deep comparator library, so we can replace `fast-deep-equal` with it.

# How

- Replace `fast-deep-equal`
- Inline `shallowEqual` function (simplified)
- Drop `shallowequal`

# Test Plan

- E2E should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
