### PR TITLE
[babel-preset-expo] Remove imports left unreferenced by loader stripping

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Remove imports left unreferenced by `loader` and metadata stripping, so the server-only loader chain does not reach the client bundle when the Metro graph optimizer is enabled ([#49879](https://github.com/expo/expo/pull/49879) by [@kev-flex](https://github.com/kev-flex))
 - Escape backslashes when serializing `'widget'` functions so escape sequences like `\n` in a widget layout survive the template-literal round-trip instead of corrupting the stored function and crashing the widget with `SyntaxError: Unexpected EOF`. ([#47626](https://github.com/expo/expo/pull/47626) by [@alecmolloy](https://github.com/alecmolloy))
 - Fix legacy decorators on class properties when corresponding class transforms are disabled, which the decorators plugin relies on ([#47724](https://github.com/expo/expo/pull/47724) by [@Gitarcitano](https://github.com/Gitarcitano), [@kitten](https://github.com/kitten))
 - Disable `@babel/plugin-transform-object-rest-spread` in Hermes v1 and Modern Web sub-presets. The ordering dependence on `@babel/plugin-transform-destructuring` could cause computed exclusion to be missed ([#49278](https://github.com/expo/expo/pull/49278) by [@kitten](https://github.com/kitten))

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -13,8 +13,8 @@
 - Escape backslashes when serializing `'widget'` functions so escape sequences like `\n` in a widget layout survive the template-literal round-trip instead of corrupting the stored function and crashing the widget with `SyntaxError: Unexpected EOF`. ([#47626](https://github.com/expo/expo/pull/47626) by [@alecmolloy](https://github.com/alecmolloy))
 - Fix legacy decorators on class properties when corresponding class transforms are disabled, which the decorators plugin relies on ([#47724](https://github.com/expo/expo/pull/47724) by [@Gitarcitano](https://github.com/Gitarcitano), [@kitten](https://github.com/kitten))
 - Disable `@babel/plugin-transform-object-rest-spread` in Hermes v1 and Modern Web sub-presets. The ordering dependence on `@babel/plugin-transform-destructuring` could cause computed exclusion to be missed ([#49278](https://github.com/expo/expo/pull/49278) by [@kitten](https://github.com/kitten))
-
 - Remove imports left unreferenced by `loader` stripping when the Metro graph optimizer is enabled ([#49879](https://github.com/expo/expo/pull/49879) by [@kev-flex](https://github.com/kev-flex))
+
 ### 💡 Others
 
 - Bump to `@expo/metro@56.1.0` and `metro@0.84.6` ([#49671](https://github.com/expo/expo/pull/49671) by [@robhogan](https://github.com/robhogan))

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fix legacy decorators on class properties when corresponding class transforms are disabled, which the decorators plugin relies on ([#47724](https://github.com/expo/expo/pull/47724) by [@Gitarcitano](https://github.com/Gitarcitano), [@kitten](https://github.com/kitten))
 - Disable `@babel/plugin-transform-object-rest-spread` in Hermes v1 and Modern Web sub-presets. The ordering dependence on `@babel/plugin-transform-destructuring` could cause computed exclusion to be missed ([#49278](https://github.com/expo/expo/pull/49278) by [@kitten](https://github.com/kitten))
 
-- Remove imports left unreferenced by `loader` and metadata stripping, so the server-only loader chain does not reach the client bundle when the Metro graph optimizer is enabled ([#49879](https://github.com/expo/expo/pull/49879) by [@kev-flex](https://github.com/kev-flex))
+- Remove imports left unreferenced by `loader` stripping when the Metro graph optimizer is enabled ([#49879](https://github.com/expo/expo/pull/49879) by [@kev-flex](https://github.com/kev-flex))
 ### 💡 Others
 
 - Bump to `@expo/metro@56.1.0` and `metro@0.84.6` ([#49671](https://github.com/expo/expo/pull/49671) by [@robhogan](https://github.com/robhogan))

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,11 +10,11 @@
 
 ### 🐛 Bug fixes
 
-- Remove imports left unreferenced by `loader` and metadata stripping, so the server-only loader chain does not reach the client bundle when the Metro graph optimizer is enabled ([#49879](https://github.com/expo/expo/pull/49879) by [@kev-flex](https://github.com/kev-flex))
 - Escape backslashes when serializing `'widget'` functions so escape sequences like `\n` in a widget layout survive the template-literal round-trip instead of corrupting the stored function and crashing the widget with `SyntaxError: Unexpected EOF`. ([#47626](https://github.com/expo/expo/pull/47626) by [@alecmolloy](https://github.com/alecmolloy))
 - Fix legacy decorators on class properties when corresponding class transforms are disabled, which the decorators plugin relies on ([#47724](https://github.com/expo/expo/pull/47724) by [@Gitarcitano](https://github.com/Gitarcitano), [@kitten](https://github.com/kitten))
 - Disable `@babel/plugin-transform-object-rest-spread` in Hermes v1 and Modern Web sub-presets. The ordering dependence on `@babel/plugin-transform-destructuring` could cause computed exclusion to be missed ([#49278](https://github.com/expo/expo/pull/49278) by [@kitten](https://github.com/kitten))
 
+- Remove imports left unreferenced by `loader` and metadata stripping, so the server-only loader chain does not reach the client bundle when the Metro graph optimizer is enabled ([#49879](https://github.com/expo/expo/pull/49879) by [@kev-flex](https://github.com/kev-flex))
 ### 💡 Others
 
 - Bump to `@expo/metro@56.1.0` and `metro@0.84.6` ([#49671](https://github.com/expo/expo/pull/49671) by [@robhogan](https://github.com/robhogan))

--- a/packages/babel-preset-expo/src/plugins/__tests__/server-data-loaders-plugin.test.ts
+++ b/packages/babel-preset-expo/src/plugins/__tests__/server-data-loaders-plugin.test.ts
@@ -368,6 +368,138 @@ describe('client', () => {
     });
   });
 
+  describe('prunes imports left unreferenced by the removed loader', () => {
+    it('removes an import only the loader used', () => {
+      const res = transformTest(
+        `
+      import { fetchThings } from '../api';
+      import { useLoaderData } from 'expo-router';
+
+      export async function loader() {
+        return fetchThings();
+      }
+
+      export default function Index() {
+        return <div>{useLoaderData().name}</div>;
+      }
+    `,
+        { bundleType: 'client' }
+      );
+
+      expect(res.code).toMatchInlineSnapshot(`
+        "import { useLoaderData } from 'expo-router';
+        import { jsx as _jsx } from "react/jsx-runtime";
+        export default function Index() {
+          return /*#__PURE__*/_jsx("div", {
+            children: useLoaderData().name
+          });
+        }"
+      `);
+    });
+
+    it('keeps an import the component still references', () => {
+      const res = transformTest(
+        `
+      import { formatName } from '../format';
+
+      export async function loader() {
+        return { name: formatName('a') };
+      }
+
+      export default function Index() {
+        return <div>{formatName('b')}</div>;
+      }
+    `,
+        { bundleType: 'client' }
+      );
+
+      expect(res.code).toMatchInlineSnapshot(`
+        "import { formatName } from '../format';
+        import { jsx as _jsx } from "react/jsx-runtime";
+        export default function Index() {
+          return /*#__PURE__*/_jsx("div", {
+            children: formatName('b')
+          });
+        }"
+      `);
+    });
+
+    it('keeps an import when only some of its specifiers became unreferenced', () => {
+      const res = transformTest(
+        `
+      import { fetchThings, formatName } from '../api';
+
+      export async function loader() {
+        return fetchThings();
+      }
+
+      export default function Index() {
+        return <div>{formatName('a')}</div>;
+      }
+    `,
+        { bundleType: 'client' }
+      );
+
+      expect(res.code).toMatchInlineSnapshot(`
+        "import { fetchThings, formatName } from '../api';
+        import { jsx as _jsx } from "react/jsx-runtime";
+        export default function Index() {
+          return /*#__PURE__*/_jsx("div", {
+            children: formatName('a')
+          });
+        }"
+      `);
+    });
+
+    it('keeps a side-effect import', () => {
+      const res = transformTest(
+        `
+      import '../polyfill';
+      import { fetchThings } from '../api';
+
+      export async function loader() {
+        return fetchThings();
+      }
+
+      export default function Index() {
+        return <div>Index</div>;
+      }
+    `,
+        { bundleType: 'client' }
+      );
+
+      expect(res.code).toMatchInlineSnapshot(`
+        "import '../polyfill';
+        import { jsx as _jsx } from "react/jsx-runtime";
+        export default function Index() {
+          return /*#__PURE__*/_jsx("div", {
+            children: "Index"
+          });
+        }"
+      `);
+    });
+
+    it('leaves imports alone in files outside the app directory', () => {
+      const res = transformTest(
+        `
+      import { fetchThings } from '../api';
+
+      export async function loader() {
+        return fetchThings();
+      }
+    `,
+        { bundleType: 'client', filename: '/src/data' }
+      );
+
+      expect(res.code).toMatchInlineSnapshot(`
+        "import { fetchThings } from '../api';
+        export async function loader() {
+          return fetchThings();
+        }"
+      `);
+    });
+  });
+
   describe('edge cases', () => {
     it('handles files with no loader export', () => {
       const res = transformTest(

--- a/packages/babel-preset-expo/src/plugins/__tests__/server-data-loaders-plugin.test.ts
+++ b/packages/babel-preset-expo/src/plugins/__tests__/server-data-loaders-plugin.test.ts
@@ -386,6 +386,7 @@ describe('client', () => {
         { bundleType: 'client' }
       );
 
+      expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.code).toMatchInlineSnapshot(`
         "import { useLoaderData } from 'expo-router';
         import { jsx as _jsx } from "react/jsx-runtime";
@@ -413,6 +414,7 @@ describe('client', () => {
         { bundleType: 'client' }
       );
 
+      expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.code).toMatchInlineSnapshot(`
         "import { formatName } from '../format';
         import { jsx as _jsx } from "react/jsx-runtime";
@@ -440,6 +442,7 @@ describe('client', () => {
         { bundleType: 'client' }
       );
 
+      expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.code).toMatchInlineSnapshot(`
         "import { fetchThings, formatName } from '../api';
         import { jsx as _jsx } from "react/jsx-runtime";
@@ -468,6 +471,7 @@ describe('client', () => {
         { bundleType: 'client' }
       );
 
+      expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.code).toMatchInlineSnapshot(`
         "import '../polyfill';
         import { jsx as _jsx } from "react/jsx-runtime";
@@ -488,13 +492,40 @@ describe('client', () => {
         return fetchThings();
       }
     `,
-        { bundleType: 'client', filename: '/src/data' }
+        { bundleType: 'client', filename: '/components/MyComponent' }
       );
 
+      expect(res.metadata.performConstantFolding).toBeUndefined();
       expect(res.code).toMatchInlineSnapshot(`
         "import { fetchThings } from '../api';
         export async function loader() {
           return fetchThings();
+        }"
+      `);
+    });
+
+    it('keeps the React import under the classic JSX runtime', () => {
+      const res = transformTest(
+        `
+      import React from 'react';
+      import { fetchThings } from '../api';
+
+      export async function loader() {
+        return fetchThings();
+      }
+
+      export default function Index() {
+        return <div>Index</div>;
+      }
+    `,
+        { bundleType: 'client', presets: [[preset, { jsxRuntime: 'classic' }]] }
+      );
+
+      expect(res.metadata.performConstantFolding).toBe(true);
+      expect(res.code).toMatchInlineSnapshot(`
+        "import React from 'react';
+        export default function Index() {
+          return /*#__PURE__*/React.createElement("div", null, "Index");
         }"
       `);
     });

--- a/packages/babel-preset-expo/src/plugins/server-data-loaders-plugin.ts
+++ b/packages/babel-preset-expo/src/plugins/server-data-loaders-plugin.ts
@@ -139,8 +139,11 @@ export function serverDataLoadersPlugin(api: ConfigAPI & typeof import('@babel/c
       },
 
       Program: {
-        // Metro skips its per-file import/export pass when the graph optimizer is on, so an
-        // import left unreferenced by the removals above would survive into the client bundle.
+        // Metro skips its per-file import/export transform when the graph optimizer is on, so an
+        // import the removals above left unreferenced would survive into the bundle. Runs for any
+        // file this preset marked for folding, which includes `generateMetadata` removals.
+        //
+        // @see packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts#transformJS
         exit(path, state) {
           if (isLoaderBundle) {
             return;

--- a/packages/babel-preset-expo/src/plugins/server-data-loaders-plugin.ts
+++ b/packages/babel-preset-expo/src/plugins/server-data-loaders-plugin.ts
@@ -137,6 +137,47 @@ export function serverDataLoadersPlugin(api: ConfigAPI & typeof import('@babel/c
           }
         }
       },
+
+      Program: {
+        // Metro skips its per-file import/export pass when the graph optimizer is on, so an
+        // import left unreferenced by the removals above would survive into the client bundle.
+        exit(path, state) {
+          if (isLoaderBundle) {
+            return;
+          }
+
+          if (!isInAppDirectory(state.file.opts.filename ?? '', routerAbsoluteRoot)) {
+            return;
+          }
+
+          assertExpoMetadata(state.file.metadata);
+          if (!state.file.metadata.performConstantFolding) {
+            return;
+          }
+
+          path.scope.crawl();
+
+          for (const declaration of path.get('body')) {
+            if (
+              !declaration.isImportDeclaration() ||
+              declaration.node.importKind === 'type' ||
+              declaration.node.specifiers.length === 0
+            ) {
+              continue;
+            }
+
+            const isUnreferenced = declaration.node.specifiers.every((specifier) => {
+              const binding = path.scope.getBinding(specifier.local.name);
+              return binding != null && !binding.referenced;
+            });
+
+            if (isUnreferenced) {
+              debug('Removing unreferenced import:', declaration.node.source.value);
+              declaration.remove();
+            }
+          }
+        },
+      },
     },
   };
 }

--- a/packages/babel-preset-expo/src/plugins/server-data-loaders-plugin.ts
+++ b/packages/babel-preset-expo/src/plugins/server-data-loaders-plugin.ts
@@ -139,11 +139,8 @@ export function serverDataLoadersPlugin(api: ConfigAPI & typeof import('@babel/c
       },
 
       Program: {
-        // Metro skips its per-file import/export transform when the graph optimizer is on, so an
-        // import the removals above left unreferenced would survive into the bundle. Runs for any
-        // file this preset marked for folding, which includes `generateMetadata` removals.
-        //
-        // @see packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts#transformJS
+        // NOTE(@kev-flex): Metro skips `applyImportSupport` under `optimize`, so an import the
+        // removals above left unreferenced would otherwise survive into the bundle.
         exit(path, state) {
           if (isLoaderBundle) {
             return;


### PR DESCRIPTION
# Why

With `EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH`, a route's server-only `loader` implementation ships to the client and hydration fails with React error #520.

This plugin removes the `loader` export, but Metro skips its per-file import/export transform when the graph optimizer is on (`metro-transform-worker.ts`, "Disable all Metro single-file optimizations when full-graph optimization will be used"), so the now-unused `import { createLoader } from '...'` reaches the serializer. `treeShakeSerializerPlugin` will not unlink it: `hasSideEffectWithDebugTrace` walks the whole dependency closure and stops at the first module a `package.json` marks side-effectful. Here that is `expo/src/async-require/asyncRequireModule.ts`, matched by expo's own `sideEffects: ["./src/async-require/*.ts"]` and pulled into the closure by a dynamic `import()` several modules down in `@sanity/client`, which itself declares `sideEffects: false`. Any route whose loader chain reaches a dynamic import lands in the same place, and marking the app's own package `sideEffects: false` does not help because the walk continues into dependencies.

# How

A `Program.exit` pass removes import declarations whose bindings are all unreferenced, in files this preset marked for folding. That flag is set by two plugins, here and by `server-metadata-plugin` when it strips `generateMetadata`, so both are covered. Type-only and bare side-effect imports are untouched. The non-optimized path already produces this result: with `performConstantFolding` set, the import/export transform does not emit a `require()` for an unreferenced import.

`applyImportSupport` is the step that drops an unreferenced import, and it is skipped under `optimize`, while `performConstantFolding(ast)` on the line above it runs either way. So a Babel pass cannot reach imports that folding itself strands, and doing this in the transform worker instead would cover every file rather than only routes. That is the open question on this PR, and the reason the pass lives in one of the two plugins that set the flag rather than beside the folding call.

# Test Plan

Six cases in `src/plugins/__tests__/server-data-loaders-plugin.test.ts`: an import only the loader used is removed; one the component still references is kept; one with a mix of used and unused specifiers is kept; a side-effect import is kept; `React` survives under the classic JSX runtime; a file outside the app directory is untouched. Two fail without the plugin change. The rest of the package suite is unaffected, and `scripts/profile-plugins.js --config web` over `apps/router-e2e` puts the plugin at 0.3 ms before and 0.4 ms after across 244 files, inside run to run variance of the 45 to 55 ms preset total.

Exported a `web.output: "server"` app with both flags and `DEBUG=expo:treeshake`. Before, the trace shows `Skip graph unlinking due to side-effect` for the loader factory and the client entry contains the server-only module. After, 32 imports are pruned across 8 routes, no server-only module appears in any client chunk, and the pages hydrate.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). N/A, web bundling only
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md). N/A, no docs changes


