### PR TITLE
[router] Replace escape-string-regexp dependency with an internal helper

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -97,6 +97,7 @@
 
 ### 💡 Others
 
+- Replace the `escape-string-regexp` dependency with an internal helper. ([#49902](https://github.com/expo/expo/pull/49902) by [@Ubax](https://github.com/Ubax))
 - Replace the internal `color` dependency with `@react-native/normalize-colors`. ([#49876](https://github.com/expo/expo/pull/49876) by [@Ubax](https://github.com/Ubax))
 - Resolve queued navigation actions against render-time state. ([#49846](https://github.com/expo/expo/pull/49846) by [@Ubax](https://github.com/Ubax))
 - Propagate prevent-remove guards to ancestors. ([#49829](https://github.com/expo/expo/pull/49829) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -288,7 +288,6 @@
     "@react-native-masked-view/masked-view": "^0.3.2",
     "@react-native/normalize-colors": "0.87.1",
     "client-only": "^0.0.1",
-    "escape-string-regexp": "^4.0.0",
     "expo-glass-effect": "workspace:^",
     "expo-server": "workspace:^",
     "nanoid": "^3.3.18",

--- a/packages/expo-router/src/fork/getStateFromPath-forks.ts
+++ b/packages/expo-router/src/fork/getStateFromPath-forks.ts
@@ -1,8 +1,8 @@
-import escape from 'escape-string-regexp';
 import type * as queryString from 'query-string';
 
 import { matchGroupName, stripGroupSegmentsFromPath } from '../matchers';
 import type { InitialState } from '../react-navigation/native';
+import { escapeStringRegexp as escape } from '../utils/escapeStringRegexp';
 import { parseUrlUsingCustomBase } from '../utils/url';
 import type { InitialRouteConfig, Options, ParsedRoute, RouteConfig } from './getStateFromPath';
 

--- a/packages/expo-router/src/fork/getStateFromPath.ts
+++ b/packages/expo-router/src/fork/getStateFromPath.ts
@@ -1,8 +1,7 @@
-import escape from 'escape-string-regexp';
-
 import { INTERNAL_SLOT_NAME } from '../constants';
 import type { PathConfigMap } from '../react-navigation/native';
 import type { InitialState, NavigationState, PartialState } from '../react-navigation/routers';
+import { escapeStringRegexp as escape } from '../utils/escapeStringRegexp';
 import { findFocusedRoute } from './findFocusedRoute';
 import type { ExpoOptions, ExpoRouteConfig } from './getStateFromPath-forks';
 import * as expo from './getStateFromPath-forks';

--- a/packages/expo-router/src/utils/__tests__/escapeStringRegexp.test.ios.ts
+++ b/packages/expo-router/src/utils/__tests__/escapeStringRegexp.test.ios.ts
@@ -1,0 +1,18 @@
+import { escapeStringRegexp } from '../escapeStringRegexp';
+
+it('escapes characters with special meaning in a regular expression', () => {
+  expect(escapeStringRegexp('|\\{}()[]^$+*?.')).toBe('\\|\\\\\\{\\}\\(\\)\\[\\]\\^\\$\\+\\*\\?\\.');
+});
+
+it('escapes a hyphen as \\x2d so it stays literal inside character classes', () => {
+  expect(escapeStringRegexp('foo-bar')).toBe('foo\\x2dbar');
+});
+
+it('leaves characters without special meaning untouched', () => {
+  expect(escapeStringRegexp('foo/bar_baz 123')).toBe('foo/bar_baz 123');
+});
+
+it('produces a pattern that matches the original string literally', () => {
+  const value = '(group)/post/[id]-v1.0+beta';
+  expect(new RegExp(`^${escapeStringRegexp(value)}$`).test(value)).toBe(true);
+});

--- a/packages/expo-router/src/utils/escapeStringRegexp.ts
+++ b/packages/expo-router/src/utils/escapeStringRegexp.ts
@@ -1,0 +1,11 @@
+// TODO: Replace with the native `RegExp.escape` once it is supported across our runtime matrix
+// (Hermes and older browsers do not implement it yet).
+
+/**
+ * Escapes the characters that have a special meaning in a regular expression, so `value` matches
+ * literally. `-` becomes `\x2d` because `\-` is not a valid escape outside a character class in
+ * Unicode-mode patterns.
+ */
+export function escapeStringRegexp(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5567,9 +5567,6 @@ importers:
       client-only:
         specifier: ^0.0.1
         version: 0.0.1
-      escape-string-regexp:
-        specifier: ^4.0.0
-        version: 4.0.0
       expo:
         specifier: '*'
         version: link:../expo


### PR DESCRIPTION
# Why

Replace  `escape-string-regexp ` with internal helper `escapeStringRegexp` - based on https://github.com/sindresorhus/escape-string-regexp/blob/main/index.js

When hermes starts supporting [RegExp.escape()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape) we can use it directly

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
