### PR TITLE
chore(expo-router): Drop `invariant` dep

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -129,6 +129,7 @@
 - [Internal] Isolate the loader's Suspense store from `LoaderClient` ([#48563](https://github.com/expo/expo/pull/48563) by [@hassankhan](https://github.com/hassankhan))
 - [Internal] Remove legacy root entrypoint shims ([#49001](https://github.com/expo/expo/pull/49001) by [@hassankhan](https://github.com/hassankhan))
 - Drop `fast-deep-equal` and `shallowequal` dependencies ([#49875](https://github.com/expo/expo/pull/49875) by [@kitten](https://github.com/kitten))
+- Drop `invariant` dependency ([#49882](https://github.com/expo/expo/pull/49882) by [@kitten](https://github.com/kitten))
 
 ## 57.0.9 - 2026-07-29
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -291,7 +291,6 @@
     "escape-string-regexp": "^4.0.0",
     "expo-glass-effect": "workspace:^",
     "expo-server": "workspace:^",
-    "invariant": "^2.2.4",
     "nanoid": "^3.3.18",
     "query-string": "^7.1.3",
     "react-fast-compare": "^3.2.2",

--- a/packages/expo-router/vendor/react-helmet-async/lib/index.esm.js
+++ b/packages/expo-router/vendor/react-helmet-async/lib/index.esm.js
@@ -1,7 +1,6 @@
 // src/index.tsx
 import React3, { Component as Component3 } from "react";
 import fastCompare from "react-fast-compare";
-import invariant from "invariant";
 
 // src/Provider.tsx
 import React2, { Component } from "react";
@@ -739,16 +738,18 @@ var Helmet = class extends Component3 {
     return newFlattenedProps;
   }
   warnOnInvalidChildren(child, nestedChildren) {
-    invariant(
-      VALID_TAG_NAMES.some((name) => child.type === name),
-      typeof child.type === "function" ? `You may be attempting to nest <Helmet> components within each other, which is not allowed. Refer to our API for more information.` : `Only elements types ${VALID_TAG_NAMES.join(
+    if (!VALID_TAG_NAMES.some((name) => child.type === name)) {
+      throw new Error(
+        typeof child.type === "function" ? `You may be attempting to nest <Helmet> components within each other, which is not allowed. Refer to our API for more information.` : `Only elements types ${VALID_TAG_NAMES.join(
         ", "
       )} are allowed. Helmet does not support rendering <${child.type}> elements. Refer to our API for more information.`
-    );
-    invariant(
-      !nestedChildren || typeof nestedChildren === "string" || Array.isArray(nestedChildren) && !nestedChildren.some((nestedChild) => typeof nestedChild !== "string"),
-      `Helmet expects a string as a child of <${child.type}>. Did you forget to wrap your children in braces? ( <${child.type}>{\`\`}</${child.type}> ) Refer to our API for more information.`
-    );
+      );
+    }
+    if (nestedChildren && typeof nestedChildren !== "string" && (!Array.isArray(nestedChildren) || nestedChildren.some((nestedChild) => typeof nestedChild !== "string"))) {
+      throw new Error(
+        `Helmet expects a string as a child of <${child.type}>. Did you forget to wrap your children in braces? ( <${child.type}>{\`\`}</${child.type}> ) Refer to our API for more information.`
+      );
+    }
     return true;
   }
   mapChildrenToProps(children, newProps) {

--- a/packages/expo-router/vendor/react-helmet-async/lib/index.js
+++ b/packages/expo-router/vendor/react-helmet-async/lib/index.js
@@ -37,7 +37,6 @@ __export(src_exports, {
 module.exports = __toCommonJS(src_exports);
 var import_react4 = __toESM(require("react"));
 var import_react_fast_compare = __toESM(require("react-fast-compare"));
-var import_invariant = __toESM(require("invariant"));
 
 // src/Provider.tsx
 var import_react2 = __toESM(require("react"));
@@ -775,16 +774,18 @@ var Helmet = class extends import_react4.Component {
     return newFlattenedProps;
   }
   warnOnInvalidChildren(child, nestedChildren) {
-    (0, import_invariant.default)(
-      VALID_TAG_NAMES.some((name) => child.type === name),
-      typeof child.type === "function" ? `You may be attempting to nest <Helmet> components within each other, which is not allowed. Refer to our API for more information.` : `Only elements types ${VALID_TAG_NAMES.join(
+    if (!VALID_TAG_NAMES.some((name) => child.type === name)) {
+      throw new Error(
+        typeof child.type === "function" ? `You may be attempting to nest <Helmet> components within each other, which is not allowed. Refer to our API for more information.` : `Only elements types ${VALID_TAG_NAMES.join(
         ", "
       )} are allowed. Helmet does not support rendering <${child.type}> elements. Refer to our API for more information.`
-    );
-    (0, import_invariant.default)(
-      !nestedChildren || typeof nestedChildren === "string" || Array.isArray(nestedChildren) && !nestedChildren.some((nestedChild) => typeof nestedChild !== "string"),
-      `Helmet expects a string as a child of <${child.type}>. Did you forget to wrap your children in braces? ( <${child.type}>{\`\`}</${child.type}> ) Refer to our API for more information.`
-    );
+      );
+    }
+    if (nestedChildren && typeof nestedChildren !== "string" && (!Array.isArray(nestedChildren) || nestedChildren.some((nestedChild) => typeof nestedChild !== "string"))) {
+      throw new Error(
+        `Helmet expects a string as a child of <${child.type}>. Did you forget to wrap your children in braces? ( <${child.type}>{\`\`}</${child.type}> ) Refer to our API for more information.`
+      );
+    }
     return true;
   }
   mapChildrenToProps(children, newProps) {

--- a/packages/expo-router/vendor/react-helmet-async/vendor.md
+++ b/packages/expo-router/vendor/react-helmet-async/vendor.md
@@ -2,4 +2,6 @@ This library has been vendored to remove the dependency on `react-dom` and allow
 
 The `shallowequal` dependency is inlined because the dispatcher only needs its basic, comparator-free behavior.
 
+The `invariant` calls use equivalent conditional `Error` throws to avoid retaining the dependency.
+
 This is a fork of `react-helmet-async` https://github.com/staylor/react-helmet-async

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5585,9 +5585,6 @@ importers:
       expo-server:
         specifier: workspace:^
         version: link:../expo-server
-      invariant:
-        specifier: ^2.2.4
-        version: 2.2.4
       nanoid:
         specifier: ^3.3.18
         version: 3.3.18


### PR DESCRIPTION
# Why

Drop `invariant` since it only serves the `react-helmet-async` fork and we otherwise don't need it. This is just to reduce noise in the deps list of `expo-router` while we're cleaning these up, since it's easy to replace.

# How

- Replace `invariant` calls with simple if-statements and `throw new Error`s
- Drop `invariant` from dependencies

# Test Plan

- `depscheck` passes, tests pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
