### PR TITLE
[router-tester] Add NativeTabs form sheet test scenario

### DIFF
--- a/apps/router-tester/app/index.tsx
+++ b/apps/router-tester/app/index.tsx
@@ -24,6 +24,7 @@ const HomeIndex = () => {
         <Text>Current Path: {pathname}</Text>
       </View>
       <CaseLink href="/tabs" text="Native Tabs" />
+      <CaseLink href="/tabs-form-sheet/home" text="Native Tabs Form Sheet" />
       <CaseLink href="/link-preview" text="Link Preview" />
       <CaseLink href="/split-view" text="Split View" />
       <CaseLink href="/toolbar" text="Toolbar" />

--- a/apps/router-tester/app/tabs-form-sheet/_layout.tsx
+++ b/apps/router-tester/app/tabs-form-sheet/_layout.tsx
@@ -1,0 +1,12 @@
+import { NativeTabs } from 'expo-router/unstable-native-tabs';
+
+export default function Layout() {
+  return (
+    <NativeTabs>
+      <NativeTabs.Trigger name="home">
+        <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
+        <NativeTabs.Trigger.Icon sf="house" md="home" />
+      </NativeTabs.Trigger>
+    </NativeTabs>
+  );
+}

--- a/apps/router-tester/app/tabs-form-sheet/home/_layout.tsx
+++ b/apps/router-tester/app/tabs-form-sheet/home/_layout.tsx
@@ -1,0 +1,18 @@
+import { Stack } from 'expo-router';
+
+export default function Layout() {
+  return (
+    <Stack>
+      <Stack.Screen name="index" options={{ title: 'Home' }} />
+      <Stack.Screen
+        name="sheet"
+        options={{
+          presentation: 'formSheet',
+          headerShown: false,
+          sheetAllowedDetents: 'fitToContents',
+          sheetGrabberVisible: true,
+        }}
+      />
+    </Stack>
+  );
+}

--- a/apps/router-tester/app/tabs-form-sheet/home/index.tsx
+++ b/apps/router-tester/app/tabs-form-sheet/home/index.tsx
@@ -1,0 +1,34 @@
+import { Link } from 'expo-router';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+export default function Home() {
+  return (
+    <View style={styles.container}>
+      <Link href="/tabs-form-sheet/home/sheet" asChild>
+        <Pressable accessibilityRole="button" style={styles.button}>
+          <Text style={styles.buttonText}>Open form sheet</Text>
+        </Pressable>
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#f4f4f5',
+  },
+  button: {
+    borderRadius: 12,
+    backgroundColor: '#2563eb',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 17,
+    fontWeight: '600',
+  },
+});

--- a/apps/router-tester/app/tabs-form-sheet/home/sheet.tsx
+++ b/apps/router-tester/app/tabs-form-sheet/home/sheet.tsx
@@ -1,0 +1,60 @@
+import { router } from 'expo-router';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+
+export default function Sheet() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Pressable accessibilityRole="button" onPress={() => router.back()}>
+          <Text style={styles.action}>Cancel</Text>
+        </Pressable>
+        <Text style={styles.title}>NativeTabs form sheet</Text>
+        <Pressable accessibilityRole="button" onPress={() => router.back()}>
+          <Text style={styles.action}>Save</Text>
+        </Pressable>
+      </View>
+      <Text style={styles.description}>The input opens the keyboard automatically.</Text>
+      <TextInput
+        autoFocus
+        accessibilityLabel="Your name"
+        placeholder="Your name"
+        placeholderTextColor="#71717a"
+        style={styles.input}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 16,
+    backgroundColor: '#fff',
+    padding: 20,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  action: {
+    color: '#2563eb',
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  title: {
+    color: '#18181b',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  description: {
+    color: '#52525b',
+  },
+  input: {
+    borderRadius: 12,
+    backgroundColor: '#f4f4f5',
+    color: '#18181b',
+    fontSize: 18,
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+  },
+});


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested on Android 16 (API 36) with `react-native-screens` 4.27.0.

<table>
  <tr>
    <th>Keyboard closed</th>
    <th>Keyboard open</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/4eb19d63-0750-4db5-a147-021789e9e150" alt="Android form sheet with keyboard closed" width="512"></td>
    <td><img src="https://github.com/user-attachments/assets/db7ffbb7-7d4e-4d0c-b6c5-0fa600cabf37" alt="Android form sheet with keyboard open" width="512"></td>
  </tr>
</table>

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
