### PR TITLE
[router] Fix unchecked index access in usePreventRemove test

### DIFF
--- a/packages/expo-router/src/react-navigation/core/__tests__/usePreventRemove.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/usePreventRemove.test.ios.tsx
@@ -218,7 +218,7 @@ test.each([
 
   expect(ref.current?.getRootState().routes.map((route) => route.name)).toEqual(['foo', 'bar']);
   expect(onPreventRemove).toHaveBeenCalledTimes(1);
-  expect(onPreventRemove.mock.calls[0][0].data.action).toBe(action);
+  expect(onPreventRemove.mock.calls[0]?.[0].data.action).toBe(action);
 
   act(() => {
     if (clearPrevention) {


### PR DESCRIPTION
<!-- disable:changelog-checks -->

# Why

Docs CI is red on `main`. The `Docs Website` run fails at "📝 Regenerate `unversioned` data for Docs":
https://github.com/expo/expo/actions/runs/34403420001/job/102640554037

`packages/expo-router/tsconfig.json` uses `"include": ["./src"]`, and `__tests__/` lives under `src/`, so TypeDoc compiles the test files along with the package. The base config sets `noUncheckedIndexedAccess: true`, so the test block added in #49908 does not compile:

packages/expo-router/src/react-navigation/core/tests/usePreventRemove.test.ios.tsx(221,10): error TS2532: Object is possibly 'undefined'.

TypeDoc returns no project on a compile error, so all 8 `expo-router` entries in `PACKAGES_MAPPING` fail and `generate-docs-api-data` exits 1. The step is gated on a cache miss, which is why it only surfaced when #49893 changed a package source file.

The same error also failed `sdk.yml` "Check changed packages" on `3d846041b1`.

# How

Optional-chain the mock call lookup: `onPreventRemove.mock.calls[0]?.[0]`.

# Test Plan

`tsc -b packages/expo-router/tsconfig.all.json --force` should exit cleanly.

`et generate-docs-api-data -p expo-router` should be successful.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
