### PR TITLE
[android][image-picker] Recreate crop output dir and map cropper errors instead of crashing

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Fix a failed crop resolving with the uncropped original image instead of rejecting when `allowsEditing` is `true`. ([#48524](https://github.com/expo/expo/issues/48524) by [@aashishshrestha5532](https://github.com/aashishshrestha5532), [#48541](https://github.com/expo/expo/pull/48541) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the video `PHAssetResourceManager` fast path rejecting instead of falling back to the slower path that can fetch iCloud assets, and pass `shouldDownloadFromNetwork` through when reading Live Photo resources. As a result, a video whose data is not stored locally is now downloaded through the fallback path even when `shouldDownloadFromNetwork` is `false` and `videoExportPreset` is `Passthrough`. ([#48658](https://github.com/expo/expo/issues/48658) by [@gcampoyf-cloud](https://github.com/gcampoyf-cloud), [#48794](https://github.com/expo/expo/pull/48794) by [@expo-bot](https://github.com/expo-bot))
 - [iOS] Fix picking a video terminating apps that ship no `NSPhotoLibraryUsageDescription` by only taking the `PHAssetResourceManager` fast path when photo library read access has already been granted. ([#49362](https://github.com/expo/expo/pull/49362) by [@OlegBezr](https://github.com/OlegBezr))
+- [Android] Recreate the crop output directory if Android evicted it while the crop UI was open, and map cropper errors to a rejected promise instead of crashing. ([#49802](https://github.com/expo/expo/issues/49802))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -30,4 +30,7 @@ dependencies {
   if (project.findProject(':expo-modules-test-core')) {
     androidTestImplementation project(':expo-modules-test-core')
   }
+
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.robolectric:robolectric:4.16'
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/CropOutputDirectory.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/CropOutputDirectory.kt
@@ -1,0 +1,24 @@
+package expo.modules.imagepicker
+
+import java.io.File
+
+/**
+ * The crop output file is created in the cache directory before [ExpoCropImageActivity] starts.
+ * Android can delete the cache directory at any time, for example when storage runs low while
+ * the app is in the background. The cropper writes the result through a `FileProvider` URI
+ * opened with `MODE_CREATE`, so a missing file is recreated, but a missing parent directory
+ * makes the write fail with `ENOENT`. Recreate the directory right before the write starts.
+ *
+ * The path must be the real output file (an intent extra) because Expo Go's module cache directory
+ * is not [android.content.Context.getCacheDir].
+ */
+internal fun ensureCropOutputDirectoryExists(outputFilePath: String?) {
+  if (outputFilePath == null) {
+    return
+  }
+  try {
+    File(outputFilePath).parentFile?.mkdirs()
+  } catch (_: SecurityException) {
+    // Best-effort: a missing directory is still reported as a cropper error.
+  }
+}

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
@@ -413,6 +413,7 @@ class ExpoCropImageActivity :
     if (cropImageOptions.noOutputImage) {
       setResult(null, null, 1)
     } else {
+      ensureCropOutputDirectoryExists(intent.getStringExtra(ImagePickerConstants.CROP_OUTPUT_FILE_PATH_EXTRA))
       cropImageView?.croppedImageAsync(
         saveCompressFormat = cropImageOptions.outputCompressFormat,
         saveCompressQuality = cropImageOptions.outputCompressQuality,

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerConstants.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerConstants.kt
@@ -8,6 +8,11 @@ object ImagePickerConstants {
   const val CACHE_DIR_NAME = "ImagePicker"
 
   /**
+   * Intent extra that carries the absolute path of the crop output file to [expo.modules.imagepicker.ExpoCropImageActivity].
+   */
+  const val CROP_OUTPUT_FILE_PATH_EXTRA = "expo.modules.imagepicker.CROP_OUTPUT_FILE_PATH"
+
+  /**
    * Expose List<Pair<Type, Exif>> as [Iterable] for easier access.
    */
   val EXIF_TAGS = object : Iterable<Pair<String, String>> {

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
@@ -12,6 +12,7 @@ import com.canhub.cropper.CropImageOptions
 import com.canhub.cropper.CropImageView
 import expo.modules.imagepicker.CropShape
 import expo.modules.imagepicker.ExpoCropImageActivity
+import expo.modules.imagepicker.ImagePickerConstants
 import expo.modules.imagepicker.ImagePickerOptions
 import expo.modules.imagepicker.MediaType
 import expo.modules.imagepicker.copyExifData
@@ -27,6 +28,8 @@ internal class CropImageContract(
 ) : AppContextActivityResultContract<CropImageContractOptions, ImagePickerContractResult> {
   override fun createIntent(context: Context, input: CropImageContractOptions) = Intent(context, ExpoCropImageActivity::class.java).apply {
     val outputUri = input.outputFile.getContentUri(context)
+
+    putExtra(ImagePickerConstants.CROP_OUTPUT_FILE_PATH_EXTRA, input.outputFile.absolutePath)
 
     putExtra(
       CropImage.CROP_IMAGE_EXTRA_BUNDLE,
@@ -61,13 +64,35 @@ internal class CropImageContract(
       @Suppress("DEPRECATION")
       intent?.getParcelableExtra(CropImage.CROP_IMAGE_EXTRA_RESULT)
     }
-    if (resultCode == Activity.RESULT_CANCELED || result == null) {
-      return ImagePickerContractResult.Cancelled
-    }
-    val targetUri = requireNotNull(result.uriContent)
+    mapCropImageParseResult(resultCode, result)?.let { return it }
+    val targetUri = requireNotNull(result?.uriContent)
     val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null" }.contentResolver
     runBlocking { copyExifData(input.sourceUri.toUri(), input.outputFile, contentResolver) }
     return ImagePickerContractResult.Success(listOf(MediaType.IMAGE to targetUri))
+  }
+}
+
+/**
+ * Maps a crop activity result to cancellation or error. Returns `null` when cropping succeeded
+ * and [CropImage.ActivityResult.uriContent] is present.
+ */
+internal fun mapCropImageParseResult(
+  resultCode: Int,
+  result: CropImage.ActivityResult?
+): ImagePickerContractResult? {
+  return when (
+    mapCropImageParseKind(
+      resultCode = resultCode,
+      resultIsPresent = result != null,
+      uriContentIsNull = result?.uriContent == null,
+      hasError = result?.error != null,
+      cancelledCode = Activity.RESULT_CANCELED,
+      errorCode = CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE
+    )
+  ) {
+    CropImageParseKind.CANCELLED -> ImagePickerContractResult.Cancelled
+    CropImageParseKind.ERROR -> ImagePickerContractResult.Error
+    CropImageParseKind.SUCCESS -> null
   }
 }
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageParse.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageParse.kt
@@ -1,0 +1,41 @@
+package expo.modules.imagepicker.contracts
+
+/**
+ * Outcome of mapping a crop activity result before EXIF copy / success handling.
+ *
+ * [CROP_IMAGE_PARSE_CANCELLED_CODE] matches `Activity.RESULT_CANCELED`.
+ * [CROP_IMAGE_PARSE_ERROR_CODE] matches `CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE`.
+ */
+internal enum class CropImageParseKind {
+  CANCELLED,
+  ERROR,
+  SUCCESS
+}
+
+internal const val CROP_IMAGE_PARSE_CANCELLED_CODE = 0
+internal const val CROP_IMAGE_PARSE_ERROR_CODE = 204
+
+/**
+ * Maps a crop activity result to cancellation or error. [CropImageParseKind.SUCCESS] means
+ * cropping succeeded and a non-null output URI is present.
+ *
+ * @see https://github.com/expo/expo/issues/49802
+ */
+internal fun mapCropImageParseKind(
+  resultCode: Int,
+  resultIsPresent: Boolean,
+  uriContentIsNull: Boolean,
+  hasError: Boolean,
+  cancelledCode: Int = CROP_IMAGE_PARSE_CANCELLED_CODE,
+  errorCode: Int = CROP_IMAGE_PARSE_ERROR_CODE
+): CropImageParseKind {
+  if (resultCode == cancelledCode || !resultIsPresent) {
+    return CropImageParseKind.CANCELLED
+  }
+  // The crop activity reports a failure with an error result. Map it to an error the module can
+  // reject with, instead of throwing on a null output URI.
+  if (resultCode == errorCode || hasError || uriContentIsNull) {
+    return CropImageParseKind.ERROR
+  }
+  return CropImageParseKind.SUCCESS
+}

--- a/packages/expo-image-picker/android/src/test/java/expo/modules/imagepicker/contracts/CropImageContractParseResultTest.kt
+++ b/packages/expo-image-picker/android/src/test/java/expo/modules/imagepicker/contracts/CropImageContractParseResultTest.kt
@@ -1,0 +1,69 @@
+package expo.modules.imagepicker.contracts
+
+import android.app.Activity
+import com.canhub.cropper.CropImage
+import expo.modules.imagepicker.ensureCropOutputDirectoryExists
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.io.FileNotFoundException
+import kotlin.io.path.createTempDirectory
+
+/**
+ * @see https://github.com/expo/expo/issues/49802
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class CropImageContractParseResultTest {
+  @Test
+  fun parseResult_mapsCropperErrorWithNullUriToError() {
+    assertEquals(Activity.RESULT_CANCELED, CROP_IMAGE_PARSE_CANCELLED_CODE)
+    assertEquals(CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE, CROP_IMAGE_PARSE_ERROR_CODE)
+
+    val result = CropImage.ActivityResult(
+      originalUri = null,
+      uriContent = null,
+      error = FileNotFoundException("open failed: ENOENT"),
+      cropPoints = floatArrayOf(),
+      cropRect = null,
+      rotation = 0,
+      wholeImageRect = null,
+      sampleSize = 1
+    )
+
+    val mapped = mapCropImageParseResult(
+      CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE,
+      result
+    )
+
+    assertSame(ImagePickerContractResult.Error, mapped)
+  }
+
+  @Test
+  fun parseResult_mapsCancelledToCancelled() {
+    val mapped = mapCropImageParseResult(Activity.RESULT_CANCELED, null)
+    assertSame(ImagePickerContractResult.Cancelled, mapped)
+  }
+
+  @Test
+  fun ensureCropOutputDirectoryExists_recreatesDeletedParent() {
+    val root = createTempDirectory("image-picker-crop").toFile()
+    try {
+      val parent = File(root, "ImagePicker")
+      val outputFile = File(parent, "crop.png")
+      assertTrue(parent.mkdirs())
+      assertTrue(parent.deleteRecursively())
+      assertFalse(parent.exists())
+
+      ensureCropOutputDirectoryExists(outputFile.absolutePath)
+
+      assertTrue(parent.isDirectory)
+    } finally {
+      root.deleteRecursively()
+    }
+  }
+}


### PR DESCRIPTION
# Why

Recreate `cache/ImagePicker/` immediately before the cropper writes, and map cropper error results to `ImagePickerContractResult.Error` instead of crashing.

On Android, if that directory is deleted while `ExpoCropImageActivity` is open (system cache eviction, or `adb`/`pm trim-caches`), confirming the crop kills the process with `FileNotFoundException: open failed: ENOENT`. `launchImageLibraryAsync` neither resolves nor rejects.

A second crash on the same path: a cropper error result hits `requireNotNull(result.uriContent)` and throws `IllegalArgumentException` on the main thread.

Closes #49802

brentvatne's `/verify`: https://github.com/expo/expo/issues/49802#issuecomment-5590195063
expo-bot Outcome: problem: https://github.com/expo/expo/issues/49802#issuecomment-5590863605

This issue is labeled `needs review`, not `Issue accepted`. Related reports with the same stack: #47357, #47356.

# How

Two Expo-side changes; no cropper fork.

1. Pass the real crop output file path to `ExpoCropImageActivity` as intent extra `expo.modules.imagepicker.CROP_OUTPUT_FILE_PATH`, and call `File(path).parentFile?.mkdirs()` immediately before `croppedImageAsync`. `FileProvider` recreates a missing file, not a missing directory. The extra exists because Expo Go's module cache directory is not `context.cacheDir` (scoped `AppDirectoriesService`).

2. Map `CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE`, a non-null `result.error`, or a null `uriContent` to `ImagePickerContractResult.Error`, which `launchPicker` already rejects as `FailedToPickMediaException`.

The intent extra is used instead of `File(context.cacheDir, "ImagePicker")` in the activity. Deriving the directory from `Context.getCacheDir()` would point Expo Go at the wrong place (`.../cache` vs `.../cache/ExperienceData/<scope>`).

`mkdirs()` is used instead of `FileUtilities.ensureDirExists`, which would throw `IOException` if the directory cannot be created. Directory creation is best-effort before the cropper write; remaining failures the cropper reports still map to `Error`.

`ensureCropOutputDirectoryExists`, `mapCropImageParseKind`, and `mapCropImageParseResult` are extracted so the mapping and `mkdirs` can be unit-tested without constructing `CropImageContract`. expo-bot's alternative was an inline `if` in `parseResult` and a private method on the activity.

Happy to inject `AppDirectoriesService`, inline the helpers, or throw on `mkdirs` failure if a maintainer prefers any of those.

The cropper still runs the bitmap write in an uncaught child coroutine. Other write failures (for example a full disk) can still kill the process. A complete fix belongs in CanHub/Android-Image-Cropper.

# Test Plan

- [x] `et check-packages expo-image-picker`: all checks passed (JS/TS build, typecheck, lint, format, Jest).
- [x] JVM compile of the extracted helpers: cropper-error mapping and deleted-parent `mkdirs` fail without the fix (`IllegalArgumentException: Required value was null.` / parent not recreated) and pass with the fix.
- [ ] `./gradlew :expo-image-picker:testDebugUnitTest` from `apps/bare-expo/android` (JDK 17). This checkout had no Android SDK (`SDK location not found`). CI `android-unit-tests` should run this target; the package already had `android/src/androidTest`, and now has `android/src/test` with Robolectric 4.16 (same pattern as `expo-image-manipulator`).
- [ ] Manual: `launchImageLibraryAsync({ allowsEditing: true })`, delete `cache/ImagePicker` while the crop screen is open, confirm the crop. Expect a resolved crop (directory recreated) or a rejected promise, not a process death.
- [ ] Camera + `allowsEditing` with the source also in the deleted directory: expect a rejected promise, not `IllegalArgumentException` in `parseResult`.

Published `expo-image-picker` tarballs ship a prebuilt AAR. A patch that only changes `android/src/**/*.kt` is ignored by a build that links that AAR. Monorepo / source builds pick this up. This lands for apps that compile the module from this repo (or a later published version).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (native module source; no config plugin change). EAS builds that consume the published AAR will not compile these Kotlin sources until a new package version is published.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
