### PR TITLE
[ui][android] Let DatePickerDialog open without a selection when initialDate is omitted

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -38,6 +38,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `DatePickerDialog` preselecting today when `initialDate` is omitted, and keep its confirm button disabled while no date is selected so `onDateSelected` never receives an invalid date. ([#49898](https://github.com/expo/expo/pull/49898) by [@pataar](https://github.com/pataar))
+
 - [Android][iOS] Fix `community/bottom-sheet` content shrinking to its own width instead of filling the sheet when the sheet sizes to its content. ([#49742](https://github.com/expo/expo/issues/49742) by [@agung-adhinata](https://github.com/agung-adhinata)) ([#49762](https://github.com/expo/expo/pull/49762) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fixed a `Text` or an `Icon` with no explicit color rendering black inside `Host`, which made it unreadable in the dark color scheme. `Host` now provides `LocalContentColor` from the color scheme. ([#49697](https://github.com/expo/expo/pull/49697) by [@expo-bot](https://github.com/expo-bot))
 - [iOS][Android] Fixed a `matchContents` `RNHostView` inside a `matchContents` `Host` growing the layout on every pass. ([#49483](https://github.com/expo/expo/pull/49483) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
@@ -357,7 +357,7 @@ fun ExpoDatePickerDialogContent(props: DatePickerDialogProps, onDateSelected: (D
     DatePickerState(
       initialDisplayMode = variant,
       locale = locale,
-      initialSelectedDateMillis = initialDate,
+      initialSelectedDateMillis = props.initialDate,
       initialDisplayedMonthMillis = initialDate,
       yearRange = yearRange,
       selectableDates = selectableDates
@@ -371,7 +371,7 @@ fun ExpoDatePickerDialogContent(props: DatePickerDialogProps, onDateSelected: (D
   DatePickerDialog(
     onDismissRequest = { onDismissRequest() },
     confirmButton = {
-      TextButton(onClick = { onDateSelected(DatePickerResult(date = state.selectedDateMillis)) }, colors = buttonColors) {
+      TextButton(onClick = { onDateSelected(DatePickerResult(date = state.selectedDateMillis)) }, enabled = state.selectedDateMillis != null, colors = buttonColors) {
         Text(props.confirmButtonLabel ?: stringResource(android.R.string.ok))
       }
     },

--- a/packages/expo-ui/src/jetpack-compose/DatePicker/index.tsx
+++ b/packages/expo-ui/src/jetpack-compose/DatePicker/index.tsx
@@ -325,6 +325,10 @@ export function DateRangePicker(props: DateRangePickerProps) {
 // -- Dialog views (used internally by the compat layer) ---------------------
 
 export interface DatePickerDialogProps {
+  /**
+   * The initially selected date. When omitted, the dialog opens on the current month with no
+   * selection and the confirm button stays disabled until a date is picked.
+   */
   initialDate?: string | null;
   variant?: AndroidVariant;
   showVariantToggle?: boolean;


### PR DESCRIPTION
# Why

`DatePickerDialogProps.initialDate` is optional, but the Compose dialog substitutes today when it is omitted, so a caller can't open the dialog without a preselected date. For the `input` variant that means a date-of-birth field opens with a date already typed into the text field and the user has to erase it before entering their own. Material 3's `DatePickerState` already accepts `initialSelectedDateMillis = null`.

The confirm button was also always enabled, so clearing the text field in `input` mode and confirming emitted `DatePickerResult(date = null)`, which the JS wrapper turns into `new Date(null)` (1970-01-01).

# How

- Pass the raw nullable `props.initialDate` as `initialSelectedDateMillis`. `initialDisplayedMonthMillis` and the year range keep the today fallback, so the calendar still opens on the current month.
- Enable the confirm button only while `state.selectedDateMillis != null`.
- Document the behaviour on `DatePickerDialogProps.initialDate`.

Callers that pass an `initialDate` see no change. The `community/datetime-picker` compat layer always passes its `value`, so it is unaffected. The inline `DateTimePicker` view keeps its today fallback; it reports every selection change through `onDateSelected`, so opening it empty would need a null guard in the JS wrapper as well and felt like a separate change.

# Test Plan

Android, `DatePickerDialog` from `@expo/ui/jetpack-compose`:

- [ ] No `initialDate`, `variant="input"`: text field empty, confirm disabled; typing a valid date enables confirm and `onDateSelected` receives it.
- [ ] No `initialDate`, `variant="picker"`: calendar on the current month with nothing selected, confirm disabled until a day is tapped.
- [ ] With `initialDate`: unchanged, date preselected and confirm enabled.
- [ ] `variant="input"`, clear the text field: confirm disables instead of emitting 1970-01-01.

# Checklist

- [ ] Tested on an Android device or emulator (not yet run; verifying in a consuming app)
- [x] Added a `CHANGELOG.md` entry
