### PR TITLE
[workflows] Bump @expo/verify fallback pin to 0.11.7

### DIFF
--- a/.github/workflows/verify-comment.yml
+++ b/.github/workflows/verify-comment.yml
@@ -50,7 +50,7 @@ jobs:
     # engine exit 1 behind a green run (run 32919110451).
     continue-on-error: true
     env:
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.6' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.7' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,7 +60,7 @@ jobs:
       # Same version feeds the guard and the run, so the engine that clears
       # the profile is the engine that reads it. Override with the repo
       # variable VERIFY_VERSION; the fallback pins the tested release.
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.6' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.7' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
# Why

`@expo/verify` 0.11.7 strips trailing sentence punctuation from the verb token before matching. `@expo-bot review, make sure to test it on iOS 26 and 27` in #49850 tokenized the verb as `review,`, which matched no reserved verb and fell through to work mode. Work mode then rejected the PR for not being bot-authored.

Release: https://github.com/expo/verify/releases/tag/v0.11.7 (expo/verify@1564da8).

# How

Bump the `'0.11.6'` fallback in `verify-comment.yml` and `verify.yml` to `'0.11.7'`. The `VERIFY_VERSION` repository variable is the effective pin and is being bumped to 0.11.7 alongside this PR.

Not in this PR: `agent-commands.yml` and `expo-code-review-command.yml` still exact-match the second token, so `@expo-bot review,` is still rejected by the former and ignored by the latter. That is a separate grammar fix.

# Test Plan

Comment `@expo-bot review, ...` on an open PR after the variable is bumped. `verify-comment.yml` should exit silently instead of posting a rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)