### PR TITLE
[router] Remove guarded history entries from JavaScript and experimental stacks

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -77,7 +77,7 @@
 
 ### 🐛 Bug fixes
 
-- Remove guarded history entries from JavaScript and experimental stacks.
+- Remove guarded history entries from JavaScript and experimental stacks. ([#49985](https://github.com/expo/expo/pull/49985) by [@Ubax](https://github.com/Ubax))
 - Oder tabs by `.Trigger` order during initial render ([#49848](https://github.com/expo/expo/pull/49848) by [@Ubax](https://github.com/Ubax))
 - Prevent Native Tabs from remounting the focused tab while preloading other tabs after a cold-start deep link. (by [@Ubax](https://github.com/Ubax)) ([#49811](https://github.com/expo/expo/pull/49811) by [@Ubax](https://github.com/Ubax))
 - Re-export the vendored JavaScript stack API from `expo-router/js-stack`. ([#49657](https://github.com/expo/expo/pull/49657) by [@davidmokos](https://github.com/davidmokos))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -77,6 +77,7 @@
 
 ### 🐛 Bug fixes
 
+- Remove guarded history entries from JavaScript and experimental stacks.
 - Oder tabs by `.Trigger` order during initial render ([#49848](https://github.com/expo/expo/pull/49848) by [@Ubax](https://github.com/Ubax))
 - Prevent Native Tabs from remounting the focused tab while preloading other tabs after a cold-start deep link. (by [@Ubax](https://github.com/Ubax)) ([#49811](https://github.com/expo/expo/pull/49811) by [@Ubax](https://github.com/Ubax))
 - Re-export the vendored JavaScript stack API from `expo-router/js-stack`. ([#49657](https://github.com/expo/expo/pull/49657) by [@davidmokos](https://github.com/davidmokos))

--- a/packages/expo-router/src/__tests__/experimental-stack.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/experimental-stack.test.ios.tsx
@@ -63,6 +63,7 @@ const { Stack: MockedStackV5 } = jest.requireMock(
 const MockedHost = MockedStackV5.Host as unknown as jest.Mock;
 const MockedScreen = MockedStackV5.Screen as unknown as jest.Mock;
 const MockedHeaderConfig = MockedStackV5.HeaderConfig as unknown as jest.Mock;
+let warnSpy: jest.SpyInstance | undefined;
 
 function NativeNavigatorContextProbe() {
   return <Text>{String(use(IsWithinNativeNavigator))}</Text>;
@@ -94,6 +95,11 @@ beforeEach(() => {
   MockedHost.mockClear();
   MockedScreen.mockClear();
   MockedHeaderConfig.mockClear();
+});
+
+afterEach(() => {
+  warnSpy?.mockRestore();
+  warnSpy = undefined;
 });
 
 describe('ExperimentalStack — basic navigation', () => {
@@ -128,7 +134,7 @@ describe('ExperimentalStack — basic navigation', () => {
 
   it('removes guarded routes from history when a guard flips false', () => {
     let setGuard: Dispatch<SetStateAction<boolean>>;
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     renderRouter({
       _layout: function Layout() {
@@ -152,8 +158,10 @@ describe('ExperimentalStack — basic navigation', () => {
     act(() => router.push('/other'));
     act(() => setGuard(false));
     act(() => router.back());
-    warnSpy.mockRestore();
 
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ignoring unsupported screenOption 'hidden'")
+    );
     expect(screen).toHavePathname('/');
     expect(router.canGoBack()).toBe(false);
   });

--- a/packages/expo-router/src/__tests__/experimental-stack.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/experimental-stack.test.ios.tsx
@@ -1,5 +1,5 @@
 import { act, screen } from '@testing-library/react-native';
-import { use, type ReactNode } from 'react';
+import { use, useState, type Dispatch, type ReactNode, type SetStateAction } from 'react';
 import { Text, type NativeSyntheticEvent } from 'react-native';
 import type { TabSelectedEvent, TabsHostProps } from 'react-native-screens';
 
@@ -124,6 +124,38 @@ describe('ExperimentalStack — basic navigation', () => {
 
     expect(screen).toHavePathname('/b');
     expect(router.canDismiss()).toBe(true);
+  });
+
+  it('removes guarded routes from history when a guard flips false', () => {
+    let setGuard: Dispatch<SetStateAction<boolean>>;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    renderRouter({
+      _layout: function Layout() {
+        const [guard, setState] = useState(true);
+        setGuard = setState;
+        return (
+          <ExperimentalStack>
+            <ExperimentalStack.Protected guard={guard}>
+              <ExperimentalStack.Screen name="secret" />
+            </ExperimentalStack.Protected>
+            <ExperimentalStack.Screen name="other" />
+          </ExperimentalStack>
+        );
+      },
+      index: () => <Text testID="index">index</Text>,
+      secret: () => <Text testID="secret">secret</Text>,
+      other: () => <Text testID="other">other</Text>,
+    });
+
+    act(() => router.push('/secret'));
+    act(() => router.push('/other'));
+    act(() => setGuard(false));
+    act(() => router.back());
+    warnSpy.mockRestore();
+
+    expect(screen).toHavePathname('/');
+    expect(router.canGoBack()).toBe(false);
   });
 
   it('pops via router.dismiss', () => {

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -5,6 +5,7 @@ import { Text } from 'react-native';
 
 import { navigationRef } from '../global-state/navigationRef';
 import { router } from '../imperative-api';
+import JSStack from '../layouts/JSStack';
 import Stack from '../layouts/Stack';
 import Tabs from '../layouts/Tabs';
 import { renderRouter } from '../testing-library';
@@ -402,6 +403,37 @@ it('should remove guarded routes from history when a guard flips false', () => {
     setGuard(false);
   });
 
+  act(() => router.back());
+
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen).toHavePathname('/');
+  expect(router.canGoBack()).toBe(false);
+});
+
+it('should remove guarded routes from JavaScript stack history when a guard flips false', () => {
+  let setGuard: Dispatch<SetStateAction<boolean>>;
+
+  renderRouter({
+    _layout: function Layout() {
+      const [guard, setState] = useState(true);
+      setGuard = setState;
+      return (
+        <JSStack>
+          <JSStack.Protected guard={guard}>
+            <JSStack.Screen name="secret" />
+          </JSStack.Protected>
+          <JSStack.Screen name="other" />
+        </JSStack>
+      );
+    },
+    index: () => <Text testID="index">index</Text>,
+    secret: () => <Text testID="secret">secret</Text>,
+    other: () => <Text testID="other">other</Text>,
+  });
+
+  act(() => router.push('/secret'));
+  act(() => router.push('/other'));
+  act(() => setGuard(false));
   act(() => router.back());
 
   expect(screen.getByTestId('index')).toBeVisible();

--- a/packages/expo-router/src/layouts/JSStack.tsx
+++ b/packages/expo-router/src/layouts/JSStack.tsx
@@ -25,6 +25,7 @@ export * from '../react-navigation/stack';
  * Creates the adapter props required to integrate the JavaScript stack with Expo Router.
  */
 export function unstable_createPropsForJSStack({
+  dispatch,
   dispatchSync,
   navigation,
   state,
@@ -33,6 +34,7 @@ export function unstable_createPropsForJSStack({
 >): StackNavigatorCreateProps {
   return {
     pop: makePopAction(dispatchSync, state.key),
+    removeRoutes: (routeNames) => dispatch({ type: 'REMOVE_ROUTES', payload: { routeNames } }),
     restoreRoute: makeRestoreRouteAction(dispatchSync, state),
     subscribePopToTopOnParentTabPress: () => subscribePopToTopOnParentTabPress(navigation, state),
   };

--- a/packages/expo-router/src/layouts/experimental-stack/createExperimentalStackNavigator.tsx
+++ b/packages/expo-router/src/layouts/experimental-stack/createExperimentalStackNavigator.tsx
@@ -9,6 +9,7 @@ import {
   useCompositionRegistry,
 } from '../../fork/native-stack/composition-options';
 import type { NavigatorContentProps } from '../../standard-navigation';
+import { useClearGuardedRoutes } from '../useClearGuardedRoutes';
 import { ExperimentalStackView } from './ExperimentalStackView';
 import type {
   ExperimentalStackNavigationEventMap,
@@ -17,6 +18,7 @@ import type {
 
 export interface ExperimentalStackNavigatorCreateProps {
   pop: (count: number, sourceRouteKey: string) => void;
+  removeRoutes: (routeNames: string[]) => void;
   subscribePopToTopOnParentTabPress: () => (() => void) | undefined;
 }
 
@@ -38,6 +40,7 @@ function ExperimentalStackNavigatorContent({
   descriptors,
   emitter,
   pop,
+  removeRoutes,
   subscribePopToTopOnParentTabPress,
 }: ExperimentalStackNavigatorContentProps) {
   const { registry, contextValue } = useCompositionRegistry();
@@ -47,6 +50,7 @@ function ExperimentalStackNavigatorContent({
     [descriptors, registry, state]
   );
 
+  useClearGuardedRoutes(removeRoutes);
   React.useEffect(() => subscribePopToTopOnParentTabPress(), [subscribePopToTopOnParentTabPress]);
 
   return (

--- a/packages/expo-router/src/layouts/experimental-stack/index.tsx
+++ b/packages/expo-router/src/layouts/experimental-stack/index.tsx
@@ -26,8 +26,9 @@ const RNExperimentalStack = unstable_integrateWithRouter<
   object,
   ExperimentalStackNavigatorCreateProps
 >(createStandardExperimentalStackNavigator, StackRouter, {
-  createProps: ({ dispatchSync, navigation, state }) => ({
+  createProps: ({ dispatch, dispatchSync, navigation, state }) => ({
     pop: makePopAction(dispatchSync, state.key),
+    removeRoutes: (routeNames) => dispatch({ type: 'REMOVE_ROUTES', payload: { routeNames } }),
     subscribePopToTopOnParentTabPress: () => subscribePopToTopOnParentTabPress(navigation, state),
   }),
 });

--- a/packages/expo-router/src/react-navigation/stack/navigators/createStackNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/stack/navigators/createStackNavigator.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { createStandardNavigator } from 'standard-navigation';
 
+import { useClearGuardedRoutes } from '../../../layouts/useClearGuardedRoutes';
 import type { NavigatorContentProps } from '../../../standard-navigation';
 import { type Route, useLocale } from '../../native';
 import type {
@@ -13,6 +14,7 @@ import { StackView } from '../views/Stack/StackView';
 
 export interface StackNavigatorCreateProps {
   pop: (count: number, sourceRouteKey: string) => void;
+  removeRoutes: (routeNames: string[]) => void;
   restoreRoute: (route: Route<string>) => boolean;
   subscribePopToTopOnParentTabPress: () => (() => void) | undefined;
 }
@@ -35,12 +37,14 @@ function StackNavigatorContent({
   descriptors,
   emitter,
   pop,
+  removeRoutes,
   restoreRoute,
   subscribePopToTopOnParentTabPress,
   ...rest
 }: StackNavigatorContentProps) {
   const { direction } = useLocale();
 
+  useClearGuardedRoutes(removeRoutes);
   React.useEffect(() => subscribePopToTopOnParentTabPress(), [subscribePopToTopOnParentTabPress]);
 
   if (state.routes.length === 0) {


### PR DESCRIPTION
# Why

`useClearGuardedRoutes` only ran for the default native stack. When a protected route became unavailable in the JavaScript or experimental stack, its old history entries remained and could still affect Back navigation.

# How

Pass the existing `REMOVE_ROUTES` stack action into the JavaScript and experimental stack content and call `useClearGuardedRoutes` from both implementations.

# Test Plan

CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)