### PR TITLE
[docs] Fix table cell flattening destroys a literal ellipsis

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -848,43 +848,35 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
       )
         .replace(/\s+/g, ' ')
         .trim();
-      $callout.replaceWith(text ? '. ' + escapeHtml(text) + ' ' : '');
+      $callout.replaceWith(text ? '%%MD_SEP%%' + escapeHtml(text) + ' ' : '');
     });
 
-    // Generic block flattening — loop until stable since nested divs require multiple passes.
-    // Prepend ". " when unwrapping so adjacent blocks read as separate sentences, then
-    // clean up artifacts (double periods, leading separators) after the loop.
     let hasBlocks = true;
     while (hasBlocks) {
       hasBlocks = false;
       $cell.find('blockquote').each((_, el) => {
-        $(el).replaceWith('. ' + $(el).text().trim());
+        $(el).replaceWith('%%MD_SEP%%' + $(el).text().trim());
         hasBlocks = true;
       });
       $cell.find('p').each((_, el) => {
-        $(el).replaceWith('. ' + ($(el).html() ?? ''));
+        $(el).replaceWith('%%MD_SEP%%' + ($(el).html() ?? ''));
         hasBlocks = true;
       });
       $cell.find('div').each((_, el) => {
-        $(el).replaceWith('. ' + ($(el).html() ?? ''));
+        $(el).replaceWith('%%MD_SEP%%' + ($(el).html() ?? ''));
         hasBlocks = true;
       });
     }
-    // Clean up artifacts from block flattening:
-    // - Collapse ". ." / ".." from nested unwrapping. Skip <code>/<pre> so "..." is untouched.
-    // - Repeat until stable: a single pass leaves ". ." from triple nesting.
-    // - Trim leading ". " at cell start
-    // - Remove orphan "-" after periods (upstream renders a bare dash for empty descriptions)
     const blocks: string[] = [];
     let cellHtml = $cell.html()!.replace(/<(code|pre)\b[^>]*>[\S\s]*?<\/\1>/gi, match => {
       blocks.push(match);
       return `%%MD_CODE_${blocks.length - 1}%%`;
     });
-    while (/\.\s*\./.test(cellHtml)) {
-      cellHtml = cellHtml.replace(/\.\s*\./g, '. ');
-    }
     cellHtml = cellHtml
-      .replace(/^\s*\.\s*/, '')
+      .replace(/(?:%%MD_SEP%%)+/g, '%%MD_SEP%%')
+      .replace(/^\s*%%MD_SEP%%\s*/, '')
+      .replace(/\.\s*%%MD_SEP%%/g, '. ')
+      .replace(/%%MD_SEP%%/g, '. ')
       .replace(/\.\s*-\s*$/, '.')
       .replace(/%%MD_CODE_(\d+)%%/g, (_, i) => blocks[Number(i)]);
     $cell.html(cellHtml);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26677

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix table cell flattening destroys a literal ellipsis.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

After the fix, the ellipsis renders are correctly: 


<img width="1568" height="256" alt="eng-26677-audio-after" src="https://github.com/user-attachments/assets/916d5c9f-e76b-4e06-83b5-8ed868d5e9f6" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
