### PR TITLE
[docs][ci] Move the docs workflows and docs/ to pnpm 12

### DIFF
--- a/.github/workflows/docs-link-health-reporter.yml
+++ b/.github/workflows/docs-link-health-reporter.yml
@@ -26,9 +26,9 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: 🏗️ Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 10
+          install: false
       - name: ⬢ Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -33,9 +33,9 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 🏗️ Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 10
+          install: false
       - name: ⬢ Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -53,9 +53,9 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: 🏗️ Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 10
+          install: false
       - name: ⬢ Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/docs-sdk-promote.yml
+++ b/.github/workflows/docs-sdk-promote.yml
@@ -38,9 +38,9 @@ jobs:
           # has to be present. The default shallow single-branch clone has none of them.
           fetch-depth: 0
       - name: 🏗️ Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 10
+          install: false
       - name: ⬢ Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/docs-upstream-sync.yml
+++ b/.github/workflows/docs-upstream-sync.yml
@@ -21,9 +21,9 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 🏗️ Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 10
+          install: false
       - name: ⬢ Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,9 +34,9 @@ jobs:
         with:
           fetch-depth: 30000
       - name: 🏗️ Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 10
+          install: false
       - name: ⬢ Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,1 +1,0 @@
-node-linker=hoisted

--- a/docs/package.json
+++ b/docs/package.json
@@ -38,7 +38,13 @@
     "postinstall": "pnpm copy-latest && pnpm generate-static-resources && pnpm install-vale",
     "upstream-sync": "node --experimental-strip-types ./scripts/upstream-sync.ts"
   },
