### PR TITLE
[verify] Bump verify engine to 0.11.12, including et verify's own pin

### DIFF
--- a/.github/workflows/verify-comment.yml
+++ b/.github/workflows/verify-comment.yml
@@ -50,7 +50,7 @@ jobs:
     # engine exit 1 behind a green run (run 32919110451).
     continue-on-error: true
     env:
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.11' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.12' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/verify-comment.yml
+++ b/.github/workflows/verify-comment.yml
@@ -50,7 +50,7 @@ jobs:
     # engine exit 1 behind a green run (run 32919110451).
     continue-on-error: true
     env:
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.10' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.11' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,7 +60,7 @@ jobs:
       # Same version feeds the guard and the run, so the engine that clears
       # the profile is the engine that reads it. Override with the repo
       # variable VERIFY_VERSION; the fallback pins the tested release.
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.11' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.12' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,7 +60,7 @@ jobs:
       # Same version feeds the guard and the run, so the engine that clears
       # the profile is the engine that reads it. Override with the repo
       # variable VERIFY_VERSION; the fallback pins the tested release.
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.10' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.11' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/tools/src/commands/VerifyCommand.ts
+++ b/tools/src/commands/VerifyCommand.ts
@@ -940,7 +940,7 @@ function contextHelp(argv: string[]): string {
 // subcommands exec the engine with the repo's .expo-agents/verify/ profile. roundup
 // stays native here — it is expo policy (emoji conventions, branch scoping,
 // cost tables) the engine has not absorbed yet.
-const ENGINE_VERSION = process.env.VERIFY_ENGINE_VERSION || '0.11.6';
+const ENGINE_VERSION = process.env.VERIFY_ENGINE_VERSION || '0.11.11';
 
 async function delegateToEngine(engineArgs: string[]): Promise<never> {
   // The profile's home is .expo-agents/verify/ (engine 0.9.0); the engine itself

--- a/tools/src/commands/VerifyCommand.ts
+++ b/tools/src/commands/VerifyCommand.ts
@@ -940,7 +940,7 @@ function contextHelp(argv: string[]): string {
 // subcommands exec the engine with the repo's .expo-agents/verify/ profile. roundup
 // stays native here — it is expo policy (emoji conventions, branch scoping,
 // cost tables) the engine has not absorbed yet.
-const ENGINE_VERSION = process.env.VERIFY_ENGINE_VERSION || '0.11.11';
+const ENGINE_VERSION = process.env.VERIFY_ENGINE_VERSION || '0.11.12';
 
 async function delegateToEngine(engineArgs: string[]): Promise<never> {
   // The profile's home is .expo-agents/verify/ (engine 0.9.0); the engine itself


### PR DESCRIPTION
# Why

`et verify` showed no runs in flight and a week-old dispatch as the newest activity while several comment-triggered runs were in progress. Two causes:

- `verify status` listed only `verify.yml`, the `workflow_dispatch` runner. Runs from `verify-comment.yml` were invisible. It also reported the run-level conclusion, which the thin workflows' job-level `continue-on-error` pins to `success` even when the engine step failed.
- `et verify` pins the engine separately from the workflows (`ENGINE_VERSION` in `tools/src/commands/VerifyCommand.ts`) and had been left at 0.11.6.

# How

`@expo/verify` 0.11.11 lists the dispatch and comment workflows merged newest-first, drops gate-skipped runs, reports finished runs by their jobs' outcome, and hides the bot's own queued comment runs. 0.11.12 drops the deleted `agent-commands.yml` from that listing (see #49923) and tightens the dashboard's Recent header. This PR bumps the workflow fallbacks and `et verify`'s engine pin to 0.11.12. The `VERIFY_VERSION` repo variable is already on 0.11.12.

# Test Plan

Run `et verify` and confirm in-flight comment runs appear, and that a run whose engine step failed shows as `failure`.