### PR TITLE
[docs] Use the agent prompt block on the native upgrade helper

### DIFF
--- a/docs/ui/components/AgentPrompt/AgentPrompt.test.tsx
+++ b/docs/ui/components/AgentPrompt/AgentPrompt.test.tsx
@@ -57,6 +57,20 @@ function developmentBuildsPrompt() {
   );
 }
 
+const NATIVE_UPGRADE_PAGE = '/bare/upgrade/';
+const RUNTIME_PROMPT =
+  'Upgrade my Expo React Native project from SDK 52 to SDK 53.\n\ndiff --git a/android/app/build.gradle';
+
+function runtimePrompt() {
+  return (
+    <AgentPrompt
+      title="Upgrade your native project with an AI agent"
+      description={DESCRIPTION}
+      prompt={RUNTIME_PROMPT}
+    />
+  );
+}
+
 function setupClipboard() {
   const writeText = jest.fn();
   Object.defineProperty(navigator, 'clipboard', {
@@ -138,6 +152,27 @@ describe('AgentPrompt', () => {
     renderAt(SINGLE_PROMPT_PAGE, singlePrompt());
 
     expect(screen.getByRole('button', { name: /show prompt/i })).toHaveAttribute('data-md', 'skip');
+  });
+
+  it('copies a runtime prompt given as a prop', async () => {
+    const writeText = setupClipboard();
+
+    renderAt(NATIVE_UPGRADE_PAGE, runtimePrompt());
+
+    expect(await copiedTextAsync(writeText)).toBe(RUNTIME_PROMPT);
+  });
+
+  it('hides a runtime prompt until the reader asks for it', () => {
+    setupClipboard();
+
+    renderAt(NATIVE_UPGRADE_PAGE, runtimePrompt());
+    const code = screen.getByText(RUNTIME_PROMPT, { normalizer: text => text });
+
+    expect(code).not.toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: /show prompt/i }));
+
+    expect(code).toBeVisible();
   });
 
   it('has no axe violations', async () => {

--- a/docs/ui/components/AgentPrompt/index.tsx
+++ b/docs/ui/components/AgentPrompt/index.tsx
@@ -3,7 +3,7 @@ import { TriangleDownIcon } from '@expo/styleguide-icons/custom/TriangleDownIcon
 import { ClipboardIcon } from '@expo/styleguide-icons/outline/ClipboardIcon';
 import { MagicWand01Icon } from '@expo/styleguide-icons/outline/MagicWand01Icon';
 import { motion } from 'framer-motion';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/compat/router';
 import {
   Children,
   createContext,
@@ -24,6 +24,8 @@ import { CALLOUT, HEADLINE } from '~/ui/components/Text';
 type AgentPromptProps = PropsWithChildren<{
   title: string;
   description: string;
+  /** Prompt built at runtime, for callers that cannot author it as MDX. */
+  prompt?: string;
   selectorLabel?: string;
   queryParam?: string;
   defaultOption?: string;
@@ -55,6 +57,7 @@ function selectedPromptText(container: HTMLElement | null) {
 export function AgentPrompt({
   title,
   description,
+  prompt,
   selectorLabel,
   queryParam,
   defaultOption,
@@ -68,9 +71,11 @@ export function AgentPrompt({
   const [isPromptVisible, setIsPromptVisible] = useState(false);
   const promptId = useId();
   const contentRef = useRef<HTMLDivElement>(null);
-  const { copiedIsVisible, onCopyAsync } = useCopy(() => selectedPromptText(contentRef.current));
+  const { copiedIsVisible, onCopyAsync } = useCopy(
+    () => prompt ?? selectedPromptText(contentRef.current)
+  );
 
-  const fromQuery = queryParam ? router.query[queryParam] : undefined;
+  const fromQuery = queryParam ? router?.query[queryParam] : undefined;
   const selectedId = queryParam
     ? (options.find(option => option.id === fromQuery)?.id ?? fallbackId)
     : localOptionId;
@@ -92,7 +97,7 @@ export function AgentPrompt({
       return;
     }
 
-    const nextQuery = { ...router.query };
+    const nextQuery = { ...router?.query };
 
     if (nextId === fallbackId) {
       delete nextQuery[queryParam];
@@ -100,7 +105,7 @@ export function AgentPrompt({
       nextQuery[queryParam] = nextId;
     }
 
-    void router.push({ query: nextQuery }, undefined, { shallow: true });
+    void router?.push({ query: nextQuery }, undefined, { shallow: true });
   }
 
   return (
@@ -179,9 +184,19 @@ export function AgentPrompt({
             ref={contentRef}
             hidden={!isPromptVisible}
             className="mt-3 [&_.code-block-wrapper]:my-0">
-            <SelectedOptionContext.Provider value={selectedId}>
-              {children}
-            </SelectedOptionContext.Provider>
+            {prompt ? (
+              <div className="code-block-wrapper overflow-clip rounded-3xl border border-secondary bg-subtle">
+                <pre className="relative max-h-96 overflow-auto whitespace-pre">
+                  <div className="w-fit p-4">
+                    <code className="text-xs text-default">{prompt}</code>
+                  </div>
+                </pre>
+              </div>
+            ) : (
+              <SelectedOptionContext.Provider value={selectedId}>
+                {children}
+              </SelectedOptionContext.Provider>
+            )}
           </div>
         </motion.div>
       </div>

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/NativeUpgradePromptCallout.test.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/NativeUpgradePromptCallout.test.tsx
@@ -69,6 +69,15 @@ describe('NativeUpgradePromptCallout', () => {
     expect(await screen.findByText('Copied!')).toBeInTheDocument();
   });
 
+  it('reveals the generated prompt behind the disclosure', () => {
+    setupClipboard();
+
+    render(<NativeUpgradePromptCallout fromVersion="52" toVersion="53" diff={DIFF} />);
+    fireEvent.click(screen.getByRole('button', { name: /show prompt/i }));
+
+    expect(screen.getByText(/Apply every change in this diff/)).toBeVisible();
+  });
+
   it('has no axe violations', async () => {
     setupClipboard();
 

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/NativeUpgradePromptCallout.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/NativeUpgradePromptCallout.tsx
@@ -1,10 +1,6 @@
-import { Button, mergeClasses } from '@expo/styleguide';
-import { ClipboardIcon } from '@expo/styleguide-icons/outline/ClipboardIcon';
-import { MagicWand01Icon } from '@expo/styleguide-icons/outline/MagicWand01Icon';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { useCopy } from '~/common/useCopy';
-import { CALLOUT, FOOTNOTE } from '~/ui/components/Text';
+import { AgentPrompt } from '~/ui/components/AgentPrompt';
 
 import { buildNativeUpgradePrompt } from './buildUpgradePrompt';
 
@@ -19,48 +15,35 @@ export function NativeUpgradePromptCallout({
   toVersion,
   diff,
 }: NativeUpgradePromptCalloutProps) {
-  const url =
-    typeof window !== 'undefined'
-      ? `${window.location.origin}${window.location.pathname}?fromSdk=${fromVersion}&toSdk=${toVersion}`
-      : undefined;
-  const prompt = useMemo(
-    () => (diff ? buildNativeUpgradePrompt({ from: fromVersion, to: toVersion, diff, url }) : ''),
-    [fromVersion, toVersion, diff, url]
-  );
-  const { copiedIsVisible, onCopyAsync } = useCopy(prompt);
+  const [isMounted, setIsMounted] = useState(false);
+
+  // The prompt carries the page URL and the whole diff, so it is built after mount: the server has
+  // no origin to pin the URL to, and the diff already ships once in the diff blocks below.
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const prompt = useMemo(() => {
+    if (!isMounted || !diff) {
+      return '';
+    }
+
+    const url = `${window.location.origin}${window.location.pathname}?fromSdk=${fromVersion}&toSdk=${toVersion}`;
+
+    return buildNativeUpgradePrompt({ from: fromVersion, to: toVersion, diff, url });
+  }, [isMounted, fromVersion, toVersion, diff]);
 
   if (!diff) {
     return null;
   }
 
   return (
-    <div
-      data-md="skip"
-      className={mergeClasses(
-        'mb-4 flex flex-col gap-3 rounded-3xl border border-info bg-info px-4 py-3 shadow-xs',
-        'sm:flex-row sm:items-center sm:gap-4'
-      )}>
-      <div className="flex gap-3 sm:flex-1">
-        <MagicWand01Icon aria-hidden="true" className="mt-0.5 icon-sm shrink-0 text-info" />
-        <div>
-          <CALLOUT weight="medium">Upgrading with an AI agent?</CALLOUT>
-          <FOOTNOTE theme="secondary" className="mt-1 block text-sm">
-            Copy a ready-to-run prompt with the full diff and apply instructions, then paste it into
-            your AI assistant to update your native projects configuration.
-          </FOOTNOTE>
-        </div>
-      </div>
-      <Button
-        theme="primary"
-        size="sm"
-        leftSlot={<ClipboardIcon aria-hidden="true" className="icon-sm" />}
-        className="shrink-0 justify-center border-palette-blue11 bg-palette-blue11 text-palette-blue1 dark:border-palette-blue9 dark:bg-palette-blue9 dark:text-palette-blue2 dark:hocus:bg-palette-blue9 hocus:bg-palette-blue11 max-sm:w-full"
-        onClick={() => void onCopyAsync()}>
-        {copiedIsVisible ? 'Copied!' : 'Copy prompt'}
-      </Button>
-      <span role="status" aria-live="polite" className="sr-only">
-        {copiedIsVisible ? 'Prompt copied to clipboard' : ''}
-      </span>
+    <div data-md="skip">
+      <AgentPrompt
+        title="Upgrade your native project with an AI agent"
+        description={`Paste this into Claude, Cursor, Codex, or another agent. It carries the full diff from SDK ${fromVersion} to SDK ${toVersion}.`}
+        prompt={prompt}
+      />
     </div>
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/49814

# How

<!--
How did you build this feature or fix this bug and why?
-->

Use the agent prompt block on the native upgrade helper.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


<img width="2304" height="1148" alt="CleanShot 2026-09-09 at 23 12 56@2x" src="https://github.com/user-attachments/assets/43e6163c-0807-4874-bab4-695f5b449b2c" />


See preview: https://pr-49919.expo-docs.pages.dev/bare/upgrade/?fromSdk=56&toSdk=57

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
