### PR TITLE
[verify] Bump verify engine fallback to 0.11.10 and document `with <model>`

### DIFF
--- a/.github/expo-bot.md
+++ b/.github/expo-bot.md
@@ -12,7 +12,7 @@ Comment `@expo-bot help` on an expo/expo thread for a short list. That command a
 | `@expo-bot verify` | `/verify` | issue or PR | Investigate and post attested findings. On an issue, also opens a fix PR when it can. On a PR, report only unless `--fix`. |
 | `@expo-bot verify --fix` | `/verify --fix` | PR (on an issue, fix is already the default) | Also attempt a fix pull request |
 | `@expo-bot verify --no-fix` | `/verify --no-fix` | issue or PR | Report only; never open a PR |
-| `… --model <name>` | `… --fable`, `--opus`, `--sonnet`, `--haiku` | issue or PR | Run the agent on a different model for this run (`fable`/`opus`/`sonnet`/`haiku` or a full `claude-*` id). Combines with any verify/check/work form. |
+| `… --model <name>` or `… with <name>` | `… --fable`, `--opus`, `--sonnet`, `--haiku` | issue or PR | Run the agent on a different model for this run (`fable`/`opus`/`sonnet`/`haiku` or a full `claude-*` id), e.g. `@expo-bot verify with fable`. The flag forms combine with any verify/check/work form; the `with <name>` phrase applies to verify, check, and triage only, since "with" is ordinary prose in a work task. |
 | `@expo-bot review` | `/review`, `/expo-review` | PR | One-shot AI review; router picks agents |
 | `@expo-bot review all` | `/review all` | PR | Review with every agent |
 | `@expo-bot review <agents>` | `/review <agents>` | PR | Review with a named subset (`correctness security`, …) |

--- a/.github/workflows/verify-comment.yml
+++ b/.github/workflows/verify-comment.yml
@@ -50,7 +50,7 @@ jobs:
     # engine exit 1 behind a green run (run 32919110451).
     continue-on-error: true
     env:
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.8' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.9' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/verify-comment.yml
+++ b/.github/workflows/verify-comment.yml
@@ -50,7 +50,7 @@ jobs:
     # engine exit 1 behind a green run (run 32919110451).
     continue-on-error: true
     env:
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.9' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.10' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,7 +60,7 @@ jobs:
       # Same version feeds the guard and the run, so the engine that clears
       # the profile is the engine that reads it. Override with the repo
       # variable VERIFY_VERSION; the fallback pins the tested release.
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.8' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.9' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,7 +60,7 @@ jobs:
       # Same version feeds the guard and the run, so the engine that clears
       # the profile is the engine that reads it. Override with the repo
       # variable VERIFY_VERSION; the fallback pins the tested release.
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.9' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.10' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
# Why

Two engine releases to roll out:

- **0.11.9**: every comment-path `verify run` on GitHub Actions had failed in context collection since the ubuntu-latest image picked up gh CLI 2.100.0. gh 2.99.0 ([cli/cli#14215](https://github.com/cli/cli/pull/14215)) rejects `--comments` together with `--json`, and the engine passed both. Example: [run 34387666970](https://github.com/expo/expo/actions/runs/34387666970) on #49896.
- **0.11.10**: `@expo-bot verify with fable` (a comment on #49896) ran on the default model because the grammar knew only `--model <name>` and the shorthand flags. The phrase `with <name>` now resolves like `--model` on verify, check, and triage.

# How

The `VERIFY_VERSION` repo variable is set to 0.11.10. This bumps the hardcoded fallback in `verify.yml` and `verify-comment.yml` to match, and adds the `with <name>` form to the `@expo-bot help` table.

# Test Plan

Comment `@expo-bot verify with fable` on an issue or PR and confirm the `verify (comment)` workflow gets past "Run verify (comment path)", logs `model=claude-fable-5`, and posts findings.