### PR TITLE
[ui][web] Fix ListItem always showing a pointer cursor on web without onPress

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -41,7 +41,6 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix `DatePickerDialog` preselecting today when `initialDate` is omitted, and keep its confirm button disabled while no date is selected so `onDateSelected` never receives an invalid date. ([#49898](https://github.com/expo/expo/pull/49898) by [@pataar](https://github.com/pataar))
-
 - [Android][iOS] Fix `community/bottom-sheet` content shrinking to its own width instead of filling the sheet when the sheet sizes to its content. ([#49742](https://github.com/expo/expo/issues/49742) by [@agung-adhinata](https://github.com/agung-adhinata)) ([#49762](https://github.com/expo/expo/pull/49762) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fixed a `Text` or an `Icon` with no explicit color rendering black inside `Host`, which made it unreadable in the dark color scheme. `Host` now provides `LocalContentColor` from the color scheme. ([#49697](https://github.com/expo/expo/pull/49697) by [@expo-bot](https://github.com/expo-bot))
 - [iOS][Android] Fixed a `matchContents` `RNHostView` inside a `matchContents` `Host` growing the layout on every pass. ([#49483](https://github.com/expo/expo/pull/49483) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
@@ -69,6 +68,7 @@
 - [Android] Explicitly enable `buildFeatures.buildConfig`, required by AGP 9. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix `Host` color scheme type errors on React Native 0.87. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fixed `PlatformColor` and `DynamicColorIOS` values dropping the `backgroundColor` and `borderColor` of a universal component. Both were stringified to `"[object Object]"`, which the native color converter rejects, so the modifier was discarded without a trace. ([#49746](https://github.com/expo/expo/pull/49746) by [@Den1Marshall](https://github.com/Den1Marshall))
+- [web] Fix `ListItem` always showing a pointer cursor, even without an `onPress`, because React Native Web's `Pressable` applies one unconditionally. A `ListItem` with no `onPress` now shows the default cursor instead of misleadingly looking clickable. ([#49986](https://github.com/expo/expo/pull/49986) by [@timheilman](https://github.com/timheilman))
 
 ### 💡 Others
 

--- a/packages/expo-ui/src/universal/ListItem/ListItem.tsx
+++ b/packages/expo-ui/src/universal/ListItem/ListItem.tsx
@@ -33,7 +33,10 @@ export function ListItem(props: ListItemProps) {
   const supporting = slots.supporting ?? supportingText;
 
   return (
-    <Pressable onPress={onPress} style={styles.row} testID={testID}>
+    <Pressable
+      onPress={onPress}
+      style={[styles.row, onPress != null ? styles.rowIsPressable : styles.rowIsStatic]}
+      testID={testID}>
       {leading != null ? <View style={styles.slot}>{leading}</View> : null}
       <View style={styles.main}>
         <Text style={isDark && styles.darkText}>{slots.headline}</Text>
@@ -52,7 +55,13 @@ const styles = StyleSheet.create({
     width: '100%',
     paddingVertical: 12,
     paddingHorizontal: 16,
+  },
+  // Pressable defaults to cursor: pointer; override it when not pressable.
+  rowIsPressable: {
     cursor: 'pointer',
+  },
+  rowIsStatic: {
+    cursor: 'auto',
   },
   main: {
     flexDirection: 'column',


### PR DESCRIPTION
## Summary

- React Native Web's own `Pressable` applies `cursor: pointer` unconditionally whenever it isn't `disabled` (see its `active` style: `{ cursor: 'pointer', touchAction: 'manipulation' }`, used whenever `disabled` is falsy). `expo-ui`'s universal `ListItem` on web passes `onPress` straight through without ever setting `disabled`, so a `ListItem` rendered with no `onPress` (an informational row, not a tappable one) still shows a pointer cursor on hover, misleadingly suggesting it's clickable.
- Adds two named styles, `rowIsPressable` (`cursor: pointer`) and `rowIsStatic` (`cursor: auto`), and picks between them based on whether `onPress` is set, overriding `Pressable`'s built-in default in the non-interactive case. `auto` (rather than `default`) is used because RN's `CursorValue` type only allows `'auto' | 'pointer'`.
- No behavior change for any `ListItem` that already has `onPress` — it keeps the same pointer cursor as before.

## Is this a real use case?

`onPress` is typed as optional (`onPress?: () => void` in `ListItemProps`), and there's first-party precedent for omitting it — not just our own usage:

- The official docs' pull-to-refresh example (`docs/pages/versions/unversioned/sdk/ui/universal/list.mdx`) renders plain data rows with no tap handler: `<ListItem key={id}>{`Item #${id}`}</ListItem>`.
- Expo's own demo app (`apps/native-component-list/src/screens/UIUniversal/ListScreen.tsx`) uses a `ListItem` as a status line with no `onPress`: `<ListItem supportingText={...}>{`${items.length} items`}</ListItem>`.

Neither file is platform-restricted, so both already render this same misleading pointer cursor on web today.

## Test plan

- Manually verified in a real browser: an `onPress`-less `ListItem` now shows the default arrow cursor on hover instead of a pointer; one with `onPress` is unaffected.
- Also manually verified via a throwaway Jest test using `@testing-library/react` + `getComputedStyle` against the real DOM in this package's "Web" jest project, confirming `cursor: pointer` vs `cursor: auto` for the two cases.
- No automated test was added to the PR itself: this package's "Web"/"Node" jest projects both match `*.test.web.tsx` files, but only the "Web" project's React Native Web build actually injects `StyleSheet.create`-derived CSS into the DOM — the "Node" project (used to check SSR-safety) resolves `getComputedStyle(...).cursor` to `""` regardless of the fix, since it doesn't inject a live stylesheet. There's no existing precedent elsewhere in this package for asserting on `StyleSheet.create`-derived CSS values in a Jest unit test (confirmed via grep — the only other `getComputedStyle` usage in the whole monorepo is an unrelated Playwright e2e test), and `react-test-renderer` (which would let a test inspect `Pressable`'s `style` prop directly, bypassing the DOM/CSS layer entirely) isn't used anywhere in this repo either. Given that, adding a project-specific single-purpose test harness felt like more machinery than this small, purely visual CSS fix warrants, so I verified manually instead rather than force an atypical test pattern into the package.
- Ran `et check-packages @expo/ui` (build, typecheck, depscheck, test, lint, format) — all green.

Changelog entry added via `et add-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzstECbB1tLzsDZbB8B1SE
