### PR TITLE
[expo-cli] Remove unnecessary confirm_account query param

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -68,6 +68,7 @@
 - [Internal] Align local annotations in the Metro integration with Metro's own types. ([#49669](https://github.com/expo/expo/pull/49669) by [@robhogan](https://github.com/robhogan))
 - [Internal] Import Expo's Metro type extensions from `@expo/metro-config` instead of relying on global type augmentations. ([#49670](https://github.com/expo/expo/pull/49670) by [@robhogan](https://github.com/robhogan))
 - Bump to `@expo/metro@56.1.0` and `metro@0.84.6` ([#49671](https://github.com/expo/expo/pull/49671) by [@robhogan](https://github.com/robhogan))
+- Remove the unused `confirm_account` query param from the browser login URL. (by [@byronkarlen](https://github.com/byronkarlen))
 
 ## 57.0.11 - 2026-07-29
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -68,7 +68,7 @@
 - [Internal] Align local annotations in the Metro integration with Metro's own types. ([#49669](https://github.com/expo/expo/pull/49669) by [@robhogan](https://github.com/robhogan))
 - [Internal] Import Expo's Metro type extensions from `@expo/metro-config` instead of relying on global type augmentations. ([#49670](https://github.com/expo/expo/pull/49670) by [@robhogan](https://github.com/robhogan))
 - Bump to `@expo/metro@56.1.0` and `metro@0.84.6` ([#49671](https://github.com/expo/expo/pull/49671) by [@robhogan](https://github.com/robhogan))
-- Remove the unused `confirm_account` query param from the browser login URL. (by [@byronkarlen](https://github.com/byronkarlen))
+- Remove the unused `confirm_account` query param from the browser login URL. ([#49891](https://github.com/expo/expo/pull/49891) by [@byronkarlen](https://github.com/byronkarlen))
 
 ## 57.0.11 - 2026-07-29
 

--- a/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
+++ b/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
@@ -80,7 +80,6 @@ export async function getSessionUsingBrowserAuthFlowAsync({
       `code_challenge=${codeChallenge}`,
       `code_challenge_method=S256`,
       `state=${state}`,
-      `confirm_account=true`,
     ].join('&');
     return `${expoWebsiteUrl}${sso ? '/sso-login' : '/login'}?${params}`;
   };


### PR DESCRIPTION
# Why
(Same as https://github.com/expo/eas-cli/pull/4368)

On login, the cli redirects to the website. Currently, it passes a `confirm_account` query param so that the user can explicitly choose which Expo user to log in as. Now, the website automatically shows an authorize page (that lets users select another user) so the param is no longer necessary.

# How
Removed the `confirm_account` query param

# Test Plan
Ran `node /Users/byronkarlen/Dev/Expo/expo/packages/@expo/cli/bin/cli.js login`