### PR TITLE
[create-expo]: fix supported nodeJS range

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Raise minimum Node.js version according to [docs](https://docs.expo.dev/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version) ([#49967](https://github.com/expo/expo/pull/49967) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 5.0.1 — 2026-08-14

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -23,7 +23,7 @@
     "template"
   ],
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^22.13.0 || ^24.3.0 || ^26.0.0 || >=27.0.0"
   },
   "scripts": {
     "build": "ncc build ./src/index.ts -o build/",


### PR DESCRIPTION
# Why

fix supported node range which didn't follow what's documented at https://docs.expo.dev/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version

# How

bump node range


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
