### PR TITLE
[verify] Retire and delete agent-commands.yml; job-level concurrency for verify-comment.yml

### DIFF
--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -94,9 +94,13 @@
 #                            collection) — never placed in the agent's env.
 name: Agent commands
 
+# RETIRED from the comment path (2026-09-09): `verify-comment.yml` and the
+# @expo/verify engine own `/verify` and `@expo-bot …` comments now. The
+# issue_comment trigger is removed here so one comment starts one run; the
+# workflow_dispatch path stays as the rollback (`gh workflow run
+# agent-commands.yml -f target=N`) until this file is deleted in a
+# follow-up, per LLP 0001 P1c (one revert-sized commit).
 on:
-  issue_comment:
-    types: [created]
   # Quiet path. Dispatching from the Actions tab runs a verification that
   # posts NOTHING to the thread until the findings themselves — no eyes
   # reaction, no "started" comment, no failure notice. That matters on a

--- a/.github/workflows/verify-comment.yml
+++ b/.github/workflows/verify-comment.yml
@@ -3,10 +3,8 @@
 # gate, parse, ack/announce, the run, and the failure report all live in
 # `verify run` (engine LLP 0001; expo-sandbox-mcp LLP 0020).
 #
-# STAGED: lives beside agent-commands.yml, which still owns the comment
-# path until this one is proven live; both are gated on the same comment
-# shapes, so to avoid double runs the legacy workflow's issue_comment
-# trigger is removed in the same commit that promotes this one.
+# Owns the comment path since 2026-09-09; agent-commands.yml keeps only its
+# workflow_dispatch trigger as the rollback until it is deleted.
 name: verify (comment)
 run-name: "verify #${{ github.event.issue.number }} — ${{ github.event.comment.user.login }}"
 
@@ -19,12 +17,18 @@ permissions:
   issues: write
   pull-requests: read
 
-concurrency:
-  group: verify-target-${{ github.event.issue.number }}
-  cancel-in-progress: false
-
 jobs:
   verify:
+    # Job-level, not workflow-level: a workflow-level group is claimed at run
+    # creation, before the gate below runs, so every comment on the thread —
+    # including the bot's own triage and findings replies — counted as an
+    # arrival. With cancel-in-progress:false a group holds one waiting run and
+    # a third arrival evicts it, which cancelled waiting verifications (the
+    # 2026-08-20 incident, repeated on 2026-09-09 against the legacy job). A
+    # job-level group is only entered when the gate passes.
+    concurrency:
+      group: verify-target-${{ github.event.issue.number }}
+      cancel-in-progress: false
     # The LOOSE shape gate: command-shaped, from a maintainer-association
     # author, not the bot itself. Exact shapes, the authoritative
     # write-access check, and thread replies are the engine's comment


### PR DESCRIPTION
# Why

Since `verify-comment.yml` landed, every `/verify` or `@expo-bot …` comment has started two runs: the new thin workflow and the legacy `agent-commands.yml`. The new path is live on engine 0.11.11, so the monolith goes.

The double runs also exposed a concurrency trap. Both workflows share the group `verify-target-<n>` with `cancel-in-progress: false`. The new workflow's group was workflow-level, so it was claimed at run creation, before the gate. Every comment on the thread, including the bot's own triage and findings replies, counted as an arrival, and a third arrival evicts the waiting run. That cancelled the legacy job on every double run today (for example [run 34392072801](https://github.com/expo/expo/actions/runs/34392072801), evicted at 18:58:30 by the run that the 18:58:21 triage comment created). It would cancel a second maintainer `verify` on the same target the same way.

# How

Two commits, each revertable on its own:

1. `agent-commands.yml` loses its `issue_comment` trigger, and `verify-comment.yml` moves its concurrency block to the job. A job-level group is entered only when the gate passes, so bot comments and non-command comments no longer count as arrivals.
2. `agent-commands.yml` is deleted. Its `workflow_dispatch` path was redundant with `verify.yml`, which `et verify` already targets. Comments in the code-review workflows, `verify.yml`, `expo-bot-help.yml`, and `et verify` that named it as the owner of the verify/work comment shapes now name `verify-comment.yml`.

Rollback is a revert of this PR.

# Test Plan

Comment `@expo-bot verify` on an issue or PR. Exactly one run starts, under `verify (comment)`. Then comment `@expo-bot verify` again while it runs and confirm the second waits and starts after the first finishes, without being cancelled when the first posts its findings.