### PR TITLE
[router-server] Do not outline completed Suspense boundaries on size alone

### DIFF
--- a/packages/@expo/router-server/CHANGELOG.md
+++ b/packages/@expo/router-server/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Stop outlining completed Suspense boundaries during streaming SSR, so visible markup is written before the bootstrap script rather than after it ([#49878](https://github.com/expo/expo/pull/49878) by [@kev-flex](https://github.com/kev-flex))
+
 ### 💡 Others
 
 - [Internal] Inject CSS and JavaScript bundle tags within `getStaticContent()`. ([#47006](https://github.com/expo/expo/pull/47006) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/router-server/CHANGELOG.md
+++ b/packages/@expo/router-server/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Stop outlining completed Suspense boundaries during streaming SSR, so visible markup is written before the bootstrap script rather than after it ([#49878](https://github.com/expo/expo/pull/49878) by [@kev-flex](https://github.com/kev-flex))
+- Write the page's markup before the bootstrap script during streaming SSR, instead of outlining completed Suspense boundaries behind it ([#49878](https://github.com/expo/expo/pull/49878) by [@kev-flex](https://github.com/kev-flex))
 
 ### 💡 Others
 

--- a/packages/@expo/router-server/src/server/renderStreamingContent.tsx
+++ b/packages/@expo/router-server/src/server/renderStreamingContent.tsx
@@ -29,10 +29,8 @@ import {
 
 const debug = createDebug('expo:router:server:renderStreamingContent');
 
-// Outlining a completed Suspense boundary moves its markup after `bootstrapScriptContent`
-// without revealing it any sooner, so size-based outlining only delays the first paint here.
-// Not `Infinity`: this value is serialised into `PostponedState`, where it would become `null`.
-// React also derives its blocking-render limit from it, as `progressiveChunkSize * 40`.
+// NOTE(@kev-flex): not `Infinity`, which `PostponedState` serialises to `null`. React also
+// derives its blocking-render limit from this value, as `progressiveChunkSize * 40`.
 const DISABLE_SIZE_BASED_OUTLINING = Number.MAX_SAFE_INTEGER;
 
 function resetReactNavigationContexts() {

--- a/packages/@expo/router-server/src/server/renderStreamingContent.tsx
+++ b/packages/@expo/router-server/src/server/renderStreamingContent.tsx
@@ -29,6 +29,12 @@ import {
 
 const debug = createDebug('expo:router:server:renderStreamingContent');
 
+// Outlining a completed Suspense boundary moves its markup after `bootstrapScriptContent`
+// without revealing it any sooner, so size-based outlining only delays the first paint here.
+// Not `Infinity`: this value is serialised into `PostponedState`, where it would become `null`.
+// React also derives its blocking-render limit from it, as `progressiveChunkSize * 40`.
+const DISABLE_SIZE_BASED_OUTLINING = Number.MAX_SAFE_INTEGER;
+
 function resetReactNavigationContexts() {
   // https://github.com/expo/router/discussions/588
   // https://github.com/react-navigation/react-navigation/blob/9fe34b445fcb86e5666f61e144007d7540f014fa/packages/elements/src/getNamedContext.tsx#LL3C1-L4C1
@@ -163,9 +169,7 @@ export async function getStreamingContent(
         </Head.Provider>
       </ServerDocument>,
       {
-        // Every route renders inside a Suspense boundary with a `null` fallback, so
-        // outlining a completed boundary can never reveal content sooner.
-        progressiveChunkSize: Number.MAX_SAFE_INTEGER,
+        progressiveChunkSize: DISABLE_SIZE_BASED_OUTLINING,
         bootstrapScriptContent: getBootstrapContents({ hydrate: true, loadedData }),
         bootstrapScripts: options?.assets?.js,
         signal: options?.request?.signal,

--- a/packages/@expo/router-server/src/server/renderStreamingContent.tsx
+++ b/packages/@expo/router-server/src/server/renderStreamingContent.tsx
@@ -163,9 +163,9 @@ export async function getStreamingContent(
         </Head.Provider>
       </ServerDocument>,
       {
-        // TODO(@hassankhan): Experiment and see if we can calculate a better default
-        // We're doubling the default here so non-JavaScript renders show some content
-        progressiveChunkSize: 12800 * 2,
+        // Every route renders inside a Suspense boundary with a `null` fallback, so
+        // outlining a completed boundary can never reveal content sooner.
+        progressiveChunkSize: Number.MAX_SAFE_INTEGER,
         bootstrapScriptContent: getBootstrapContents({ hydrate: true, loadedData }),
         bootstrapScripts: options?.assets?.js,
         signal: options?.request?.signal,


### PR DESCRIPTION
# Why

React outlines a completed Suspense boundary once it exceeds `progressiveChunkSize`: the markup goes into a hidden div after `bootstrapScriptContent` and a `$RC` script reveals it. On a route with a large loader payload that is where first paint goes, and outlining cannot show anything sooner than inlining would.

On our app, with 286 KB of loader data in the bootstrap script, first contentful paint went from 1544 ms to 700 ms. Medians of 3 real Chrome cold loads of the home route, mobile throttling at 150 ms RTT / 1.6 Mbps / 4x CPU, served from a CDN hit, react-dom 19.2.3, ~780 KB of rendered HTML. Total bytes go down too, since the wrappers and reveal scripts are gone.

The comment this replaces justified the doubled default as "so non-JavaScript renders show some content". Outlined content sits in `<div hidden>` until `$RC` runs, so inlining serves that intent rather than dropping it. A route with a real fallback (`SuspenseFallback`, or the dev Toast) improves as well: an outlined *completed* boundary writes the fallback and immediately swaps it, and inlining removes that flash.

# How

Names the value and sets it high enough that size alone never outlines. Boundaries with hoisted stylesheets or suspensey images still outline, and boundaries that actually suspend still stream as they resolve. Not `Infinity`, because the value is serialised into `PostponedState` where it would become `null` and invert the comparison. React also derives its blocking-render limit from it, as `progressiveChunkSize * 40`.

The inlined path writes without consulting `desiredSize`, so a very large page becomes one contiguous write burst rather than yielding per boundary. The value is not exposed as an option.

# Test Plan

Exported a `web.output: "server"` app before and after and diffed the HTML: the route's markup now precedes the bootstrap script and no `<div hidden id="S:` remains. Measured as above.

No automated coverage here yet. A unit test asserting the literal passed to `renderToReadableStream` would be a tautology; the meaningful home is `packages/@expo/cli/e2e/__tests__/export/server-rendering.test.ts`, which `cli.yml` does run for this package, with a fixture route rendering over 25600 bytes and asserting both of the above. I could not run that suite outside the monorepo, so I have left it out rather than add a test I have not seen pass. Say the word and I will add it.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). N/A, web SSR only
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md). N/A, no docs changes

