### PR TITLE
[ui][ios] Add `NavigationStack` and `Toolbar` components

### DIFF
--- a/apps/native-component-list/src/screens/UI/NavigationStackScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/NavigationStackScreen.ios.tsx
@@ -1,0 +1,277 @@
+import {
+  BottomSheet,
+  Button,
+  Host,
+  HStack,
+  Image,
+  Label,
+  List,
+  NavigationStack,
+  Section,
+  Spacer,
+  Text,
+  Toolbar,
+  VStack,
+} from '@expo/ui/swift-ui';
+import {
+  buttonStyle,
+  font,
+  foregroundStyle,
+  navigationTitle,
+  padding,
+  presentationDetents,
+} from '@expo/ui/swift-ui/modifiers';
+import * as React from 'react';
+
+const HABITATS = [
+  {
+    title: 'Woodland and gardens',
+    birds: [
+      {
+        name: 'Eurasian Wren',
+        latin: 'Troglodytes troglodytes',
+        systemImage: 'bird.fill',
+        color: '#8E6E53',
+        description:
+          'A very small brown bird with a short tail it often holds upright. Its song is far louder than its size suggests.',
+      },
+      {
+        name: 'European Robin',
+        latin: 'Erithacus rubecula',
+        systemImage: 'bird.fill',
+        color: '#E4572E',
+        description:
+          'Orange breast, upright stance, and a habit of following gardeners for turned soil. It holds a territory all year.',
+      },
+      {
+        name: 'Great Tit',
+        latin: 'Parus major',
+        systemImage: 'bird.fill',
+        color: '#F2C14E',
+        description:
+          'Black head with white cheeks and a black stripe down a yellow belly. A bold and adaptable visitor to feeders.',
+      },
+      {
+        name: 'Eurasian Blackbird',
+        latin: 'Turdus merula',
+        systemImage: 'bird.fill',
+        color: '#2F2F33',
+        description:
+          'The male is all black with a bright orange bill and eye ring. Its fluting song carries at dusk.',
+      },
+      {
+        name: 'Goldcrest',
+        latin: 'Regulus regulus',
+        systemImage: 'leaf.fill',
+        color: '#5C9E3F',
+        description:
+          'Europe’s smallest bird, weighing about as much as a twenty pence coin. It favours conifers.',
+      },
+    ],
+  },
+  {
+    title: 'Farmland and open country',
+    birds: [
+      {
+        name: 'Barn Swallow',
+        latin: 'Hirundo rustica',
+        systemImage: 'bird',
+        color: '#3A6EA5',
+        description:
+          'Long tail streamers and a dark blue back. It feeds on the wing and nests in barns and outbuildings.',
+      },
+      {
+        name: 'Eurasian Skylark',
+        latin: 'Alauda arvensis',
+        systemImage: 'sun.max.fill',
+        color: '#C9A227',
+        description:
+          'Sings while hovering high overhead, often for minutes at a time, then drops back to the field.',
+      },
+      {
+        name: 'Yellowhammer',
+        latin: 'Emberiza citrinella',
+        systemImage: 'bird.fill',
+        color: '#E8C547',
+        description:
+          'A bright yellow head and a song traditionally written out as “a little bit of bread and no cheese”.',
+      },
+      {
+        name: 'Common Kestrel',
+        latin: 'Falco tinnunculus',
+        systemImage: 'wind',
+        color: '#A0522D',
+        description:
+          'Hovers with its head held perfectly still while it scans the verge below for voles.',
+      },
+    ],
+  },
+  {
+    title: 'Coast and wetland',
+    birds: [
+      {
+        name: 'Common Kingfisher',
+        latin: 'Alcedo atthis',
+        systemImage: 'drop.fill',
+        color: '#2FA8CC',
+        description:
+          'Electric blue above and orange below. Usually seen as a flash of colour low over the water.',
+      },
+      {
+        name: 'Grey Heron',
+        latin: 'Ardea cinerea',
+        systemImage: 'water.waves',
+        color: '#7D8A99',
+        description:
+          'Stands motionless at the water’s edge for long spells, then strikes at fish with its dagger bill.',
+      },
+      {
+        name: 'Eurasian Oystercatcher',
+        latin: 'Haematopus ostralegus',
+        systemImage: 'bird.fill',
+        color: '#D1495B',
+        description:
+          'Pied plumage and a long orange bill used to prise open shellfish. Noisy in flight.',
+      },
+      {
+        name: 'Sandwich Tern',
+        latin: 'Thalasseus sandvicensis',
+        systemImage: 'bird',
+        color: '#4C6EF5',
+        description:
+          'A pale tern with a shaggy black cap and a yellow bill tip. It plunge dives for small fish.',
+      },
+    ],
+  },
+] as const;
+
+type Bird = (typeof HABITATS)[number]['birds'][number];
+type Selection = Bird & { habitat: string };
+
+export default function NavigationStackScreen() {
+  const [selected, setSelected] = React.useState<Selection | null>(null);
+  const [isPresented, setIsPresented] = React.useState(false);
+  const [descending, setDescending] = React.useState(false);
+
+  const sort = (birds: readonly Bird[]) =>
+    [...birds].sort((a, b) =>
+      descending ? b.name.localeCompare(a.name) : a.name.localeCompare(b.name)
+    );
+
+  return (
+    <Host style={{ flex: 1 }}>
+      <NavigationStack>
+        {/* The title and the sort button both belong to the bar this stack provides. */}
+        <Toolbar modifiers={[navigationTitle('Birds')]}>
+          <BottomSheet
+            isPresented={isPresented}
+            onIsPresentedChange={setIsPresented}
+            // Cleared only once the sheet is fully gone, so its content does not
+            // blank out mid dismiss.
+            onDismiss={() => setSelected(null)}
+            anchor={
+              <List>
+                {HABITATS.map((habitat) => (
+                  <Section key={habitat.title} title={habitat.title}>
+                    {sort(habitat.birds).map((bird) => (
+                      <Button
+                        key={bird.name}
+                        modifiers={[buttonStyle('plain')]}
+                        onPress={() => {
+                          setSelected({ ...bird, habitat: habitat.title });
+                          setIsPresented(true);
+                        }}>
+                        <HStack spacing={12}>
+                          <Label
+                            icon={
+                              <Image
+                                systemName={bird.systemImage}
+                                size={22}
+                                modifiers={[foregroundStyle(bird.color)]}
+                              />
+                            }>
+                            <VStack alignment="leading" spacing={2}>
+                              <Text>{bird.name}</Text>
+                              <Text
+                                modifiers={[
+                                  font({ textStyle: 'caption' }),
+                                  foregroundStyle('secondaryLabel'),
+                                ]}>
+                                {bird.latin}
+                              </Text>
+                            </VStack>
+                          </Label>
+                          <Spacer />
+                          <Image
+                            systemName="chevron.right"
+                            size={13}
+                            modifiers={[foregroundStyle('tertiaryLabel')]}
+                          />
+                        </HStack>
+                      </Button>
+                    ))}
+                  </Section>
+                ))}
+              </List>
+            }>
+            {/* A sheet has no navigation bar of its own. The stack adds one, which gives the
+                `close` button somewhere to sit. iOS 26 draws that button as an xmark. */}
+            <NavigationStack modifiers={[presentationDetents(['medium', 'large'])]}>
+              <Toolbar modifiers={[navigationTitle(selected?.name ?? '')]}>
+                <VStack alignment="leading" spacing={16} modifiers={[padding({ all: 20 })]}>
+                  <HStack spacing={12}>
+                    <Image
+                      systemName={selected?.systemImage ?? 'bird.fill'}
+                      size={34}
+                      modifiers={[foregroundStyle(selected?.color ?? 'label')]}
+                    />
+                    <VStack alignment="leading" spacing={2}>
+                      <Text modifiers={[font({ textStyle: 'headline' })]}>
+                        {selected?.name ?? ''}
+                      </Text>
+                      <Text
+                        modifiers={[
+                          font({ textStyle: 'subheadline' }),
+                          foregroundStyle('secondaryLabel'),
+                        ]}>
+                        {selected?.latin ?? ''}
+                      </Text>
+                    </VStack>
+                  </HStack>
+
+                  <Label
+                    title={selected?.habitat ?? ''}
+                    systemImage="mappin.and.ellipse"
+                    modifiers={[
+                      font({ textStyle: 'subheadline' }),
+                      foregroundStyle('secondaryLabel'),
+                    ]}
+                  />
+
+                  <Text>{selected?.description ?? ''}</Text>
+                  <Spacer />
+                </VStack>
+
+                <Toolbar.Content>
+                  <Button role="close" onPress={() => setIsPresented(false)} />
+                </Toolbar.Content>
+              </Toolbar>
+            </NavigationStack>
+          </BottomSheet>
+
+          <Toolbar.Content>
+            <Button
+              systemImage="arrow.up.arrow.down"
+              label={descending ? 'Sort Z to A' : 'Sort A to Z'}
+              onPress={() => setDescending((value) => !value)}
+            />
+          </Toolbar.Content>
+        </Toolbar>
+      </NavigationStack>
+    </Host>
+  );
+}
+
+NavigationStackScreen.navigationOptions = {
+  title: 'NavigationStack',
+};

