### PR TITLE
[ui][ios] Add `components` dateStyle to `Text` for calendar-unit countdowns

### DIFF
--- a/apps/native-component-list/src/screens/UI/TextScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/TextScreen.ios.tsx
@@ -108,6 +108,14 @@ export default function TextScreen() {
         <Section title="Date (style: relative)">
           <Text date={new Date(Date.now() + 300000)} dateStyle="relative" />
         </Section>
+        <Section title="Date (style: components, hours and minutes)">
+          <Text
+            date={new Date(Date.now() + 3960000)}
+            dateStyle="components"
+            componentsStyle="narrow"
+            componentsFields={['hour', 'minute']}
+          />
+        </Section>
         <Section title="Timer Interval (countdown)">
           <Text
             timerInterval={{ lower: new Date(), upper: new Date(Date.now() + 600000) }}

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/text.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/text.mdx
@@ -361,6 +361,29 @@ export default function DateTextExample() {
 
 </ComponentExample>
 
+### Countdown in calendar units
+
+Use the `components` date style to show the time until (or since) a date in calendar units instead of a running clock. `componentsFields` picks the units, so a countdown can leave out seconds, and `componentsStyle` picks how the units are named. This requires iOS/tvOS 18+ and falls back to the `relative` style on older versions.
+
+```tsx
+import { Host, Text } from '@expo/ui/swift-ui';
+
+export default function ComponentsDateExample() {
+  return (
+    <Host style={{ flex: 1 }}>
+      <Text
+        date={new Date(Date.now() + 3960000)}
+        dateStyle="components"
+        componentsStyle="narrow"
+        componentsFields={['hour', 'minute']}
+      />
+    </Host>
+  );
+}
+```
+
+The example above reads `1h 6m` and updates every minute. Set `countsDown={false}` to count up from a past date instead.
+
 ### Timer interval
 
 Use `timerInterval` to display a live countdown or count-up timer. This requires iOS/tvOS 16+.

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🎉 New features
 
+- [iOS] Added the `components` `dateStyle` to `Text`, with `componentsStyle` and `componentsFields`, so a `date` can be shown as a live countdown in calendar units such as `1h 6m` instead of `mm:ss`. ([#49929](https://github.com/expo/expo/pull/49929) by [@AlAdler](https://github.com/AlAdler))
 - [Android] Added the `enabled` and `colors` props to the Jetpack Compose `RadioButton` component. (by [@felipe-software](https://github.com/felipe-software))
 - [Android] Added the Jetpack Compose `DateRangePicker` and `DateRangePickerDialog` components. (by [@felipe-software](https://github.com/felipe-software))
 - [Android] Add `cornerRadius` support to dropdown menu. ([#49515](https://github.com/expo/expo/pull/49515) by [@aaronleopold](https://github.com/aaronleopold))

--- a/packages/expo-ui/ios/TextView.swift
+++ b/packages/expo-ui/ios/TextView.swift
@@ -4,15 +4,45 @@ import SwiftUI
 import ExpoModulesCore
 
 public enum TextDateStyle: String, Enumerable {
-  case timer, relative, offset, date, time
+  case timer, relative, offset, date, time, components
 
   func toSwiftUI() -> SwiftUI.Text.DateStyle {
     switch self {
     case .timer: return .timer
-    case .relative: return .relative
+    case .relative, .components: return .relative
     case .offset: return .offset
     case .date: return .date
     case .time: return .time
+    }
+  }
+}
+
+public enum TextComponentsStyle: String, Enumerable {
+  case spellOut, wide, abbreviated, condensedAbbreviated, narrow
+
+  func toSwiftUI() -> Date.ComponentsFormatStyle.Style {
+    switch self {
+    case .spellOut: return .spellOut
+    case .wide: return .wide
+    case .abbreviated: return .abbreviated
+    case .condensedAbbreviated: return .condensedAbbreviated
+    case .narrow: return .narrow
+    }
+  }
+}
+
+public enum TextComponentsField: String, Enumerable {
+  case year, month, week, day, hour, minute, second
+
+  func toSwiftUI() -> Date.ComponentsFormatStyle.Field {
+    switch self {
+    case .year: return .year
+    case .month: return .month
+    case .week: return .week
+    case .day: return .day
+    case .hour: return .hour
+    case .minute: return .minute
+    case .second: return .second
     }
   }
 }
@@ -22,6 +52,8 @@ public final class TextViewProps: UIBaseViewProps {
   @Field public var markdownEnabled: Bool = false
   @Field public var date: Date?
   @Field public var dateStyle: TextDateStyle?
+  @Field public var componentsStyle: TextComponentsStyle?
+  @Field public var componentsFields: [TextComponentsField]?
   @Field public var timerInterval: ClosedRangeDate?
   @Field public var countsDown: Bool?
   @Field public var pauseTime: Date?
@@ -54,6 +86,17 @@ public struct TextView: ExpoSwiftUI.View {
         timerInterval: ClosedRange(uncheckedBounds: (lower: lower, upper: upper)),
         pauseTime: props.pauseTime,
         countsDown: props.countsDown ?? true
+      )
+    } else if #available(iOS 18.0, tvOS 18.0, *), let date = props.date, props.dateStyle == .components {
+      let range: TimeDataSource<Range<Date>> = props.countsDown ?? true
+        ? .dateRange(endingAt: date)
+        : .dateRange(startingAt: date)
+      text = Text(
+        range,
+        format: .components(
+          style: props.componentsStyle?.toSwiftUI() ?? .abbreviated,
+          fields: props.componentsFields.map { Set($0.map { $0.toSwiftUI() }) }
+        )
       )
     } else if let date = props.date {
       text = Text(date, style: props.dateStyle?.toSwiftUI() ?? .date)

--- a/packages/expo-ui/src/swift-ui/Text/index.tsx
+++ b/packages/expo-ui/src/swift-ui/Text/index.tsx
@@ -7,7 +7,22 @@ import { type ClosedRangeDate, type CommonViewModifierProps } from '../types';
 /**
  * The style used to format a date in a SwiftUI `Text` view.
  */
-export type TextDateStyle = 'timer' | 'relative' | 'offset' | 'date' | 'time';
+export type TextDateStyle = 'timer' | 'relative' | 'offset' | 'date' | 'time' | 'components';
+
+/**
+ * The unit style of a `components` date, mirroring `Date.ComponentsFormatStyle.Style`.
+ */
+export type TextComponentsStyle =
+  | 'spellOut'
+  | 'wide'
+  | 'abbreviated'
+  | 'condensedAbbreviated'
+  | 'narrow';
+
+/**
+ * A calendar unit a `components` date may be expressed in, mirroring `Date.ComponentsFormatStyle.Field`.
+ */
+export type TextComponentsField = 'year' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second';
 
 export interface TextProps extends CommonViewModifierProps {
   /**
@@ -27,9 +42,30 @@ export interface TextProps extends CommonViewModifierProps {
 
   /**
    * The style used to format the `date` prop.
+   *
+   * `components` shows the time between now and `date` in calendar units, such as `1 hr, 6 min`,
+   * and updates live. It counts down to a future `date`, or up from a past one when `countsDown`
+   * is `false`. Below iOS 18 it falls back to `relative`.
    * @default 'date'
    */
   dateStyle?: TextDateStyle;
+
+  /**
+   * How a `components` date names its units, for example `1 hr, 6 min` for `abbreviated`
+   * or `1h 6m` for `narrow`.
+   * @default 'abbreviated'
+   * @platform ios 18.0+
+   * @platform tvos 18.0+
+   */
+  componentsStyle?: TextComponentsStyle;
+
+  /**
+   * The calendar units a `components` date may use. Pass `['hour', 'minute']` for a countdown
+   * without seconds. Defaults to the units SwiftUI picks for the interval.
+   * @platform ios 18.0+
+   * @platform tvos 18.0+
+   */
+  componentsFields?: TextComponentsField[];
 
   /**
    * A time interval to display as a live-updating timer.
@@ -60,6 +96,8 @@ type NativeTextProps = CommonViewModifierProps & {
   markdownEnabled?: boolean;
   date?: number;
   dateStyle?: TextDateStyle;
+  componentsStyle?: TextComponentsStyle;
+  componentsFields?: TextComponentsField[];
   timerInterval?: { lower: number; upper: number };
   countsDown?: boolean;
   pauseTime?: number;


### PR DESCRIPTION
# Why

`Text` can show a live countdown today only as a clock: `dateStyle="timer"` and `timerInterval` both render `mm:ss`, and `dateStyle="relative"` always includes seconds (`4 min, 59 sec`). Live Activities and widgets often want the compact minute-level form Apple uses in its own activities, such as `5m` or `1h 6m`, and SwiftUI has no way to drop the seconds from the timer styles. Since iOS 18 this is possible with `Text(_:format:)` over a `TimeDataSource`, but expo-ui does not expose it.

# How

Adds a `components` value to `dateStyle`, rendered on iOS/tvOS 18+ as:

```swift
Text(.dateRange(endingAt: date), format: .components(style: componentsStyle, fields: componentsFields))
```

- `dateRange(endingAt:)` is `min(date, now)..<date`, so the value counts down to a future date and never shows a sign. When the existing `countsDown` prop is `false`, `dateRange(startingAt:)` counts up from a past date instead.
- Two new props mirror `Date.ComponentsFormatStyle`: `componentsStyle` (`spellOut` | `wide` | `abbreviated` | `condensedAbbreviated` | `narrow`, default `abbreviated`) and `componentsFields` (any of `year`, `month`, `week`, `day`, `hour`, `minute`, `second`; default lets SwiftUI choose).
- Below iOS 18 the style falls back to `relative`, so the text still renders.

`Date.ComponentsFormatStyle` is a system `DiscreteFormatStyle`, so the text keeps updating on its own in widgets and Live Activities, where a custom format style would not.

Also adds a docs section, a native-component-list example, and a changelog entry.

# Test Plan

- Ran the same Swift change as a patch-package patch on `@expo/ui` 56.0.26 inside a Live Activity (Lock Screen banner, Dynamic Island, and Apple Watch Smart Stack) on iOS 26. With `componentsStyle="narrow"` and `componentsFields={['hour', 'minute']}` it renders `38m`, then `1h 6m` for longer intervals, and ticks each minute without any push.
- Verified the formatter output for each style on macOS with `Range<Date>.formatted(.components(style:fields:))`: `1h 6m` / `1hr 6min` / `1 hr, 6 min` / `1 hour, 6 minutes`; the last minute reads `0m`.
- Type-checked the SwiftUI call against the iOS 26.5 SDK. I could not run `pnpm build` or `et gdad` in a sparse checkout, so the API docs data still needs regenerating.
- Reviewer: open `TextScreen` in native-component-list on an iOS 18+ device and check the "Date (style: components, hours and minutes)" section reads `1h 6m` and drops to `1h 5m` after a minute.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)