### PR TITLE
[router] Export usePreventRemove from expo-router

### DIFF
--- a/apps/router-e2e/__e2e__/router-prevent-remove/app/form-hook.tsx
+++ b/apps/router-e2e/__e2e__/router-prevent-remove/app/form-hook.tsx
@@ -21,8 +21,10 @@ export default function HookForm() {
       <Button
         testID="discard"
         title="Discard"
+        disabled={!dirty}
         onPress={() => {
           setDirty(false);
+          setPendingNavigation(null);
           pendingNavigation?.repeat();
         }}
       />

--- a/apps/router-e2e/__e2e__/router-prevent-remove/app/form-hook.tsx
+++ b/apps/router-e2e/__e2e__/router-prevent-remove/app/form-hook.tsx
@@ -1,24 +1,16 @@
-import { router, useNavigation } from 'expo-router';
-import { usePreventRemove } from 'expo-router/react-navigation';
-import { useEffect, useRef, useState } from 'react';
+import { router, usePreventRemove } from 'expo-router';
+import { useState } from 'react';
 import { Button, Text, View } from 'react-native';
 
 export default function HookForm() {
-  const navigation = useNavigation();
   const [dirty, setDirty] = useState(true);
   const [preventedCount, setPreventedCount] = useState(0);
-  const pendingAction = useRef<Parameters<typeof navigation.dispatch>[0] | null>(null);
+  const [pendingNavigation, setPendingNavigation] = useState<{ repeat: () => void } | null>(null);
 
-  usePreventRemove(dirty, ({ data }) => {
-    pendingAction.current = data.action;
+  usePreventRemove(dirty, ({ repeat }) => {
+    setPendingNavigation({ repeat });
     setPreventedCount((count) => count + 1);
   });
-
-  useEffect(() => {
-    if (!dirty && pendingAction.current) {
-      navigation.dispatch(pendingAction.current);
-    }
-  }, [dirty, navigation]);
 
   return (
     <View>
@@ -26,7 +18,14 @@ export default function HookForm() {
       <Text testID="dirty">{dirty ? 'dirty' : 'clean'}</Text>
       <Text testID="prevented-count">{preventedCount}</Text>
       <Button testID="back" title="Back" onPress={() => router.back()} />
-      <Button testID="discard" title="Discard" onPress={() => setDirty(false)} />
+      <Button
+        testID="discard"
+        title="Discard"
+        onPress={() => {
+          setDirty(false);
+          pendingNavigation?.repeat();
+        }}
+      />
     </View>
   );
 }

--- a/apps/router-e2e/__e2e__/router-prevent-remove/app/form-option.tsx
+++ b/apps/router-e2e/__e2e__/router-prevent-remove/app/form-option.tsx
@@ -1,5 +1,4 @@
-import { router } from 'expo-router';
-import { usePreventRemove } from 'expo-router/react-navigation';
+import { router, usePreventRemove } from 'expo-router';
 import { useState } from 'react';
 import { Button, Text, View } from 'react-native';
 

--- a/packages/@expo/cli/e2e/playwright/dev/router-prevent-remove.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/router-prevent-remove.test.ts
@@ -30,8 +30,7 @@ test.describe(inputDir, () => {
     await expoStart.stopAsync();
   });
 
-  // TODO(@ubax): Restore remove prevention after reducer dispatch supports it. https://linear.app/expo/issue/ENG-26123
-  test.skip('blocks removal and continues after disabling the hook', async ({ page }) => {
+  test('blocks removal and continues after disabling the hook', async ({ page }) => {
     const pageErrors = pageCollectErrors(page);
     await page.goto(expoStart.url.href);
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 ### 🎉 New features
 
+- Export `usePreventRemove` from `expo-router` and add `repeat` for continuing the blocked navigation action. (by [@Ubax](https://github.com/Ubax))
 - Add unstable APIs for integrating custom native and JavaScript stack navigators with `standard-navigation`. ([#49209](https://github.com/expo/expo/pull/49209) by [@Ubax](https://github.com/Ubax))
 - Add `LocaleProvider` to customize navigation direction at runtime. ([#49815](https://github.com/expo/expo/pull/49815) by [@Ubax](https://github.com/Ubax))
 - [Android] Add `cornerRadius` support to dropdown menu. ([#49515](https://github.com/expo/expo/pull/49515) by [@aaronleopold](https://github.com/aaronleopold))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -52,7 +52,7 @@
 
 ### 🎉 New features
 
-- Export `usePreventRemove` from `expo-router` and add `repeat` for continuing the blocked navigation action. (by [@Ubax](https://github.com/Ubax))
+- Export `usePreventRemove` from `expo-router` and add `repeat` for continuing the blocked navigation action. ([#49908](https://github.com/expo/expo/pull/49908) by [@Ubax](https://github.com/Ubax))
 - Add unstable APIs for integrating custom native and JavaScript stack navigators with `standard-navigation`. ([#49209](https://github.com/expo/expo/pull/49209) by [@Ubax](https://github.com/Ubax))
 - Add `LocaleProvider` to customize navigation direction at runtime. ([#49815](https://github.com/expo/expo/pull/49815) by [@Ubax](https://github.com/Ubax))
 - [Android] Add `cornerRadius` support to dropdown menu. ([#49515](https://github.com/expo/expo/pull/49515) by [@aaronleopold](https://github.com/aaronleopold))

--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -53,6 +53,10 @@ export type { Theme } from './react-navigation/native/types';
 export { useRoutePath } from './react-navigation/native/useRoutePath';
 export { useScrollToTop } from './react-navigation/native/useScrollToTop';
 export { useRoute } from './react-navigation/core/useRoute';
+export {
+  type PreventRemoveOptions,
+  usePreventRemove,
+} from './react-navigation/core/usePreventRemove';
 
 export type { RedirectConfig } from './getRoutesCore';
 export type { SingularOptions } from './useScreens';

--- a/packages/expo-router/src/react-navigation/core/__tests__/usePreventRemove.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/usePreventRemove.test.ios.tsx
@@ -26,7 +26,7 @@ beforeEach(() => {
 
 afterEach(() => consoleWarnSpy.mockRestore());
 
-test("repeats an action prevented by 'usePreventRemove' hook", () => {
+test("prevents removing a screen with 'usePreventRemove' hook", () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(StackRouter, props);
 
@@ -40,13 +40,11 @@ test("repeats an action prevented by 'usePreventRemove' hook", () => {
   const onPreventRemove = jest.fn();
 
   let setPreventRemove: React.Dispatch<React.SetStateAction<boolean>>;
-  let repeat: () => void;
 
   const TestScreen = () => {
     const [preventRemove, setPreventRemoveState] = React.useState(true);
     setPreventRemove = setPreventRemoveState;
-    usePreventRemove(preventRemove, ({ repeat: repeatAction }) => {
-      repeat = repeatAction;
+    usePreventRemove(preventRemove, () => {
       onPreventRemove();
     });
 
@@ -121,10 +119,9 @@ test("repeats an action prevented by 'usePreventRemove' hook", () => {
     routeKeySeq: 2,
   });
 
-  act(() => {
-    setPreventRemove(false);
-    repeat();
-  });
+  act(() => setPreventRemove(false));
+
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toHaveBeenCalledTimes(3);
   expect(onStateChange).toHaveBeenCalledWith({
@@ -179,6 +176,69 @@ test('allows an action dispatched while disabling prevention', () => {
 
   expect(ref.current?.getRootState().routes.map((route) => route.name)).toEqual(['foo']);
   expect(onPreventRemove).toHaveBeenCalledTimes(1);
+});
+
+test.each([
+  ['when preventRemove is set to false', true, false],
+  ['when preventRemove stays true', false, true],
+])('repeats a prevented action %s', (_, clearPrevention, shouldWarn) => {
+  const TestNavigator = (props: any) => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(StackRouter, props);
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key]!.render())}
+      </NavigationContent>
+    );
+  };
+  let repeat!: () => void;
+  let setPreventRemove!: React.Dispatch<React.SetStateAction<boolean>>;
+  const onPreventRemove = jest.fn(({ repeat: repeatAction }) => {
+    repeat = repeatAction;
+  });
+  const TestScreen = () => {
+    const [preventRemove, setPreventRemoveState] = React.useState(true);
+    setPreventRemove = setPreventRemoveState;
+    usePreventRemove(preventRemove, onPreventRemove);
+    return null;
+  };
+  const ref = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <BaseNavigationContainer ref={ref}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+        <Screen name="bar" component={TestScreen} />
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  act(() => ref.current?.navigate('bar'));
+  const action = StackActions.popTo('foo');
+  act(() => ref.current?.dispatch(action));
+
+  expect(ref.current?.getRootState().routes.map((route) => route.name)).toEqual(['foo', 'bar']);
+  expect(onPreventRemove).toHaveBeenCalledTimes(1);
+  expect(onPreventRemove.mock.calls[0][0].data.action).toBe(action);
+
+  act(() => {
+    if (clearPrevention) {
+      setPreventRemove(false);
+    }
+    repeat();
+  });
+
+  expect(ref.current?.getRootState().routes.map((route) => route.name)).toEqual(['foo']);
+  expect(onPreventRemove).toHaveBeenCalledTimes(1);
+  if (shouldWarn) {
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '`repeat` or `disablePrevention` from `usePreventRemove` was called, but `preventRemove` is ' +
+        'still `true`. The screen is no longer protected, but the hook will not re-enable ' +
+        'prevention until `preventRemove` changes. Set `preventRemove` to `false` in the same ' +
+        'handler to keep the prop and the prevention state in sync.'
+    );
+  } else {
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  }
 });
 
 test('warns when disablePrevention is called and preventRemove stays true', () => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/usePreventRemove.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/usePreventRemove.test.ios.tsx
@@ -26,7 +26,7 @@ beforeEach(() => {
 
 afterEach(() => consoleWarnSpy.mockRestore());
 
-test("prevents removing a screen with 'usePreventRemove' hook", () => {
+test("repeats an action prevented by 'usePreventRemove' hook", () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(StackRouter, props);
 
@@ -40,11 +40,13 @@ test("prevents removing a screen with 'usePreventRemove' hook", () => {
   const onPreventRemove = jest.fn();
 
   let setPreventRemove: React.Dispatch<React.SetStateAction<boolean>>;
+  let repeat: () => void;
 
   const TestScreen = () => {
     const [preventRemove, setPreventRemoveState] = React.useState(true);
     setPreventRemove = setPreventRemoveState;
-    usePreventRemove(preventRemove, () => {
+    usePreventRemove(preventRemove, ({ repeat: repeatAction }) => {
+      repeat = repeatAction;
       onPreventRemove();
     });
 
@@ -119,9 +121,10 @@ test("prevents removing a screen with 'usePreventRemove' hook", () => {
     routeKeySeq: 2,
   });
 
-  act(() => setPreventRemove(false));
-
-  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
+  act(() => {
+    setPreventRemove(false);
+    repeat();
+  });
 
   expect(onStateChange).toHaveBeenCalledTimes(3);
   expect(onStateChange).toHaveBeenCalledWith({

--- a/packages/expo-router/src/react-navigation/core/usePreventRemove.tsx
+++ b/packages/expo-router/src/react-navigation/core/usePreventRemove.tsx
@@ -29,10 +29,10 @@ function useWarnOnStalePreventRemoveDev(preventRemove: boolean) {
     setShouldCheck(false);
     if (preventRemove) {
       console.warn(
-        '`disablePrevention` from `usePreventRemove` was called, but `preventRemove` is still ' +
-          '`true`. The screen is no longer protected, but the hook will not re-enable prevention ' +
-          'until `preventRemove` changes. Set `preventRemove` to `false` in the same handler to ' +
-          'keep the prop and the prevention state in sync.'
+        '`repeat` or `disablePrevention` from `usePreventRemove` was called, but `preventRemove` is ' +
+          'still `true`. The screen is no longer protected, but the hook will not re-enable ' +
+          'prevention until `preventRemove` changes. Set `preventRemove` to `false` in the same ' +
+          'handler to keep the prop and the prevention state in sync.'
       );
     }
   }, [shouldCheck, preventRemove]);
@@ -49,7 +49,8 @@ const useWarnOnStalePreventRemove: (preventRemove: boolean) => () => void =
  * with the blocked navigation action.
  *
  * To continue the blocked navigation action, set `preventRemove` to `false` and call the
- * callback's `repeat` function.
+ * callback's `repeat` function. To navigate somewhere else, set `preventRemove` to `false`, call
+ * the returned `disablePrevention` function, and then navigate.
  *
  * @example
  * ```tsx

--- a/packages/expo-router/src/react-navigation/core/usePreventRemove.tsx
+++ b/packages/expo-router/src/react-navigation/core/usePreventRemove.tsx
@@ -48,26 +48,25 @@ const useWarnOnStalePreventRemove: (preventRemove: boolean) => () => void =
  * Prevents the screen from being removed while `preventRemove` is `true` and calls `callback`
  * with the blocked navigation action.
  *
- * To continue from the same handler, call the returned `disablePrevention` function before
- * navigating.
+ * To continue the blocked navigation action, set `preventRemove` to `false` and call the
+ * callback's `repeat` function.
  *
  * @example
  * ```tsx
  * const [hasUnsavedChanges, setHasUnsavedChanges] = useState(true);
- * const [showConfirm, setShowConfirm] = useState(false);
- *
- * const disablePrevention = usePreventRemove(hasUnsavedChanges, () => setShowConfirm(true));
- *
- * {showConfirm && (
- *   <Button
- *     title="Discard changes"
- *     onPress={() => {
- *       setHasUnsavedChanges(false);
- *       disablePrevention();
- *       router.back();
- *     }}
- *   />
- * )}
+ * usePreventRemove(hasUnsavedChanges, ({ repeat }) => {
+ *   Alert.alert('Discard changes?', undefined, [
+ *     { text: 'Cancel', style: 'cancel' },
+ *     {
+ *       text: 'Discard',
+ *       style: 'destructive',
+ *       onPress: () => {
+ *         setHasUnsavedChanges(false);
+ *         repeat();
+ *       },
+ *     },
+ *   ]);
+ * });
  * ```
  *
  * @param preventRemove Boolean indicating whether to prevent screen from being removed.
@@ -76,7 +75,7 @@ const useWarnOnStalePreventRemove: (preventRemove: boolean) => () => void =
  */
 export function usePreventRemove(
   preventRemove: boolean,
-  callback?: (options: { data: { action: NavigationAction } }) => void,
+  callback?: (options: { data: { action: NavigationAction }; repeat: () => void }) => void,
   options?: PreventRemoveOptions
 ) {
   const id = React.useId();
@@ -98,11 +97,23 @@ export function usePreventRemove(
     };
   }, [id, preventInPreloadedRoutes, preventRemove, setPreventRemove]);
 
+  // TODO(@ubax): use standard useCallback if possible
+  const disablePrevention = useLatestCallback(() => {
+    setPreventRemove(id, false, preventInPreloadedRoutes);
+    markDisabled();
+  });
+
   const removePreventedListener = useLatestCallback<
     EventListenerCallback<EventMapCore<any>, 'removePrevented'>
   >((event) => {
     if (preventRemove && callback) {
-      callback({ data: event.data });
+      callback({
+        data: event.data,
+        repeat: () => {
+          disablePrevention();
+          navigation.dispatch(event.data.action);
+        },
+      });
     }
   });
 
@@ -110,10 +121,5 @@ export function usePreventRemove(
     () => navigation.addListener('removePrevented', removePreventedListener),
     [navigation, removePreventedListener]
   );
-  // TODO(@ubax): use standard useCallback if possible
-  // TODO(@ubax): add repeat function which will call this and repeat the action
-  return useLatestCallback(() => {
-    setPreventRemove(id, false, preventInPreloadedRoutes);
-    markDisabled();
-  });
+  return disablePrevention;
 }


### PR DESCRIPTION
# Why

1. Treat `usePreventRemove` as first class citizen in router (export from `expo-router`)
2. Add utility function `repeat`, to repeat the prevented action

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
