### PR TITLE
[router] Refactor unhandled navigation action reporting

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Remove the `onUnhandledAction` container prop from `expo-router/react-navigation`. ([#49917](https://github.com/expo/expo/pull/49917) by [@Ubax](https://github.com/Ubax))
 - Remove the `onReady` container prop and the `ready` container event. ([#49845](https://github.com/expo/expo/pull/49845) by [@Ubax](https://github.com/Ubax))
 - Remove `createStackNavigator` from `expo-router/js-stack`. Use `unstable_createStandardStackNavigator` with `unstable_integrateWithRouter` instead. ([#49209](https://github.com/expo/expo/pull/49209) by [@Ubax](https://github.com/Ubax))
 - Make `expo-symbols` an optional peer dependency. Install it to use `md` icons with `NativeTabs.Trigger.Icon` on Android. ([#49738](https://github.com/expo/expo/pull/49738) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/fork/NavigationContainer.tsx
+++ b/packages/expo-router/src/fork/NavigationContainer.tsx
@@ -43,7 +43,6 @@ type Props<ParamList extends object> = Omit<NavigationContainerProps, 'initialSt
  * Container component which holds the navigation state designed for React Native apps.
  * This should be rendered at the root wrapping the whole app.
  *
- * @param props.onUnhandledAction Callback which is called when an action is not handled. TODO(@ubax): restore this callback. https://linear.app/expo/issue/ENG-26123
  * @param props.direction Text direction of the components. Defaults to `'ltr'`.
  * @param props.theme Theme object for the UI elements.
  * @param props.linking Options for deep linking.

--- a/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
@@ -506,19 +506,19 @@ it('warns for direct navigation actions carrying a screen param', () => {
   warn.mockRestore();
 });
 
-it('logs an error when an action is dispatched before its router registers', () => {
-  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+it('reports an action dispatched before its router registers as unhandled', () => {
   const result = renderReducer({ registry: new Map() });
+  const action = { type: 'TEST' };
 
-  act(() => result.result.current.handleAction({ type: 'TEST' }));
+  act(() => result.result.current.handleAction(action));
 
-  expect(error).toHaveBeenCalledWith(expect.stringContaining("The action 'TEST'"));
+  expect(result.result.current.report?.events).toEqual([
+    { id: 0, type: 'unhandled-action', action },
+  ]);
   expect(result.result.current.state).toBe(initialState);
-  error.mockRestore();
 });
 
-it('logs an error for a later action after a same-batch reset changes the registered state key', () => {
-  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+it('reports a later action as unhandled after a same-batch reset changes the state key', () => {
   const registryEntry = entry((state, action) =>
     action.type === 'RESET_KEY'
       ? {
@@ -536,9 +536,11 @@ it('logs an error for a later action after a same-batch reset changes the regist
     result.result.current.handleAction({ type: 'NEXT' });
   });
 
-  expect(error).toHaveBeenCalledWith(expect.stringContaining("The action 'NEXT'"));
+  expect(result.result.current.report?.events).toEqual([
+    expect.objectContaining({ id: 0, type: 'action-dispatched', action: { type: 'RESET_KEY' } }),
+    { id: 1, type: 'unhandled-action', action: { type: 'NEXT' } },
+  ]);
   expect(result.result.current.state.key).toBe('next-root');
-  error.mockRestore();
 });
 
 it('resets a state slice when its router unregisters', () => {

--- a/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
@@ -530,7 +530,7 @@ it('does not report an unhandled action in production', () => {
     expect(result.result.current.state).toBe(initialState);
   } finally {
     if (nodeEnv === undefined) {
-      delete process.env.NODE_ENV;
+      Reflect.deleteProperty(process.env, 'NODE_ENV');
     } else {
       process.env.NODE_ENV = nodeEnv;
     }

--- a/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
@@ -340,7 +340,9 @@ it('logs an error for focused state without an index after commit', () => {
     } as unknown as NavigationState;
     return { state: incompleteState, affectedRouteKey: state.routes[0]!.key };
   });
-  const result = renderReducer({ registry: new Map([['root', entry(reduce)]]) });
+  const result = renderReducer({
+    registry: new Map([['root', entry(reduce)]]),
+  });
 
   act(() => result.result.current.handleAction({ type: 'INCOMPLETE' }));
 
@@ -380,7 +382,9 @@ it('uses the registry from the render that reduces an operation', () => {
     state: { ...state, index: 1 },
     affectedRouteKey: state.routes[1]!.key,
   }));
-  const result = renderReducer({ registry: new Map([['root', entry(firstReduce)]]) });
+  const result = renderReducer({
+    registry: new Map([['root', entry(firstReduce)]]),
+  });
   const processIntent = result.result.current.processIntent;
 
   result.rerender({
@@ -388,7 +392,10 @@ it('uses the registry from the render that reduces an operation', () => {
     routesWithRemovalPrevented: new Set(),
   });
   act(() =>
-    processIntent({ type: 'ACTION', payload: { action: { type: 'USE_CURRENT_REGISTRY' } } })
+    processIntent({
+      type: 'ACTION',
+      payload: { action: { type: 'USE_CURRENT_REGISTRY' } },
+    })
   );
 
   expect(result.result.current.processIntent).toBe(processIntent);
@@ -402,7 +409,9 @@ it('uses removal prevention from the render that reduces an operation', () => {
     state: { ...state, routes: state.routes.slice(0, 1) },
     affectedRouteKey: state.routes[0]!.key,
   }));
-  const result = renderReducer({ registry: new Map([['root', entry(reduce)]]) });
+  const result = renderReducer({
+    registry: new Map([['root', entry(reduce)]]),
+  });
   const processIntent = result.result.current.processIntent;
 
   result.rerender({
@@ -423,20 +432,37 @@ it('computes a queued action from accumulated state', () => {
     type: 'tab',
     routeNames: ['first', 'second'],
     routes: [
-      { key: 'first', name: 'first', state: { ...initialState, key: 'first-stack' } },
-      { key: 'second', name: 'second', state: { ...initialState, key: 'second-stack' } },
+      {
+        key: 'first',
+        name: 'first',
+        state: { ...initialState, key: 'first-stack' },
+      },
+      {
+        key: 'second',
+        name: 'second',
+        state: { ...initialState, key: 'second-stack' },
+      },
     ],
   };
   const reduce = jest.fn((state: NavigationState, action: NavigationAction) => {
     if (action.type === 'FOCUS_SECOND') {
-      return { state: { ...state, index: 1 }, affectedRouteKey: state.routes[1]!.key };
+      return {
+        state: { ...state, index: 1 },
+        affectedRouteKey: state.routes[1]!.key,
+      };
     }
     if (action.type === 'JUMP_TO' || action.type === 'NAVIGATE') {
-      return { state: { ...state, index: 0 }, affectedRouteKey: state.routes[0]!.key };
+      return {
+        state: { ...state, index: 0 },
+        affectedRouteKey: state.routes[0]!.key,
+      };
     }
     return null;
   });
-  const result = renderReducer({ state: tabState, registry: new Map([['root', entry(reduce)]]) });
+  const result = renderReducer({
+    state: tabState,
+    registry: new Map([['root', entry(reduce)]]),
+  });
 
   act(() => {
     result.result.current.processIntent({
@@ -463,7 +489,9 @@ it('computes a queued action from accumulated state', () => {
 
 it('warns and keeps the state when computing a queued action throws', () => {
   const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-  const result = renderReducer({ registry: new Map([['root', entry(() => null)]]) });
+  const result = renderReducer({
+    registry: new Map([['root', entry(() => null)]]),
+  });
 
   act(() =>
     result.result.current.processIntent({
@@ -518,6 +546,18 @@ it('reports an action dispatched before its router registers as unhandled', () =
   expect(result.result.current.state).toBe(initialState);
 });
 
+it('does not report an unhandled action in production', () => {
+  const nodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'production';
+  const result = renderReducer({ registry: new Map() });
+
+  act(() => result.result.current.handleAction({ type: 'TEST' }));
+
+  expect(result.result.current.report).toBeUndefined();
+  expect(result.result.current.state).toBe(initialState);
+  process.env.NODE_ENV = nodeEnv;
+});
+
 it('reports a later action as unhandled after a same-batch reset changes the state key', () => {
   const registryEntry = entry((state, action) =>
     action.type === 'RESET_KEY'
@@ -537,7 +577,11 @@ it('reports a later action as unhandled after a same-batch reset changes the sta
   });
 
   expect(result.result.current.report?.events).toEqual([
-    expect.objectContaining({ id: 0, type: 'action-dispatched', action: { type: 'RESET_KEY' } }),
+    expect.objectContaining({
+      id: 0,
+      type: 'action-dispatched',
+      action: { type: 'RESET_KEY' },
+    }),
     { id: 1, type: 'unhandled-action', action: { type: 'NEXT' } },
   ]);
   expect(result.result.current.state.key).toBe('next-root');

--- a/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
@@ -306,9 +306,7 @@ it('logs an error for stale focused state after commit', () => {
     } as unknown as NavigationState;
     return { state: staleState, affectedRouteKey: state.routes[0]!.key };
   });
-  const result = renderReducer({
-    registry: new Map([['root', entry(reduce)]]),
-  });
+  const result = renderReducer({ registry: new Map([['root', entry(reduce)]]) });
 
   act(() => result.result.current.handleAction({ type: 'STALE' }));
 
@@ -382,9 +380,7 @@ it('uses the registry from the render that reduces an operation', () => {
     state: { ...state, index: 1 },
     affectedRouteKey: state.routes[1]!.key,
   }));
-  const result = renderReducer({
-    registry: new Map([['root', entry(firstReduce)]]),
-  });
+  const result = renderReducer({ registry: new Map([['root', entry(firstReduce)]]) });
   const processIntent = result.result.current.processIntent;
 
   result.rerender({
@@ -392,10 +388,7 @@ it('uses the registry from the render that reduces an operation', () => {
     routesWithRemovalPrevented: new Set(),
   });
   act(() =>
-    processIntent({
-      type: 'ACTION',
-      payload: { action: { type: 'USE_CURRENT_REGISTRY' } },
-    })
+    processIntent({ type: 'ACTION', payload: { action: { type: 'USE_CURRENT_REGISTRY' } } })
   );
 
   expect(result.result.current.processIntent).toBe(processIntent);
@@ -409,9 +402,7 @@ it('uses removal prevention from the render that reduces an operation', () => {
     state: { ...state, routes: state.routes.slice(0, 1) },
     affectedRouteKey: state.routes[0]!.key,
   }));
-  const result = renderReducer({
-    registry: new Map([['root', entry(reduce)]]),
-  });
+  const result = renderReducer({ registry: new Map([['root', entry(reduce)]]) });
   const processIntent = result.result.current.processIntent;
 
   result.rerender({
@@ -432,37 +423,20 @@ it('computes a queued action from accumulated state', () => {
     type: 'tab',
     routeNames: ['first', 'second'],
     routes: [
-      {
-        key: 'first',
-        name: 'first',
-        state: { ...initialState, key: 'first-stack' },
-      },
-      {
-        key: 'second',
-        name: 'second',
-        state: { ...initialState, key: 'second-stack' },
-      },
+      { key: 'first', name: 'first', state: { ...initialState, key: 'first-stack' } },
+      { key: 'second', name: 'second', state: { ...initialState, key: 'second-stack' } },
     ],
   };
   const reduce = jest.fn((state: NavigationState, action: NavigationAction) => {
     if (action.type === 'FOCUS_SECOND') {
-      return {
-        state: { ...state, index: 1 },
-        affectedRouteKey: state.routes[1]!.key,
-      };
+      return { state: { ...state, index: 1 }, affectedRouteKey: state.routes[1]!.key };
     }
     if (action.type === 'JUMP_TO' || action.type === 'NAVIGATE') {
-      return {
-        state: { ...state, index: 0 },
-        affectedRouteKey: state.routes[0]!.key,
-      };
+      return { state: { ...state, index: 0 }, affectedRouteKey: state.routes[0]!.key };
     }
     return null;
   });
-  const result = renderReducer({
-    state: tabState,
-    registry: new Map([['root', entry(reduce)]]),
-  });
+  const result = renderReducer({ state: tabState, registry: new Map([['root', entry(reduce)]]) });
 
   act(() => {
     result.result.current.processIntent({
@@ -489,9 +463,7 @@ it('computes a queued action from accumulated state', () => {
 
 it('warns and keeps the state when computing a queued action throws', () => {
   const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-  const result = renderReducer({
-    registry: new Map([['root', entry(() => null)]]),
-  });
+  const result = renderReducer({ registry: new Map([['root', entry(() => null)]]) });
 
   act(() =>
     result.result.current.processIntent({
@@ -549,13 +521,20 @@ it('reports an action dispatched before its router registers as unhandled', () =
 it('does not report an unhandled action in production', () => {
   const nodeEnv = process.env.NODE_ENV;
   process.env.NODE_ENV = 'production';
-  const result = renderReducer({ registry: new Map() });
+  try {
+    const result = renderReducer({ registry: new Map() });
 
-  act(() => result.result.current.handleAction({ type: 'TEST' }));
+    act(() => result.result.current.handleAction({ type: 'TEST' }));
 
-  expect(result.result.current.report).toBeUndefined();
-  expect(result.result.current.state).toBe(initialState);
-  process.env.NODE_ENV = nodeEnv;
+    expect(result.result.current.report).toBeUndefined();
+    expect(result.result.current.state).toBe(initialState);
+  } finally {
+    if (nodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = nodeEnv;
+    }
+  }
 });
 
 it('reports a later action as unhandled after a same-batch reset changes the state key', () => {
@@ -577,11 +556,7 @@ it('reports a later action as unhandled after a same-batch reset changes the sta
   });
 
   expect(result.result.current.report?.events).toEqual([
-    expect.objectContaining({
-      id: 0,
-      type: 'action-dispatched',
-      action: { type: 'RESET_KEY' },
-    }),
+    expect.objectContaining({ id: 0, type: 'action-dispatched', action: { type: 'RESET_KEY' } }),
     { id: 1, type: 'unhandled-action', action: { type: 'NEXT' } },
   ]);
   expect(result.result.current.state.key).toBe('next-root');

--- a/packages/expo-router/src/global-state/__tests__/useNavigationTreeReportEvents.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/useNavigationTreeReportEvents.test.ios.tsx
@@ -84,6 +84,29 @@ test('emits removePrevented and removed to the registered route emitters', () =>
   expect(consumeReportEvents).toHaveBeenCalledWith([0, 1]);
 });
 
+test('warns about an unhandled action', () => {
+  const action = { type: 'NAVIGATE', payload: { name: 'missing' } };
+  const consumeReportEvents = jest.fn();
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const report: NavigationTreeReport = {
+    events: [
+      { id: 0, type: 'unhandled-action', action },
+      { id: 1, type: 'unhandled-action', action },
+    ],
+  };
+
+  renderHook(() => useNavigationTreeReportEvents(report, consumeReportEvents), { wrapper });
+
+  expect(error).toHaveBeenCalledTimes(1);
+  expect(error).toHaveBeenCalledWith(
+    expect.stringContaining(
+      "The action 'NAVIGATE' with payload {\"name\":\"missing\"} was not handled"
+    )
+  );
+  expect(consumeReportEvents).toHaveBeenCalledWith([0, 1]);
+  error.mockRestore();
+});
+
 test('does not emit twice in StrictMode', () => {
   const actions: string[] = [];
   const consumeReportEvents = jest.fn();

--- a/packages/expo-router/src/global-state/__tests__/useNavigationTreeReportEvents.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/useNavigationTreeReportEvents.test.ios.tsx
@@ -84,27 +84,37 @@ test('emits removePrevented and removed to the registered route emitters', () =>
   expect(consumeReportEvents).toHaveBeenCalledWith([0, 1]);
 });
 
-test('warns about an unhandled action', () => {
-  const action = { type: 'NAVIGATE', payload: { name: 'missing' } };
-  const consumeReportEvents = jest.fn();
-  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
-  const report: NavigationTreeReport = {
-    events: [
-      { id: 0, type: 'unhandled-action', action },
-      { id: 1, type: 'unhandled-action', action },
-    ],
-  };
+describe('unhandled action warnings', () => {
+  let error: jest.SpyInstance;
 
-  renderHook(() => useNavigationTreeReportEvents(report, consumeReportEvents), { wrapper });
+  beforeEach(() => {
+    error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
 
-  expect(error).toHaveBeenCalledTimes(1);
-  expect(error).toHaveBeenCalledWith(
-    expect.stringContaining(
-      "The action 'NAVIGATE' with payload {\"name\":\"missing\"} was not handled"
-    )
-  );
-  expect(consumeReportEvents).toHaveBeenCalledWith([0, 1]);
-  error.mockRestore();
+  afterEach(() => {
+    error.mockRestore();
+  });
+
+  test('warns about an unhandled action', () => {
+    const action = { type: 'NAVIGATE', payload: { name: 'missing' } };
+    const consumeReportEvents = jest.fn();
+    const report: NavigationTreeReport = {
+      events: [
+        { id: 0, type: 'unhandled-action', action },
+        { id: 1, type: 'unhandled-action', action },
+      ],
+    };
+
+    renderHook(() => useNavigationTreeReportEvents(report, consumeReportEvents), { wrapper });
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'The action \'NAVIGATE\' with payload {"name":"missing"} was not handled'
+      )
+    );
+    expect(consumeReportEvents).toHaveBeenCalledWith([0, 1]);
+  });
 });
 
 test('does not emit twice in StrictMode', () => {
@@ -147,7 +157,9 @@ test('keeps emitting the remaining events when a listener throws', () => {
     ],
   };
 
-  renderHook(() => useNavigationTreeReportEvents(report, consumeReportEvents), { wrapper });
+  renderHook(() => useNavigationTreeReportEvents(report, consumeReportEvents), {
+    wrapper,
+  });
 
   expect(actions).toEqual(['FIRST', 'SECOND']);
   expect(warn).toHaveBeenCalledTimes(1);

--- a/packages/expo-router/src/global-state/__tests__/useNavigationTreeReportEvents.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/useNavigationTreeReportEvents.test.ios.tsx
@@ -157,9 +157,7 @@ test('keeps emitting the remaining events when a listener throws', () => {
     ],
   };
 
-  renderHook(() => useNavigationTreeReportEvents(report, consumeReportEvents), {
-    wrapper,
-  });
+  renderHook(() => useNavigationTreeReportEvents(report, consumeReportEvents), { wrapper });
 
   expect(actions).toEqual(['FIRST', 'SECOND']);
   expect(warn).toHaveBeenCalledTimes(1);

--- a/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
+++ b/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
@@ -60,6 +60,10 @@ export type NavigationTreeReport = {
 
 type NavigationTreeReportEventData =
   | {
+      type: 'unhandled-action';
+      action: NavigationAction;
+    }
+  | {
       type: 'removed-routes';
       routeKeys: readonly string[];
       action: NavigationAction;
@@ -85,7 +89,6 @@ type NavigationTreeResult = {
   eventSeq: number;
 };
 
-const warnedActions = new WeakSet<NavigationAction>();
 const ACTIONS_WITHOUT_REMOVAL_PREVENTION = new Set(['ROUTE_NAMES_CHANGED']);
 
 function warnIfStaleState(state: NavigationState) {
@@ -101,46 +104,6 @@ function warnIfStaleState(state: NavigationState) {
     }
     focusedState = focusedState.routes[focusedState.index]?.state as NavigationState | undefined;
   }
-}
-
-function warnUnhandledAction(action: NavigationAction) {
-  if (process.env.NODE_ENV === 'production' || warnedActions.has(action)) {
-    return;
-  }
-  warnedActions.add(action);
-
-  const payload =
-    typeof action.payload === 'object' && action.payload !== null ? action.payload : undefined;
-  let message = `The action '${action.type}'${
-    payload ? ` with payload ${JSON.stringify(payload)}` : ''
-  } was not handled by any navigator.`;
-
-  switch (action.type) {
-    case 'NAVIGATE':
-    case 'PUSH':
-    case 'REPLACE':
-    case 'JUMP_TO':
-      if (payload && 'name' in payload && typeof payload.name === 'string') {
-        message += `\n\nDo you have a route named '${payload.name}'?`;
-      } else {
-        message += '\n\nYou need to pass the name of the screen to navigate to. This may be a bug.';
-      }
-      break;
-    case 'GO_BACK':
-    case 'POP':
-    case 'POP_TO_TOP':
-      message += '\n\nIs there any screen to go back to?';
-      break;
-    case 'OPEN_DRAWER':
-    case 'CLOSE_DRAWER':
-    case 'TOGGLE_DRAWER':
-      message += '\n\nIs your screen inside a Drawer navigator?';
-      break;
-  }
-
-  console.error(
-    `${message}\n\nThis is a development-only warning and won't be shown in production.`
-  );
 }
 
 function navigationTreeReducer(
@@ -219,10 +182,10 @@ function navigationTreeReducer(
         operation.payload.originKey
       );
       if (!origin) {
-        // TODO(@ubax): move console side effects out of the reducer and restore `onUnhandledAction`.
-        // https://linear.app/expo/issue/ENG-26123
-        warnUnhandledAction(operation.payload.action);
-        return result;
+        return appendReportEvent(result, {
+          type: 'unhandled-action',
+          action: operation.payload.action,
+        });
       }
 
       const reduction = reduceNavigationTree(operation.payload.action, config.registry, {
@@ -230,10 +193,10 @@ function navigationTreeReducer(
         tree,
       });
       if (!reduction.handled) {
-        // TODO(@ubax): move console side effects out of the reducer and restore `onUnhandledAction`.
-        // https://linear.app/expo/issue/ENG-26123
-        warnUnhandledAction(operation.payload.action);
-        return result;
+        return appendReportEvent(result, {
+          type: 'unhandled-action',
+          action: operation.payload.action,
+        });
       }
       const nextState = config.routeNode
         ? completeNavigationState(reduction.nextState, config.routeNode)
@@ -327,6 +290,20 @@ function navigationTreeReducer(
       return { ...result, report: events.length > 0 ? { events } : undefined };
     }
   }
+}
+
+function appendReportEvent(
+  result: NavigationTreeResult,
+  event: NavigationTreeReportEventData
+): NavigationTreeResult {
+  const eventWithId: NavigationTreeReportEvent = { ...event, id: result.eventSeq };
+  return {
+    ...result,
+    report: {
+      events: result.report ? [...result.report.events, eventWithId] : [eventWithId],
+    },
+    eventSeq: result.eventSeq + 1,
+  };
 }
 
 export function useNavigationTreeReducer({

--- a/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
+++ b/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
@@ -169,10 +169,7 @@ function navigationTreeReducer(
       }
       return navigationTreeReducer(
         result,
-        {
-          type: 'ACTION',
-          payload: { action, originKey: operation.payload.originKey },
-        },
+        { type: 'ACTION', payload: { action, originKey: operation.payload.originKey } },
         config
       );
     }
@@ -185,14 +182,7 @@ function navigationTreeReducer(
         operation.payload.originKey
       );
       if (!origin) {
-        return process.env.NODE_ENV === 'production'
-          ? result
-          : appendReportEvents(result, [
-              {
-                type: 'unhandled-action',
-                action: operation.payload.action,
-              },
-            ]);
+        return reportUnhandledAction(result, operation.payload.action);
       }
 
       const reduction = reduceNavigationTree(operation.payload.action, config.registry, {
@@ -200,14 +190,7 @@ function navigationTreeReducer(
         tree,
       });
       if (!reduction.handled) {
-        return process.env.NODE_ENV === 'production'
-          ? result
-          : appendReportEvents(result, [
-              {
-                type: 'unhandled-action',
-                action: operation.payload.action,
-              },
-            ]);
+        return reportUnhandledAction(result, operation.payload.action);
       }
       const nextState = config.routeNode
         ? completeNavigationState(reduction.nextState, config.routeNode)
@@ -289,6 +272,15 @@ function navigationTreeReducer(
       return { ...result, report: events.length > 0 ? { events } : undefined };
     }
   }
+}
+
+function reportUnhandledAction(
+  result: NavigationTreeResult,
+  action: NavigationAction
+): NavigationTreeResult {
+  return process.env.NODE_ENV === 'production'
+    ? result
+    : appendReportEvents(result, [{ type: 'unhandled-action', action }]);
 }
 
 function appendReportEvents(

--- a/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
+++ b/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
@@ -169,7 +169,10 @@ function navigationTreeReducer(
       }
       return navigationTreeReducer(
         result,
-        { type: 'ACTION', payload: { action, originKey: operation.payload.originKey } },
+        {
+          type: 'ACTION',
+          payload: { action, originKey: operation.payload.originKey },
+        },
         config
       );
     }
@@ -182,10 +185,14 @@ function navigationTreeReducer(
         operation.payload.originKey
       );
       if (!origin) {
-        return appendReportEvent(result, {
-          type: 'unhandled-action',
-          action: operation.payload.action,
-        });
+        return process.env.NODE_ENV === 'production'
+          ? result
+          : appendReportEvents(result, [
+              {
+                type: 'unhandled-action',
+                action: operation.payload.action,
+              },
+            ]);
       }
 
       const reduction = reduceNavigationTree(operation.payload.action, config.registry, {
@@ -193,10 +200,14 @@ function navigationTreeReducer(
         tree,
       });
       if (!reduction.handled) {
-        return appendReportEvent(result, {
-          type: 'unhandled-action',
-          action: operation.payload.action,
-        });
+        return process.env.NODE_ENV === 'production'
+          ? result
+          : appendReportEvents(result, [
+              {
+                type: 'unhandled-action',
+                action: operation.payload.action,
+              },
+            ]);
       }
       const nextState = config.routeNode
         ? completeNavigationState(reduction.nextState, config.routeNode)
@@ -236,19 +247,7 @@ function navigationTreeReducer(
                 state: committedState,
               },
             ];
-      const events: NavigationTreeReportEvent[] = eventsWithoutIds.map((event, index) => ({
-        ...event,
-        id: result.eventSeq + index,
-      }));
-      const report: NavigationTreeReport = {
-        events: result.report ? [...result.report.events, ...events] : events,
-      };
-
-      return {
-        state: committedState,
-        report,
-        eventSeq: result.eventSeq + events.length,
-      };
+      return appendReportEvents({ ...result, state: committedState }, eventsWithoutIds);
     }
     case 'NAVIGATOR_UNMOUNTED': {
       // A still-registered key re-registered before this operation reduced, so it did not unmount.
@@ -292,17 +291,20 @@ function navigationTreeReducer(
   }
 }
 
-function appendReportEvent(
+function appendReportEvents(
   result: NavigationTreeResult,
-  event: NavigationTreeReportEventData
+  events: NavigationTreeReportEventData[]
 ): NavigationTreeResult {
-  const eventWithId: NavigationTreeReportEvent = { ...event, id: result.eventSeq };
+  const eventsWithIds: NavigationTreeReportEvent[] = events.map((event, index) => ({
+    ...event,
+    id: result.eventSeq + index,
+  }));
   return {
     ...result,
     report: {
-      events: result.report ? [...result.report.events, eventWithId] : [eventWithId],
+      events: result.report ? [...result.report.events, ...eventsWithIds] : eventsWithIds,
     },
-    eventSeq: result.eventSeq + 1,
+    eventSeq: result.eventSeq + eventsWithIds.length,
   };
 }
 

--- a/packages/expo-router/src/global-state/useNavigationTreeReportEvents.ts
+++ b/packages/expo-router/src/global-state/useNavigationTreeReportEvents.ts
@@ -4,8 +4,51 @@ import * as React from 'react';
 
 import { unstable_navigationEvents } from '../navigationEvents';
 import { useClientLayoutEffect } from '../react-navigation/core/useClientLayoutEffect';
+import type { NavigationAction } from '../react-navigation/routers';
 import { GlobalRemovalEventEmitterRegistryContext } from './removalPrevention';
 import type { NavigationTreeReport } from './useNavigationTreeReducer';
+
+const warnedActions = new WeakSet<NavigationAction>();
+
+function warnUnhandledAction(action: NavigationAction) {
+  if (process.env.NODE_ENV === 'production' || warnedActions.has(action)) {
+    return;
+  }
+  warnedActions.add(action);
+
+  const payload =
+    typeof action.payload === 'object' && action.payload !== null ? action.payload : undefined;
+  let message = `The action '${action.type}'${
+    payload ? ` with payload ${JSON.stringify(payload)}` : ''
+  } was not handled by any navigator.`;
+
+  switch (action.type) {
+    case 'NAVIGATE':
+    case 'PUSH':
+    case 'REPLACE':
+    case 'JUMP_TO':
+      if (payload && 'name' in payload && typeof payload.name === 'string') {
+        message += `\n\nDo you have a route named '${payload.name}'?`;
+      } else {
+        message += '\n\nYou need to pass the name of the screen to navigate to. This may be a bug.';
+      }
+      break;
+    case 'GO_BACK':
+    case 'POP':
+    case 'POP_TO_TOP':
+      message += '\n\nIs there any screen to go back to?';
+      break;
+    case 'OPEN_DRAWER':
+    case 'CLOSE_DRAWER':
+    case 'TOGGLE_DRAWER':
+      message += '\n\nIs your screen inside a Drawer navigator?';
+      break;
+  }
+
+  console.error(
+    `${message}\n\nThis is a development-only warning and won't be shown in production.`
+  );
+}
 
 export function useNavigationTreeReportEvents(
   report: NavigationTreeReport | undefined,
@@ -35,6 +78,9 @@ export function useNavigationTreeReportEvents(
       // A listener that throws must not stop the remaining events from being delivered.
       try {
         switch (event.type) {
+          case 'unhandled-action':
+            warnUnhandledAction(event.action);
+            break;
           case 'prevented-routes':
             for (const routeKey of event.routeKeys) {
               emitterRegistry.emitRemovalEvent(routeKey, 'removePrevented', event.action);

--- a/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
@@ -64,7 +64,6 @@ const duplicateNameWarnings: string[] = [];
  * This should be rendered at the root wrapping the whole app.
  *
  * @param props.initialState Initial state object for the navigation tree.
- * @param props.onUnhandledAction Callback which is called when an action is not handled. TODO(@ubax): restore this callback. https://linear.app/expo/issue/ENG-26123
  * @param props.theme Theme object for the UI elements.
  * @param props.children Child elements to render the content.
  * @param props.ref Ref object which refers to the navigation object containing helper methods.

--- a/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
@@ -744,47 +744,6 @@ test('isReady always returns true', () => {
   expect(ref.current?.isReady()).toBe(true);
 });
 
-// TODO(@ubax): restore when unhandled actions are wired to the reducer. https://linear.app/expo/issue/ENG-26123
-test.skip('invokes the unhandled action listener with the unhandled action', () => {
-  const ref = createNavigationContainerRef<ParamListBase>();
-  const fn = jest.fn();
-
-  const TestNavigator = (props: any) => {
-    const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
-
-    return (
-      <NavigationContent>
-        {state.routes.map((route) => descriptors[route.key]!.render())}
-      </NavigationContent>
-    );
-  };
-
-  const TestScreen = () => <></>;
-
-  render(
-    <BaseNavigationContainer ref={ref} onUnhandledAction={fn}>
-      <TestNavigator>
-        <Screen name="foo" component={TestScreen} />
-        <Screen name="bar" component={TestScreen} />
-      </TestNavigator>
-    </BaseNavigationContainer>
-  );
-
-  act(() => {
-    ref.current!.navigate('bar');
-  });
-  act(() => {
-    ref.current!.navigate('baz');
-  });
-
-  expect(fn).toHaveBeenCalledWith({
-    payload: {
-      name: 'baz',
-    },
-    type: 'NAVIGATE',
-  });
-});
-
 test('warns for duplicate route names nested inside each other', () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);

--- a/packages/expo-router/src/react-navigation/core/__tests__/actionBubbling.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/actionBubbling.test.ios.tsx
@@ -125,7 +125,6 @@ test("lets parent handle the action if child didn't", () => {
 
 test('handles an unsupported targeted action as a no-op without bubbling', () => {
   const ref = createNavigationContainerRef<ParamListBase>();
-  const onUnhandledAction = jest.fn();
 
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
@@ -136,7 +135,7 @@ test('handles an unsupported targeted action as a no-op without bubbling', () =>
   };
 
   render(
-    <BaseNavigationContainer ref={ref} onUnhandledAction={onUnhandledAction}>
+    <BaseNavigationContainer ref={ref}>
       <TestNavigator>
         <Screen name="foo">{() => null}</Screen>
       </TestNavigator>
@@ -148,11 +147,9 @@ test('handles an unsupported targeted action as a no-op without bubbling', () =>
   act(() => ref.dispatchSync({ type: 'POP_TO_TOP', target: state.key }));
 
   expect(ref.current!.getRootState()).toBe(state);
-  expect(onUnhandledAction).not.toHaveBeenCalled();
 });
 
-// TODO(@ubax): Restore unhandled action callbacks after the reducer migration. https://linear.app/expo/issue/ENG-26123
-test.skip("doesn't let a child handle an untargeted navigate action", () => {
+test("doesn't let a child handle an untargeted navigate action", () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
 
@@ -166,7 +163,7 @@ test.skip("doesn't let a child handle an untargeted navigate action", () => {
   const TestScreen = () => null;
 
   const onStateChange = jest.fn();
-  const onUnhandledAction = jest.fn();
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
 
   const navigation = createNavigationContainerRef<ParamListBase>();
 
@@ -180,8 +177,7 @@ test.skip("doesn't let a child handle an untargeted navigate action", () => {
           { name: 'baz', state: { routes: [{ name: 'qux' }, { name: 'lex' }] } },
         ],
       }}
-      onStateChange={onStateChange}
-      onUnhandledAction={onUnhandledAction}>
+      onStateChange={onStateChange}>
       <TestNavigator>
         <Screen name="foo" component={TestScreen} />
         <Screen name="bar" component={TestScreen} />
@@ -202,15 +198,11 @@ test.skip("doesn't let a child handle an untargeted navigate action", () => {
   act(() => navigation.navigate('lex'));
 
   expect(onStateChange).not.toHaveBeenCalled();
-  expect(onUnhandledAction).toHaveBeenCalledTimes(1);
-  expect(onUnhandledAction).toHaveBeenCalledWith(
-    expect.objectContaining({
-      type: 'NAVIGATE',
-      payload: { name: 'lex' },
-    })
+  expect(error).toHaveBeenCalledWith(
+    expect.stringContaining('was not handled by any navigator.')
   );
-
   expect(navigation.getCurrentRoute()?.name).toBe('foo');
+  error.mockRestore();
 });
 
 test('action goes to correct parent navigator if target is specified', () => {
@@ -535,8 +527,7 @@ test("action doesn't bubble if target is specified", () => {
   expect(onStateChange).not.toHaveBeenCalled();
 });
 
-// TODO(@ubax): Restore unhandled action callbacks after the reducer migration. https://linear.app/expo/issue/ENG-26123
-test.skip('logs error if no navigator handled the action', () => {
+test('logs error if no navigator handled the action', () => {
   const TestRouter = MockRouter;
 
   const TestNavigator = (props: any) => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/actionBubbling.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/actionBubbling.test.ios.tsx
@@ -183,10 +183,7 @@ describe('unhandled action warnings', () => {
           routes: [
             { name: 'foo' },
             { name: 'bar' },
-            {
-              name: 'baz',
-              state: { routes: [{ name: 'qux' }, { name: 'lex' }] },
-            },
+            { name: 'baz', state: { routes: [{ name: 'qux' }, { name: 'lex' }] } },
           ],
         }}
         onStateChange={onStateChange}>
@@ -865,12 +862,7 @@ test("prevents removing a grand child screen with 'removePrevented' event", () =
             name: 'baz',
             state: {
               type: 'stack',
-              routes: [
-                {
-                  name: 'qux',
-                  state: { type: 'stack', routes: [{ name: 'lex' }] },
-                },
-              ],
+              routes: [{ name: 'qux', state: { type: 'stack', routes: [{ name: 'lex' }] } }],
             },
           },
         ],
@@ -973,12 +965,7 @@ test("prevents removing by multiple screens with 'removePrevented' event", () =>
             name: 'bax',
             state: {
               type: 'stack',
-              routes: [
-                {
-                  name: 'qux',
-                  state: { type: 'stack', routes: [{ name: 'lex' }] },
-                },
-              ],
+              routes: [{ name: 'qux', state: { type: 'stack', routes: [{ name: 'lex' }] } }],
             },
           },
         ],

--- a/packages/expo-router/src/react-navigation/core/__tests__/actionBubbling.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/actionBubbling.test.ios.tsx
@@ -149,60 +149,73 @@ test('handles an unsupported targeted action as a no-op without bubbling', () =>
   expect(ref.current!.getRootState()).toBe(state);
 });
 
-test("doesn't let a child handle an untargeted navigate action", () => {
-  const TestNavigator = (props: any) => {
-    const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
+describe('unhandled action warnings', () => {
+  let error: jest.SpyInstance;
 
-    return (
-      <NavigationContent>
-        {state.routes.map((route) => descriptors[route.key]!.render())}
-      </NavigationContent>
+  beforeEach(() => {
+    error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    error.mockRestore();
+  });
+
+  test("doesn't let a child handle an untargeted navigate action", () => {
+    const TestNavigator = (props: any) => {
+      const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
+
+      return (
+        <NavigationContent>
+          {state.routes.map((route) => descriptors[route.key]!.render())}
+        </NavigationContent>
+      );
+    };
+
+    const TestScreen = () => null;
+
+    const onStateChange = jest.fn();
+    const navigation = createNavigationContainerRef<ParamListBase>();
+
+    const element = (
+      <BaseNavigationContainer
+        ref={navigation}
+        initialState={{
+          routes: [
+            { name: 'foo' },
+            { name: 'bar' },
+            {
+              name: 'baz',
+              state: { routes: [{ name: 'qux' }, { name: 'lex' }] },
+            },
+          ],
+        }}
+        onStateChange={onStateChange}>
+        <TestNavigator>
+          <Screen name="foo" component={TestScreen} />
+          <Screen name="bar" component={TestScreen} />
+          <Screen name="baz">
+            {() => (
+              <TestNavigator>
+                <Screen name="qux" component={TestScreen} />
+                <Screen name="lex" component={TestScreen} />
+              </TestNavigator>
+            )}
+          </Screen>
+        </TestNavigator>
+      </BaseNavigationContainer>
     );
-  };
 
-  const TestScreen = () => null;
+    render(element);
 
-  const onStateChange = jest.fn();
-  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    act(() => navigation.navigate('lex'));
 
-  const navigation = createNavigationContainerRef<ParamListBase>();
-
-  const element = (
-    <BaseNavigationContainer
-      ref={navigation}
-      initialState={{
-        routes: [
-          { name: 'foo' },
-          { name: 'bar' },
-          { name: 'baz', state: { routes: [{ name: 'qux' }, { name: 'lex' }] } },
-        ],
-      }}
-      onStateChange={onStateChange}>
-      <TestNavigator>
-        <Screen name="foo" component={TestScreen} />
-        <Screen name="bar" component={TestScreen} />
-        <Screen name="baz">
-          {() => (
-            <TestNavigator>
-              <Screen name="qux" component={TestScreen} />
-              <Screen name="lex" component={TestScreen} />
-            </TestNavigator>
-          )}
-        </Screen>
-      </TestNavigator>
-    </BaseNavigationContainer>
-  );
-
-  render(element);
-
-  act(() => navigation.navigate('lex'));
-
-  expect(onStateChange).not.toHaveBeenCalled();
-  expect(error).toHaveBeenCalledWith(
-    expect.stringContaining('was not handled by any navigator.')
-  );
-  expect(navigation.getCurrentRoute()?.name).toBe('foo');
-  error.mockRestore();
+    expect(onStateChange).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('was not handled by any navigator.')
+    );
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(navigation.getCurrentRoute()?.name).toBe('foo');
+  });
 });
 
 test('action goes to correct parent navigator if target is specified', () => {
@@ -852,7 +865,12 @@ test("prevents removing a grand child screen with 'removePrevented' event", () =
             name: 'baz',
             state: {
               type: 'stack',
-              routes: [{ name: 'qux', state: { type: 'stack', routes: [{ name: 'lex' }] } }],
+              routes: [
+                {
+                  name: 'qux',
+                  state: { type: 'stack', routes: [{ name: 'lex' }] },
+                },
+              ],
             },
           },
         ],
@@ -955,7 +973,12 @@ test("prevents removing by multiple screens with 'removePrevented' event", () =>
             name: 'bax',
             state: {
               type: 'stack',
-              routes: [{ name: 'qux', state: { type: 'stack', routes: [{ name: 'lex' }] } }],
+              routes: [
+                {
+                  name: 'qux',
+                  state: { type: 'stack', routes: [{ name: 'lex' }] },
+                },
+              ],
             },
           },
         ],

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -400,11 +400,6 @@ export type NavigationContainerProps = {
    */
   initialState?: InitialState;
   /**
-   * Callback which is called when an action is not handled.
-   * TODO(@ubax): restore this callback. https://linear.app/expo/issue/ENG-26123
-   */
-  onUnhandledAction?: (action: Readonly<NavigationAction>) => void;
-  /**
    * Theme object for the UI elements.
    */
   theme?: ReactNavigation.Theme;


### PR DESCRIPTION
# Why

Treat unhandled actions as reducer events and warn about them in useNavigationTreeReportEvents.ts

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
