### PR TITLE
[ios][device] add 2026 iPhone models

### DIFF
--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Added iPhone 18 models. ([#49924](https://github.com/expo/expo/pull/49924) by [@fobos531](https://github.com/fobos531))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-device/ios/UIDevice.swift
+++ b/packages/expo-device/ios/UIDevice.swift
@@ -104,7 +104,7 @@ public extension UIDevice {
         return ExpoDeviceType(modelName: "iPhone 17 Pro Max", deviceYearClass: 2025)
       case "iPhone19,2":
         return ExpoDeviceType(modelName: "iPhone 18 Pro", deviceYearClass: 2026)
-      case "iPhone19,3", iPhone19,7":
+      case "iPhone19,3", "iPhone19,7":
         return ExpoDeviceType(modelName: "iPhone 18 Pro Max", deviceYearClass: 2026)
       case "iPhone18,3":
         return ExpoDeviceType(modelName: "iPhone 17", deviceYearClass: 2025)

--- a/packages/expo-device/ios/UIDevice.swift
+++ b/packages/expo-device/ios/UIDevice.swift
@@ -102,6 +102,10 @@ public extension UIDevice {
         return ExpoDeviceType(modelName: "iPhone 17 Pro", deviceYearClass: 2025)
       case "iPhone18,2":
         return ExpoDeviceType(modelName: "iPhone 17 Pro Max", deviceYearClass: 2025)
+      case "iPhone19,2":
+        return ExpoDeviceType(modelName: "iPhone 18 Pro", deviceYearClass: 2026)
+      case "iPhone19,3", iPhone19,7":
+        return ExpoDeviceType(modelName: "iPhone 18 Pro Max", deviceYearClass: 2026)
       case "iPhone18,3":
         return ExpoDeviceType(modelName: "iPhone 17", deviceYearClass: 2025)
       case "iPhone18,4":


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Adds 2026 iPhone models.


# How

<!--
How did you build this feature or fix this bug and why?
-->

<img width="1882" height="1284" alt="CleanShot 2026-09-09 at 21 27 24@2x" src="https://github.com/user-attachments/assets/cef6361e-312e-4f20-89a5-d681ced9d037" />

Identifiers are sourced from the official Xcode 27 RC archive and https://appledb.dev/device-selection/iPhone.html

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