--- a/apps/native-component-list/src/screens/UI/UIScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/UIScreen.ios.tsx
@@ -147,6 +147,14 @@ export const UIScreens = [
     },
   },
   {
+    name: 'NavigationStack component',
+    route: 'ui/navigationstack',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./NavigationStackScreen'));
+    },
+  },
+  {
     name: 'Menu component',
     route: 'ui/menu',
     options: {},

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [iOS] Taught the `presentationBackground` modifier to paint with any `ShapeStyle`, matching SwiftUI, so a sheet can be backed by a material, a gradient or a hierarchical style instead of only a color. iOS 26 renders a material as a flat color rather than a translucent blur. ([#49767](https://github.com/expo/expo/pull/49767) by [@Den1Marshall](https://github.com/Den1Marshall))
 - [iOS] Added the `scrollClipDisabled` modifier, which lets content that draws outside a scrollable view's bounds, such as a shadow or a scaled-up card, stay visible instead of being clipped. ([#49780](https://github.com/expo/expo/pull/49780) by [@Den1Marshall](https://github.com/Den1Marshall))
 - [iOS] Taught the `tint`, `border`, `strokeBorder` and `containerBackground` modifiers to paint with any `ShapeStyle`, matching SwiftUI, where all four take a `ShapeStyle` rather than a color. The `color` parameter of `border` and `strokeBorder` is deprecated in favor of `content`, the name SwiftUI gives it. ([#49838](https://github.com/expo/expo/pull/49838) by [@Den1Marshall](https://github.com/Den1Marshall))
+- [iOS] Added the `NavigationStack` and `Toolbar` components, the `navigationTitle` modifier, and the `close` button role. ([#49940](https://github.com/expo/expo/pull/49940) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-ui/ios/Button/Button.swift
+++ b/packages/expo-ui/ios/Button/Button.swift
@@ -22,6 +22,19 @@ public struct Button: ExpoSwiftUI.View {
         }
       }
     } else {
+      labelLessButton
+    }
+  }
+
+  @ViewBuilder
+  private var labelLessButton: some View {
+    if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *),
+      props.children?.isEmpty ?? true,
+      let role = props.role?.toNativeRole() {
+      SwiftUI.Button(role: role) {
+        props.onButtonPress()
+      }
+    } else {
       SwiftUI.Button(role: props.role?.toNativeRole(), action: {
         props.onButtonPress()
       }) {

--- a/packages/expo-ui/ios/Button/ButtonProps.swift
+++ b/packages/expo-ui/ios/Button/ButtonProps.swift
@@ -7,6 +7,7 @@ public enum ButtonRole: String, Enumerable {
   case `default`
   case destructive
   case cancel
+  case close
 
   public func toNativeRole() -> SwiftUI.ButtonRole? {
     switch self {
@@ -16,6 +17,11 @@ public enum ButtonRole: String, Enumerable {
       return SwiftUI.ButtonRole.destructive
     case .cancel:
       return SwiftUI.ButtonRole.cancel
+    case .close:
+      if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *) {
+        return SwiftUI.ButtonRole.close
+      }
+      return nil
     }
   }
 }

--- a/packages/expo-ui/ios/ExpoUIModule.swift
+++ b/packages/expo-ui/ios/ExpoUIModule.swift
@@ -156,6 +156,9 @@ public final class ExpoUIModule: Module {
 
     ExpoUIView(MenuView.self)
 
+    ExpoUIView(NavigationStackView.self)
+    ExpoUIView(ToolbarView.self)
+
     ExpoUIView(FormView.self)
     ExpoUIView(GaugeView.self)
     ExpoUIView(GroupView.self)

--- a/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
+++ b/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
@@ -1800,6 +1800,19 @@ internal struct TextFieldStyleModifier: ViewModifier, Record {
   }
 }
 
+internal struct NavigationTitleModifier: ViewModifier, Record {
+  @Field var title: String?
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if let title {
+      content.navigationTitle(title)
+    } else {
+      content
+    }
+  }
+}
+
 // MARK: - Built-in Modifier Registration
 
 // swiftlint:disable:next no_grouping_extension
@@ -1970,6 +1983,10 @@ extension ViewModifierRegistry {
 
     register("hueRotation") { params, appContext, _ in
       return try HueRotationModifier(from: params, appContext: appContext)
+    }
+
+    register("navigationTitle") { params, appContext, _ in
+      return try NavigationTitleModifier(from: params, appContext: appContext)
     }
 
     register("accessibilityLabel") { params, appContext, _ in

--- a/packages/expo-ui/ios/NavigationStackView.swift
+++ b/packages/expo-ui/ios/NavigationStackView.swift
@@ -1,0 +1,20 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import SwiftUI
+import ExpoModulesCore
+
+internal final class NavigationStackViewProps: UIBaseViewProps {}
+
+internal struct NavigationStackView: ExpoSwiftUI.View {
+  @ObservedObject var props: NavigationStackViewProps
+
+  init(props: NavigationStackViewProps) {
+    self.props = props
+  }
+
+  var body: some View {
+    NavigationStack {
+      Children()
+    }
+  }
+}

--- a/packages/expo-ui/ios/ToolbarView.swift
+++ b/packages/expo-ui/ios/ToolbarView.swift
@@ -1,0 +1,33 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import SwiftUI
+import ExpoModulesCore
+
+internal final class ToolbarViewProps: UIBaseViewProps {}
+
+internal struct ToolbarView: ExpoSwiftUI.View {
+  @ObservedObject var props: ToolbarViewProps
+
+  init(props: ToolbarViewProps) {
+    self.props = props
+  }
+
+  var body: some View {
+    if let content = props.children?.slot("content") {
+      baseContent
+        .toolbar {
+          content
+        }
+    } else {
+      baseContent
+    }
+  }
+
+  @ViewBuilder
+  private var baseContent: some View {
+    ForEach(props.children?.withoutSlots() ?? [], id: \.id) { child in
+      let view: any View = child.childView
+      AnyView(view)
+    }
+  }
+}

--- a/packages/expo-ui/src/swift-ui/Button/index.tsx
+++ b/packages/expo-ui/src/swift-ui/Button/index.tsx
@@ -10,8 +10,10 @@ import { type CommonViewModifierProps } from '../types';
  * - `default` - The default button role.
  * - `cancel` - A button that cancels the current operation.
  * - `destructive` - A button that deletes data or performs a destructive action.
+ * - `close` - A button that closes the view it is presented in. Given no `label` and no children,
+ *   the system draws it as an xmark.
  */
-export type ButtonRole = 'default' | 'cancel' | 'destructive';
+export type ButtonRole = 'default' | 'cancel' | 'destructive' | 'close';
 
 export interface ButtonProps extends CommonViewModifierProps {
   /**

--- a/packages/expo-ui/src/swift-ui/NavigationStack/index.tsx
+++ b/packages/expo-ui/src/swift-ui/NavigationStack/index.tsx
@@ -1,0 +1,32 @@
+import { requireNativeView } from 'expo';
+
+import { createViewModifierEventListener } from '../modifiers/utils';
+import { type CommonViewModifierProps } from '../types';
+
+export interface NavigationStackProps extends CommonViewModifierProps {
+  /**
+   * The root view of the stack. It is displayed inside a navigation bar.
+   */
+  children: React.ReactNode;
+}
+
+const NavigationStackNativeView: React.ComponentType<NavigationStackProps> = requireNativeView(
+  'ExpoUI',
+  'NavigationStackView'
+);
+
+/**
+ * A view that displays a root view and enables you to present additional views over the root view.
+ *
+ * @platform ios
+ */
+export function NavigationStack(props: NavigationStackProps) {
+  const { modifiers, ...restProps } = props;
+  return (
+    <NavigationStackNativeView
+      modifiers={modifiers}
+      {...(modifiers ? createViewModifierEventListener(modifiers) : undefined)}
+      {...restProps}
+    />
+  );
+}

--- a/packages/expo-ui/src/swift-ui/Toolbar/index.tsx
+++ b/packages/expo-ui/src/swift-ui/Toolbar/index.tsx
@@ -1,0 +1,64 @@
+import { requireNativeView } from 'expo';
+
+import { Slot } from '../SlotView';
+import { createViewModifierEventListener } from '../modifiers/utils';
+import { type CommonViewModifierProps } from '../types';
+
+export interface ToolbarProps extends CommonViewModifierProps {
+  /**
+   * The view the toolbar belongs to, together with the `Toolbar.Content` that fills it.
+   */
+  children: React.ReactNode;
+}
+
+export interface ToolbarContentProps {
+  /**
+   * The items to place in the toolbar.
+   */
+  children: React.ReactNode;
+}
+
+const ToolbarNativeView: React.ComponentType<ToolbarProps> = requireNativeView(
+  'ExpoUI',
+  'ToolbarView'
+);
+
+/**
+ * The items placed in the toolbar of the view `Toolbar` wraps.
+ */
+function ToolbarContent(props: ToolbarContentProps) {
+  return <Slot name="content">{props.children}</Slot>;
+}
+
+/**
+ * Adds a toolbar to the view it wraps, matching SwiftUI's `toolbar(content:)`.
+ *
+ * @example
+ * ```tsx
+ * <NavigationStack>
+ *   <Toolbar>
+ *     <Text>Bird description</Text>
+ *     <Toolbar.Content>
+ *       <Button role="close" onPress={() => setIsPresented(false)} />
+ *     </Toolbar.Content>
+ *   </Toolbar>
+ * </NavigationStack>
+ * ```
+ *
+ * @platform ios
+ */
+function ToolbarComponent(props: ToolbarProps) {
+  const { modifiers, children, ...restProps } = props;
+  return (
+    <ToolbarNativeView
+      modifiers={modifiers}
+      {...(modifiers ? createViewModifierEventListener(modifiers) : undefined)}
+      {...restProps}>
+      {children}
+    </ToolbarNativeView>
+  );
+}
+
+const Toolbar = Object.assign(ToolbarComponent, { Content: ToolbarContent });
+
+export { Toolbar };

--- a/packages/expo-ui/src/swift-ui/index.tsx
+++ b/packages/expo-ui/src/swift-ui/index.tsx
@@ -25,6 +25,7 @@ export * from './ZStack';
 export * from './Group';
 export * from './List';
 export * from './Menu';
+export * from './NavigationStack';
 export * from './Picker';
 export * from './ProgressView';
 export * from './Section';
@@ -38,6 +39,7 @@ export { useNativeState } from '../State';
 export { withAnimation, type WithAnimationCompletionCriteria } from './withAnimation';
 export * from './SyncToggle';
 export * from './TabView';
+export * from './Toolbar';
 export * from './Toggle';
 export {
   TextField,

--- a/packages/expo-ui/src/swift-ui/modifiers/index.ts
+++ b/packages/expo-ui/src/swift-ui/modifiers/index.ts
@@ -1687,6 +1687,13 @@ export const resizable = (
   resizingMode?: 'stretch' | 'tile'
 ) => createModifier('resizable', { ...capInsets, resizingMode });
 
+/**
+ * Configures the view's title for purposes of navigation, using a string.
+ * @param title - The title to display.
+ * @see Official [SwiftUI documentation](https://developer.apple.com/documentation/swiftui/view/navigationtitle(_:)).
+ */
+export const navigationTitle = (title: string) => createModifier('navigationTitle', { title });
+
 // =============================================================================
 // Type Definitions
 // =============================================================================
@@ -1830,7 +1837,8 @@ export type BuiltInModifier =
   | ReturnType<typeof widgetAccentedRenderingMode>
   | ReturnType<typeof widgetURL>
   | ReturnType<typeof activityBackgroundTint>
-  | ReturnType<typeof containerBackground>;
+  | ReturnType<typeof containerBackground>
+  | ReturnType<typeof navigationTitle>;
 
 /**
  * Main ViewModifier type that supports both built-in and 3rd party modifiers.


### PR DESCRIPTION

# Why

Adds SwiftUI [NavigationStack](https://developer.apple.com/documentation/swiftui/navigationstack) and [Toolbar](https://developer.apple.com/documentation/swiftui/view/toolbar(content:)) to `@expo/ui/swift-ui`.

This would help create individual screen in BottomSheet. The toolbar API is quite powerful and auto adapts to foldable (iphone duo). XCode 27.1 is still not released which supports the duo simulator. Would've been great to test there!


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

For toolbar it is following the Overlay component API. Docs is still pending, it will be done in a follow up PR.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Added an example screen in Expo UI.

https://github.com/user-attachments/assets/c69fe393-07ad-406b-b8d1-dabf63bad1e4


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
