### PR TITLE
[crypto][iOS] Migrate the main module to the Expo Modules API 2.0

### DIFF
--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Migrate the main module to the Expo Modules API 2.0 macros. ([#49894](https://github.com/expo/expo/pull/49894) by [@tsapeta](https://github.com/tsapeta))
+
 ## 58.0.0 — 2026-09-10
 
 ### 🐛 Bug fixes

--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -3,63 +3,69 @@
 import CommonCrypto
 import ExpoModulesCore
 
+@ExpoModule("ExpoCrypto")
 public class CryptoModule: Module {
-  public func definition() -> ModuleDefinition {
-    Name("ExpoCrypto")
-
-    AsyncFunction("digestStringAsync", digestString)
-
-    Function("digestString", digestString)
-
-    Function("getRandomValues", getRandomValues)
-
-    Function("digest", digest)
-
-    Function("randomUUID", randomUUID())
+  // Async `@JS` members are isolated to the JS thread by default and this one never suspends, so
+  // `.concurrent` keeps the digest from blocking it.
+  @JS(.concurrent)
+  func digestStringAsync(
+    algorithm: DigestAlgorithm,
+    str: String,
+    options: DigestOptions
+  ) async throws -> String {
+    return try digestString(algorithm: algorithm, str: str, options: options)
   }
 
-  @OptimizedFunction
-  private func randomUUID() -> String {
+  // `nonisolated` so the digest is reachable from `digestStringAsync` too; it only computes.
+  @JS
+  nonisolated func digestString(
+    algorithm: DigestAlgorithm,
+    str: String,
+    options: DigestOptions
+  ) throws -> String {
+    guard let data = str.data(using: .utf8) else {
+      throw LossyConversionException()
+    }
+
+    let length = Int(algorithm.digestLength)
+    var digest = [UInt8](repeating: 0, count: length)
+
+    data.withUnsafeBytes { bytes in
+      let _ = algorithm.digest(bytes.baseAddress, UInt32(data.count), &digest)
+    }
+
+    switch options.encoding {
+    case .hex:
+      return digest.reduce("") { $0 + String(format: "%02x", $1) }
+    case .base64:
+      return Data(digest).base64EncodedString()
+    }
+  }
+
+  @JS
+  func getRandomValues(array: TypedArray) throws -> TypedArray {
+    let status = SecRandomCopyBytes(
+      kSecRandomDefault,
+      array.byteLength,
+      array.rawPointer
+    )
+
+    guard status == errSecSuccess else {
+      throw FailedGeneratingRandomBytesException(status)
+    }
+    return array
+  }
+
+  @JS
+  func digest(algorithm: DigestAlgorithm, output: TypedArray, data: TypedArray) {
+    let outputPtr = output.rawPointer.assumingMemoryBound(to: UInt8.self)
+    _ = algorithm.digest(data.rawPointer, UInt32(data.byteLength), outputPtr)
+  }
+
+  @JS
+  func randomUUID() -> String {
     return UUID().uuidString.lowercased()
   }
-}
-
-private func digestString(algorithm: DigestAlgorithm, str: String, options: DigestOptions) throws -> String {
-  guard let data = str.data(using: .utf8) else {
-    throw LossyConversionException()
-  }
-
-  let length = Int(algorithm.digestLength)
-  var digest = [UInt8](repeating: 0, count: length)
-
-  data.withUnsafeBytes { bytes in
-    let _ = algorithm.digest(bytes.baseAddress, UInt32(data.count), &digest)
-  }
-
-  switch options.encoding {
-  case .hex:
-    return digest.reduce("") { $0 + String(format: "%02x", $1) }
-  case .base64:
-    return Data(digest).base64EncodedString()
-  }
-}
-
-private func getRandomValues(array: TypedArray) throws -> TypedArray {
-  let status = SecRandomCopyBytes(
-    kSecRandomDefault,
-    array.byteLength,
-    array.rawPointer
-  )
-
-  guard status == errSecSuccess else {
-    throw FailedGeneratingRandomBytesException(status)
-  }
-  return array
-}
-
-private func digest(algorithm: DigestAlgorithm, output: TypedArray, data: TypedArray) {
-  let outputPtr = output.rawPointer.assumingMemoryBound(to: UInt8.self)
-  _ = algorithm.digest(data.rawPointer, UInt32(data.byteLength), outputPtr)
 }
 
 private final class LossyConversionException: Exception {

--- a/packages/expo-crypto/ios/DigestOptions.swift
+++ b/packages/expo-crypto/ios/DigestOptions.swift
@@ -2,8 +2,8 @@
 
 import ExpoModulesCore
 
-internal struct DigestOptions: Record {
-  @Field
+@Record
+internal struct DigestOptions {
   var encoding: Encoding = .hex
 
   internal enum Encoding: String, Enumerable {


### PR DESCRIPTION
# Why

`expo-crypto` is a good first SDK module to move onto the 2.0 macros: the main module is small, has no views or events, and its whole surface is covered by what core supports today.

# How

`CryptoModule` drops `definition()` entirely and exposes its five functions as `@JS` members under `@ExpoModule("ExpoCrypto")`. `DigestOptions` becomes a `@Record`, which keeps `encoding` omittable with the same default.

The one interesting bit is `digestStringAsync`. It has to stay a promise on the JS side, but the macro stamps async `@JS` members with `@JavaScriptActor` and the digest never suspends, so it would otherwise run on the JS thread. `@JS(.concurrent)` keeps the work off it, and the generated binding still decodes arguments and encodes the result on the JS thread, so nothing JSI-owned crosses threads.

It delegates to `digestString`, which is itself a `@JS` member: one method holds the digest logic and backs the synchronous binding. That one is `nonisolated`, since a JS-actor-isolated member isn't callable from the concurrent one, and it only computes.

`randomUUID` loses its `@OptimizedFunction` peer, since `@JS` already binds through JSI.

`AesCryptoModule` stays on the 1.0 DSL. Its static members can't migrate yet: the macros plugin emits an override of `_decorateSharedObject(constructor:in:)`, but core declares only the `prototype:` overload and never calls a constructor phase, so it wouldn't compile. Separately, `Either` and `EitherOfThree` have no `JavaScriptCodable` conformance, which blocks `encryptAsync` and `decryptAsync`. Happy to file issues for both if we want them tracked.

# Test Plan

`xcodebuild -scheme ExpoCrypto` against bare-expo succeeds with no new warnings, and `et check-packages expo-crypto` passes (48 JS tests, lint, format). There are no native tests for this package, so the bindings haven't been exercised at runtime yet.
