### PR TITLE
[docs] Take the pnpm version from the monorepo root

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -38,13 +38,6 @@
     "postinstall": "pnpm copy-latest && pnpm generate-static-resources && pnpm install-vale",
     "upstream-sync": "node --experimental-strip-types ./scripts/upstream-sync.ts"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "12.2.1",
-      "onFail": "warn"
-    }
-  },
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Take the pnpm version, which in this case applies to CI and is the root's pinned version from `pnpm/setup`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove `"devEngines"` from `docs/package.json`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

`pnpm install` should work locally without any warnings or errors with `"12.2.1"` version.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
