### PR TITLE
[verify] Bump verify engine to 0.11.13

### DIFF
--- a/.github/workflows/verify-comment.yml
+++ b/.github/workflows/verify-comment.yml
@@ -55,7 +55,7 @@ jobs:
     # engine exit 1 behind a green run (run 32919110451).
     continue-on-error: true
     env:
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.12' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.13' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,7 +60,7 @@ jobs:
       # Same version feeds the guard and the run, so the engine that clears
       # the profile is the engine that reads it. Override with the repo
       # variable VERIFY_VERSION; the fallback pins the tested release.
-      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.12' }}
+      VERIFY_VERSION: ${{ vars.VERIFY_VERSION || '0.11.13' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/tools/src/commands/VerifyCommand.ts
+++ b/tools/src/commands/VerifyCommand.ts
@@ -940,7 +940,7 @@ function contextHelp(argv: string[]): string {
 // subcommands exec the engine with the repo's .expo-agents/verify/ profile. roundup
 // stays native here — it is expo policy (emoji conventions, branch scoping,
 // cost tables) the engine has not absorbed yet.
-const ENGINE_VERSION = process.env.VERIFY_ENGINE_VERSION || '0.11.12';
+const ENGINE_VERSION = process.env.VERIFY_ENGINE_VERSION || '0.11.13';
 
 async function delegateToEngine(engineArgs: string[]): Promise<never> {
   // The profile's home is .expo-agents/verify/ (engine 0.9.0); the engine itself


### PR DESCRIPTION
# Why

The `/verify --fix` run on #49843 pushed a verified fix but [refused to open the pull request](https://github.com/expo/expo/issues/49843#issuecomment-5590740886), naming #49696 and #48921 as likely duplicates. Neither is related. The fix touches only `packages/@expo/cli/src/index.ts` (plus its changelog), and both PRs register new CLI commands in that entry point. The guard's rule, "every non-changelog file we touch is already touched by an open PR", is satisfied trivially by a single hub file.

# How

`@expo/verify` 0.11.13 keeps the file overlap as a shortlist and adds a judge: one tool-less, schema-bound model call per candidate (Haiku by default) reads the shared-file patches on both sides and says whether the candidate makes the same change. A confident duplicate still refuses; otherwise the PR opens with the candidates listed and the judge's one-line reason. Without a judgment the fallback is a symmetric file-set match, the shape of the original #48747/#49055 incident. The decision and its inputs are written to `.verify-out/duplicate-judge.json`.

Smoke-tested on the real #49843 patches: both flagged PRs judged distinct at 0.98 and 0.99; the fix against itself judged a duplicate at 0.95. About ten seconds and one cent per call.

This PR bumps the workflow fallbacks and `et verify`'s engine pin. The `VERIFY_VERSION` repo variable is already on 0.11.13. The profile needs no change; `duplicateJudge { enabled, model, threshold }` is optional.

# Test Plan

Re-run `/verify --fix` on #49843 (or any issue whose fix lands in an entry-point file) and confirm the pull request opens, with the overlapping PRs listed in its body as "judged distinct" with a reason.