### PR TITLE
[expo-image][Android] Fix prefetch settling its promise twice on connectivity restore

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed `prefetch` crashing with `PromiseAlreadySettledException` when Glide restarts a failed request after connectivity is restored, resolving the already-settled promise a second time. ([#49942](https://github.com/expo/expo/issues/49942) by [@riorafe](https://github.com/riorafe))
+- [Android] Fixed `prefetch` crashing with `PromiseAlreadySettledException` when Glide restarts a failed request after connectivity is restored, resolving the already-settled promise a second time. ([#49942](https://github.com/expo/expo/issues/49942), [#49944](https://github.com/expo/expo/pull/49944) by [@riorafe](https://github.com/riorafe))
 - [Android] Fixed a URL staying permanently broken after the server answered an image request with `200 OK` and a non-image body, such as an HTML error page. ([#48442](https://github.com/expo/expo/issues/48442) by [@julian-dueck](https://github.com/julian-dueck), [#48456](https://github.com/expo/expo/pull/48456) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [web] Fixed Expo Image's internal `dataSet` marker being overwritten by a user-provided `dataSet`. ([#48821](https://github.com/expo/expo/pull/48821) by [@Brentlok](https://github.com/Brentlok))
 - [iOS] Fixed `generateThumbhashAsync` crashing on images with extreme aspect ratios. ([#47189](https://github.com/expo/expo/issues/47189) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `prefetch` crashing with `PromiseAlreadySettledException` when Glide restarts a failed request after connectivity is restored, resolving the already-settled promise a second time. ([#49942](https://github.com/expo/expo/issues/49942) by [@riorafe](https://github.com/riorafe))
 - [Android] Fixed a URL staying permanently broken after the server answered an image request with `200 OK` and a non-image body, such as an HTML error page. ([#48442](https://github.com/expo/expo/issues/48442) by [@julian-dueck](https://github.com/julian-dueck), [#48456](https://github.com/expo/expo/pull/48456) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [web] Fixed Expo Image's internal `dataSet` marker being overwritten by a user-provided `dataSet`. ([#48821](https://github.com/expo/expo/pull/48821) by [@Brentlok](https://github.com/Brentlok))
 - [iOS] Fixed `generateThumbhashAsync` crashing on images with extreme aspect ratios. ([#47189](https://github.com/expo/expo/issues/47189) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -75,7 +75,7 @@ class ExpoImageModule : Module() {
       val context = appContext.reactContext ?: return@AsyncFunction false
 
       var imagesLoaded = 0
-      var failed = false
+      var settled = false
 
       val headers = headersMap?.let {
         LazyHeaders.Builder().apply {
@@ -102,8 +102,8 @@ class ExpoImageModule : Module() {
               target: Target<Drawable>,
               isFirstResource: Boolean
             ): Boolean {
-              if (!failed) {
-                failed = true
+              if (!settled) {
+                settled = true
                 promise.resolve(false)
               }
               return true
@@ -118,7 +118,8 @@ class ExpoImageModule : Module() {
             ): Boolean {
               imagesLoaded++
 
-              if (imagesLoaded == urls.size) {
+              if (!settled && imagesLoaded == urls.size) {
+                settled = true
                 promise.resolve(true)
               }
               return true


### PR DESCRIPTION
# Why

Fixes #49942.

On Android, `Image.prefetch()` can settle its promise twice, throwing an uncaught
`PromiseAlreadySettledException` on the main thread and crashing the app in production.

The listener guards the *failure* path with `failed`, but the success path has no
equivalent guard:

```kotlin
override fun onLoadFailed(...): Boolean {
  if (!failed) {          // guarded
    failed = true
    promise.resolve(false)
  }
  return true
}

override fun onResourceReady(...): Boolean {
  imagesLoaded++
  if (imagesLoaded == urls.size) {   // not guarded against an already-settled promise
    promise.resolve(true)
  }
  return true
}
```

Sequence:

1. A prefetch request fails (offline / flaky network) → `onLoadFailed` → `promise.resolve(false)`. The promise is now settled.
2. Connectivity is restored. `SingletonConnectivityReceiver` notifies `RequestManager`, which calls `RequestTracker.restartRequests()` — documented as *"Restarts failed requests and cancels and restarts in progress requests."*
3. The previously-failed request runs again and succeeds → `onResourceReady` → `imagesLoaded` reaches `urls.size` → `promise.resolve(true)` on the settled promise → crash.

Two details make this worse than it first looks:

- `Glide.with(appContext.reactContext)` resolves to the **application-scoped** `RequestManager`, which is never paused or cleared. Failed prefetch requests linger for the life of the process and are restarted on *every* connectivity transition, so the crash can fire long after the screen that called `prefetch` is gone.
- The throw happens on a Glide callback on the main looper with no JS on the stack, so **a `.catch()` in JS cannot prevent it.** Every caller of `Image.prefetch` on Android is exposed.

Production stack trace:

```
Caused by expo.modules.kotlin.exception.PromiseAlreadySettledException:
  Promise passed to 'unknown' was already settled.
  at expo.modules.kotlin.jni.PromiseImpl.checkIfWasSettled (PromiseImpl.kt:64)
  at expo.modules.image.ExpoImageModule$definition$1$3$1$2.onResourceReady (ExpoImageModule.kt:107)
  at com.bumptech.glide.request.SingleRequest.onResourceReady (SingleRequest.java:651)
  at com.bumptech.glide.load.engine.Engine.load (Engine.java:220)
  at com.bumptech.glide.request.SingleRequest.onSizeReady (SingleRequest.java:469)
  at com.bumptech.glide.request.SingleRequest.begin (SingleRequest.java:259)
  at com.bumptech.glide.manager.RequestTracker.restartRequests (RequestTracker.java:141)
  at com.bumptech.glide.RequestManager$RequestManagerConnectivityListener.onConnectivityChanged (RequestManager.java:744)
  at com.bumptech.glide.manager.SingletonConnectivityReceiver$2.onConnectivityChanged (SingletonConnectivityReceiver.java:80)
```

# How

Replaces the `failed` flag with a single `settled` flag covering both paths, so whichever
path settles first wins and the other becomes a no-op.

All of these callbacks are delivered on the main thread, so a plain flag is sufficient —
the existing code already relies on that.

# Test Plan

Reproduced and verified against `expo-image@55.0.10` in a production app:

1. Call `Image.prefetch(urls)` on Android.
2. Force the request to fail (airplane mode, or an unreachable host).
3. Restore connectivity — Glide restarts the failed request, it succeeds, and the app crashes.

With the patch applied and the module built from source, disassembling
`ExpoImageModule$definition$1$3$1$2` confirms `onResourceReady` now short-circuits when
the promise is already settled:

```
45: getfield  $settled:Ref$BooleanRef
52: ifne  92          // already settled -> jump straight to `return true`
71: if_icmpne 92
79: putfield  element:Z   // settled = true
87: invokeinterface Promise.resolve:(Z)V
```

The crash has not reproduced since.

# Note

Related but out of scope for this PR: if `appContext.reactContext` is null, `prefetch` does
`return@AsyncFunction false` without ever settling the promise, leaving it pending forever.