-  "packageManager": "pnpm@12.2.1",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "12.2.1",
+      "onFail": "warn"
+    }
+  },
   "engines": {
     "node": ">=24"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -38,7 +38,7 @@
     "postinstall": "pnpm copy-latest && pnpm generate-static-resources && pnpm install-vale",
     "upstream-sync": "node --experimental-strip-types ./scripts/upstream-sync.ts"
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@12.2.1",
   "engines": {
     "node": ">=24"
   },
@@ -155,14 +155,6 @@
   "postcss": {
     "plugins": {
       "@tailwindcss/postcss": {}
-    }
-  },
-  "pnpm": {
-    "overrides": {
-      "baseline-browser-mapping": "2.9.15"
-    },
-    "patchedDependencies": {
-      "next@16.2.11": "patches/next@16.2.11.patch"
     }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.2.1
+        version: 12.2.1
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.2.1':
+    resolution: {integrity: sha512-efC1yfz2xbyHiMLrQAYtnoo5XP20LeAiYYcyL1962qQagZrMXIB0BoQYeZoPTLggLh0Q4MD7jpZUInU5fWxCgQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.2.1':
+    resolution: {integrity: sha512-0bloFmxrvYY5LYex5V6SZySwg+egBk0pOW+YUeOm9fiG2U1wv+qRVLBOUvIzLAeJE7vBlAzxUwXkQAYtr12n+Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.2.1':
+    resolution: {integrity: sha512-AZl7apVZC4TV1/vTp/bS16XUsHeqx9AHsU4V55joiGR+iR6vl+WF0WlGvGCTjqjICS4q/kThpgNrtG8aqQ9seQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.2.1':
+    resolution: {integrity: sha512-S36+tMEGrPz3nwtfFU9kYxbHoi8sV7WJfMO9njEL4jRaShTNaLRERMAqyI2DUCiA5QCr6/a50lt4+pKCV2mCvw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.2.1':
+    resolution: {integrity: sha512-4MQClkAk1em55LFZJpeIqb7j+gEqCgX8yC42j9DFWL42q1uMX1e1tvTy2Dtd4NoWQqgdkLxOStZ+D9CYC+28ow==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.2.1':
+    resolution: {integrity: sha512-A/AlR71Leph7qgB3ThSU9yU/vLfre4HmP6nbt3/qt51fzAjQ0xuq7j+cw0f1yDskzOsGzmo5uD6ruefCwLK5uQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.2.1':
+    resolution: {integrity: sha512-TEGUmroT6NGfo2O2+tHK9Zr1lhP1zLzpwx+QAQV19l8V4ljUoMfz8Os5V9zzNCtIpzyKcK7SuG7fkVbxFgRMzg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.2.1':
+    resolution: {integrity: sha512-V2Q+AF8fCsw8/CC3bWF8kopOmH0aAjgk9m7H7uAQNulOYIJs9YJBiAlgByswmt+igV9axc4dBI//ZlK2NKpDcw==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.2.1:
+    resolution: {integrity: sha512-9Vymiqy561q2nGb4KKmK+JoyKGcDrvH42hMcp+q01nfzS/qF4YZGepGcB5nfi29KokD33CkZszsycxkBBBYmFg==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.2.1':
+    optional: true
+
+  pnpm@12.2.1:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.2.1
+      '@pnpm/exe.darwin-x64': 12.2.1
+      '@pnpm/exe.linux-arm64': 12.2.1
+      '@pnpm/exe.linux-arm64-musl': 12.2.1
+      '@pnpm/exe.linux-x64': 12.2.1
+      '@pnpm/exe.linux-x64-musl': 12.2.1
+      '@pnpm/exe.win32-arm64': 12.2.1
+      '@pnpm/exe.win32-x64': 12.2.1
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -4,9 +4,7 @@
 # as a root-workspace install and never touches docs/ as standalone.
 packages: []
 
-# Flat `node_modules`, kept from the Yarn 4 layout when docs moved to pnpm. pnpm
-# reads this setting here only, since `.npmrc` now carries auth and registry
-# settings alone.
+# Flat `node_modules`, kept from the Yarn 4 layout when docs moved to pnpm.
 nodeLinker: hoisted
 
 # Reject package versions younger than 24 hours to reduce exposure to

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -4,19 +4,10 @@
 # as a root-workspace install and never touches docs/ as standalone.
 packages: []
 
-# Explicitly allow install scripts for native-binary deps we depend on at
-# build/runtime. Yarn ran these by default; pnpm blocks them unless whitelisted.
-onlyBuiltDependencies:
-  - sharp
-  - workerd
-  - '@sentry/cli'
-
-# Silence warnings for build scripts we intentionally skip. Matches the root
-# expo monorepo's pattern for these packages.
-ignoredBuiltDependencies:
-  - '@fingerprintjs/fingerprintjs-pro-react'
-  - esbuild
-  - unrs-resolver
+# Flat `node_modules`, kept from the Yarn 4 layout when docs moved to pnpm. pnpm
+# reads this setting here only, since `.npmrc` now carries auth and registry
+# settings alone.
+nodeLinker: hoisted
 
 # Reject package versions younger than 24 hours to reduce exposure to
 # supply-chain attacks via freshly published malicious versions. Matches the
@@ -25,3 +16,21 @@ minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:
   - '@expo/*'
+
+# pnpm no longer reads the `pnpm` field in package.json, so these live here.
+overrides:
+  baseline-browser-mapping: 2.9.15
+
+patchedDependencies:
+  next@16.2.11: patches/next@16.2.11.patch
+
+# Native-binary deps whose install scripts we need at build or runtime, and the
+# ones we deliberately skip. pnpm 11 replaced `onlyBuiltDependencies` and
+# `ignoredBuiltDependencies` with this map, and pnpm 12 ignores both.
+allowBuilds:
+  '@fingerprintjs/fingerprintjs-pro-react': false
+  '@sentry/cli': true
+  esbuild: false
+  sharp: true
+  unrs-resolver: false
+  workerd: true


### PR DESCRIPTION
# Why

Docs CI is red on `main`. #49655 raised root `engines.pnpm` to `^12.2.1` and moved 33 workflow files to `pnpm/setup`, and no docs workflow was included, so the Docs Website run fails at "Install workspace deps":

ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
Expected version: ^12.2.1
Got: 10.34.5

# How

**Workflows**

- Replace `pnpm/action-setup` and its `version: 10` input with `pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0` and `install: false` in all six docs workflows. This is the same swap #49655 applied to the other 45 steps in `.github/workflows`, and no `pnpm/action-setup` usage is left in the repo.
- Let the workflows take the pnpm version from root `package.json` `devEngines.packageManager` instead of a hardcoded major, so the next pnpm upgrade needs no workflow edit.
- Keep `install: false`, because each workflow runs its own install with `--ignore-scripts --frozen-lockfile` and with cache gating. `pnpm/setup` runs `pnpm install` by default, unlike `pnpm/action-setup`.

**Docs project**

- Bump `packageManager` to `pnpm@12.2.1` in `docs/package.json`, so `docs/` and the monorepo run one pnpm major.
- Move `overrides` and `patchedDependencies` from the `package.json` `pnpm` field into `docs/pnpm-workspace.yaml`. pnpm 12 no longer reads that field, and it warns: `The "pnpm" field in package.json is no longer read by pnpm`.
- Replace `onlyBuiltDependencies` and `ignoredBuiltDependencies` with the `allowBuilds` map, written by `pnpm approve-builds`. pnpm 11 replaced both settings and pnpm 12 ignores them, so the first pnpm 12 install failed with `ERR_PNPM_IGNORED_BUILDS` for all six packages, including the three that looked approved.
- Move `node-linker=hoisted` ins `nodeLinker: hoisted` and
delete `docs/.npmrc`. pnpm now ry settings from `.npmrc`, so the
flat layout the docs build depepped.
- Regenerate `docs/pnpm-lock.yaonly: a
`packageManagerDependencies` do plus its per-platform
`@pnpm/exe` entries. No depende

# Test Plan

`docs.yml` and `docs-pr.yml` both trigger on this diff, so the PR exercises "Install workspace deps", "Install tools deps", the docs install, tests, lint, and export.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
