### PR TITLE
[docs] Stop cleanMarkdown from rewriting text inside fenced code blocks

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -1017,10 +1017,37 @@ export function insertAgentInstructionsAfterH1(
   return `${markdown.slice(0, insertAt)}\n\n${block.trimEnd()}${markdown.slice(insertAt)}`;
 }
 
-/**
- * Post-process the markdown output to clean up common artifacts.
- */
-export function cleanMarkdown(markdown: string): string {
+const CODE_FENCE_LINE = /^\s*```/;
+
+function applyOutsideCodeFences(markdown: string, transform: (text: string) => string): string {
+  const segments: { isCode: boolean; lines: string[] }[] = [];
+  let insideFence = false;
+
+  for (const line of markdown.split('\n')) {
+    const isFenceLine = CODE_FENCE_LINE.test(line);
+    const isCode = insideFence || isFenceLine;
+    const openSegment = segments.at(-1);
+
+    if (openSegment?.isCode === isCode) {
+      openSegment.lines.push(line);
+    } else {
+      segments.push({ isCode, lines: [line] });
+    }
+
+    if (isFenceLine) {
+      insideFence = !insideFence;
+    }
+  }
+
+  return segments
+    .map(segment => {
+      const text = segment.lines.join('\n');
+      return segment.isCode ? text : transform(text);
+    })
+    .join('\n');
+}
+
+function cleanProse(markdown: string): string {
   return (
     markdown
       // Remove empty headings (from sections whose only content was visual/interactive)
@@ -1031,8 +1058,6 @@ export function cleanMarkdown(markdown: string): string {
       .replace(/\[]\([^)]+\)/g, '')
       // Remove standalone horizontal rules (often from description separators)
       .replace(/^\* \* \*$/gm, '')
-      // Replace %%placeholder%% markers with ellipsis
-      .replace(/%%placeholder-start%%.*?%%placeholder-end%%/g, '...')
       // Clean up platform badge comma formatting
       .replace(/Only for:\s*,\s*/g, 'Only for: ')
       .replace(/^\s*,\s*/gm, '')
@@ -1057,6 +1082,17 @@ export function cleanMarkdown(markdown: string): string {
       .replace(/^\s*•\s*$/gm, '')
       // Replace fullwidth equals sign with regular equals
       .replace(/\uff1d/g, '=')
+  );
+}
+
+/**
+ * Post-process the markdown output to clean up common artifacts.
+ */
+export function cleanMarkdown(markdown: string): string {
+  return (
+    applyOutsideCodeFences(markdown, cleanProse)
+      // Replace %%placeholder%% markers with ellipsis
+      .replace(/%%placeholder-start%%.*?%%placeholder-end%%/g, '...')
       // Clean up excessive whitespace
       .replace(/\n{3,}/g, '\n\n')
       .trim()


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26676

# How

<!--
How did you build this feature or fix this bug and why?
-->

Stop `cleanMarkdown` from rewriting text inside fenced code blocks.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


<img width="1136" height="764" alt="eng-26676-after" src="https://github.com/user-attachments/assets/b6e86178-a86a-4d27-af82-7bbf1359c30a" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
