### PR TITLE
expo-audio: default enableBackgroundPlayback to false

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -41,7 +41,7 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
         "expo-audio",
         {
           "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone.",
-          "enableBackgroundPlayback": true,
+          "enableBackgroundPlayback": false,
           "enableBackgroundRecording": false
         }
       ]
@@ -77,8 +77,8 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
     {
       name: 'enableBackgroundPlayback',
       description:
-        'A boolean that determines whether to enable background audio playback. On Android, this adds a media playback foreground service and allows you to display the lockscreen controls and is required for sustained background playback. On iOS, this adds the `audio` background mode.',
-      default: 'true',
+        'A boolean that determines whether to enable background audio playback. On Android, this adds a media playback foreground service and allows you to display the lockscreen controls and is required for sustained background playback. On iOS, this adds the `audio` background mode. Set to `true` if your app plays audio in the background.',
+      default: 'false',
     },
   ]}
 />
@@ -199,7 +199,7 @@ On Android and iOS, `expo-audio` saves recordings in the app's cache directory b
 
 ### Playing audio in the background
 
-Background audio playback allows your app to continue playing audio when it moves to the background or when the device screen locks.
+Background audio playback allows your app to continue playing audio when it moves to the background or when the device screen locks. It is disabled by default. Apps that need it (for example music or podcast players) should set `enableBackgroundPlayback` to `true`.
 
 #### Configuration
 

--- a/docs/pages/versions/v55.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/audio.mdx
@@ -41,7 +41,7 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
         "expo-audio",
         {
           "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone.",
-          "enableBackgroundPlayback": true,
+          "enableBackgroundPlayback": false,
           "enableBackgroundRecording": false
         }
       ]
@@ -77,8 +77,8 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
     {
       name: 'enableBackgroundPlayback',
       description:
-        'A boolean that determines whether to enable background audio playback. On Android, this adds a media playback foreground service and allows you to display the lockscreen controls and is required for sustained background playback. On iOS, this adds the `audio` background mode.',
-      default: 'true',
+        'A boolean that determines whether to enable background audio playback. On Android, this adds a media playback foreground service and allows you to display the lockscreen controls and is required for sustained background playback. On iOS, this adds the `audio` background mode. Set to `true` if your app plays audio in the background.',
+      default: 'false',
     },
   ]}
 />
@@ -197,7 +197,7 @@ const styles = StyleSheet.create({
 
 ### Playing audio in the background
 
-Background audio playback allows your app to continue playing audio when it moves to the background or when the device screen locks.
+Background audio playback allows your app to continue playing audio when it moves to the background or when the device screen locks. It is disabled by default. Apps that need it (for example music or podcast players) should set `enableBackgroundPlayback` to `true`.
 
 #### Configuration
 

--- a/docs/pages/versions/v56.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/audio.mdx
@@ -41,7 +41,7 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
         "expo-audio",
         {
           "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone.",
-          "enableBackgroundPlayback": true,
+          "enableBackgroundPlayback": false,
           "enableBackgroundRecording": false
         }
       ]
@@ -77,8 +77,8 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
     {
       name: 'enableBackgroundPlayback',
       description:
-        'A boolean that determines whether to enable background audio playback. On Android, this adds a media playback foreground service and allows you to display the lockscreen controls and is required for sustained background playback. On iOS, this adds the `audio` background mode.',
-      default: 'true',
+        'A boolean that determines whether to enable background audio playback. On Android, this adds a media playback foreground service and allows you to display the lockscreen controls and is required for sustained background playback. On iOS, this adds the `audio` background mode. Set to `true` if your app plays audio in the background.',
+      default: 'false',
     },
   ]}
 />
@@ -199,7 +199,7 @@ On Android and iOS, `expo-audio` saves recordings in the app's cache directory b
 
 ### Playing audio in the background
 
-Background audio playback allows your app to continue playing audio when it moves to the background or when the device screen locks.
+Background audio playback allows your app to continue playing audio when it moves to the background or when the device screen locks. It is disabled by default. Apps that need it (for example music or podcast players) should set `enableBackgroundPlayback` to `true`.
 
 #### Configuration
 

