### PR TITLE
[docs] Remove the non EAS Observe crash reporting tools recommendation

### DIFF
--- a/docs/pages/eas/observe/errors.mdx
+++ b/docs/pages/eas/observe/errors.mdx
@@ -125,5 +125,3 @@ Error reporting is in preview, and the following are not available yet:
 
 - **Source maps for EAS Update**: errors from an app running an OTA update show the unsymbolicated stack trace.
 - **Native crash reporting**, including iOS symbolication, and more.
-
-For native crash reporting today, use a service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).

--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -93,7 +93,7 @@ Traditional development-time profiling tools show how your app performs on your 
 
 **JavaScript errors**: On SDK 57 and later, EAS Observe records JavaScript errors and shows them in the dashboard with symbolicated stack traces. This feature is in [preview](/more/release-statuses/#preview). See [Error reporting](/eas/observe/errors/) for setup and current limitations.
 
-**Native crash reporting**: EAS Observe does not capture native crashes yet. Until it does, use a crash reporting service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).
+**Native crash reporting**: EAS Observe does not capture native crashes yet.
 
 ## Frequently asked questions (FAQ)
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26158

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove the non EAS Observe crash reporting tools recommendation.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