--- a/docs/pages/versions/v57.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/audio.mdx
@@ -41,7 +41,7 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
         "expo-audio",
         {
           "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone.",
-          "enableBackgroundPlayback": true,
+          "enableBackgroundPlayback": false,
           "enableBackgroundRecording": false
         }
       ]
@@ -77,8 +77,8 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
     {
       name: 'enableBackgroundPlayback',
       description:
-        'A boolean that determines whether to enable background audio playback. On Android, this adds a media playback foreground service and allows you to display the lockscreen controls and is required for sustained background playback. On iOS, this adds the `audio` background mode.',
-      default: 'true',
+        'A boolean that determines whether to enable background audio playback. On Android, this adds a media playback foreground service and allows you to display the lockscreen controls and is required for sustained background playback. On iOS, this adds the `audio` background mode. Set to `true` if your app plays audio in the background.',
+      default: 'false',
     },
   ]}
 />
@@ -199,7 +199,7 @@ On Android and iOS, `expo-audio` saves recordings in the app's cache directory b
 
 ### Playing audio in the background
 
-Background audio playback allows your app to continue playing audio when it moves to the background or when the device screen locks.
+Background audio playback allows your app to continue playing audio when it moves to the background or when the device screen locks. It is disabled by default. Apps that need it (for example music or podcast players) should set `enableBackgroundPlayback` to `true`.
 
 #### Configuration
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Default `enableBackgroundPlayback` to `false` so apps that only play foreground audio do not declare iOS `UIBackgroundModes=audio`. (by [@softwarebyze](https://github.com/softwarebyze))
 - Paused time is now excluded from the `AudioRecorder` duration limit. ([#49239](https://github.com/expo/expo/pull/49239) by [@stvrmrz](https://github.com/stvrmrz) and [@behenate](https://github.com/behenate))
 - [Android] Aligned the default audio focus request on Android 7.0–7.1 with newer versions by using transient exclusive focus when no interruption mode has been configured. ([#49101](https://github.com/expo/expo/pull/49101) by [@behenate](https://github.com/behenate))
 

--- a/packages/expo-audio/plugin/src/withAudio.ts
+++ b/packages/expo-audio/plugin/src/withAudio.ts
@@ -33,7 +33,7 @@ export type Props = {
   enableBackgroundRecording?: boolean;
   /**
    * Whether to enable background audio playback.
-   * @default true
+   * @default false
    */
   enableBackgroundPlayback?: boolean;
 };
@@ -44,7 +44,7 @@ const withAudio: ConfigPlugin<Props | void> = (
     microphonePermission,
     recordAudioAndroid = true,
     enableBackgroundRecording = false,
-    enableBackgroundPlayback = true,
+    enableBackgroundPlayback = false,
   } = {}
 ) => {
   IOSConfig.Permissions.createPermissionsPlugin({


### PR DESCRIPTION
expo-audio’s config plugin defaults `enableBackgroundPlayback` to `true`, which always adds `UIBackgroundModes=audio`. Fine for music apps, but a lot of projects only play short SFX. Apple rejected our board game under 2.5.4 for declaring background audio we don’t use.

**App Store 2.5.4**
- App: Backgammon Mastermind (Expo SDK ~56, expo-audio ~56.0.13)
- Binary: 1.0.0 (4), iPad Air 11-inch M3
- Submission: `ffd0b12f-7491-4298-80cd-f7cf8994f992`
- Apple: Info.plist declares `UIBackgroundModes` audio but no audible content plays in the background

App-side workaround that works today: `['expo-audio', { enableBackgroundPlayback: false }]`.

Defaulting to `false` (opt-in) matches `enableBackgroundRecording` and avoids surprise App Store rejections. Capability flags that change Info.plist / Play permissions should be opt-in — same idea as why #43014 made Android foreground services configurable.

**History**
- #43014 introduced `enableBackgroundPlayback` with default `true`. Before that, bare `"expo-audio"` only added `UIBackgroundModes` audio when background *recording* was on (default false).
- #43129 suggested flipping the default and was closed as a docs / `shouldPlayInBackground` mismatch. This PR is about the Info.plist capability declaration causing 2.5.4, not the runtime playback flag.

**Migration**
If you need background playback / lock screen controls:

```js
['expo-audio', { enableBackgroundPlayback: true }]
```