### PR TITLE
[ui][ios] Add `NavigationLink` and `NavigationDestination` components

### DIFF
--- a/apps/native-component-list/src/screens/UI/NavigationStackScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/NavigationStackScreen.ios.tsx
@@ -6,6 +6,8 @@ import {
   Image,
   Label,
   List,
+  NavigationDestination,
+  NavigationLink,
   NavigationStack,
   Section,
   Spacer,
@@ -152,6 +154,7 @@ export default function NavigationStackScreen() {
   const [selected, setSelected] = React.useState<Selection | null>(null);
   const [isPresented, setIsPresented] = React.useState(false);
   const [descending, setDescending] = React.useState(false);
+  const [path, setPath] = React.useState<string[]>([]);
 
   const sort = (birds: readonly Bird[]) =>
     [...birds].sort((a, b) =>
@@ -160,7 +163,7 @@ export default function NavigationStackScreen() {
 
   return (
     <Host style={{ flex: 1 }}>
-      <NavigationStack>
+      <NavigationStack path={path} onPathChange={setPath}>
         {/* The title and the sort button both belong to the bar this stack provides. */}
         <Toolbar modifiers={[navigationTitle('Birds')]}>
           <BottomSheet
@@ -212,6 +215,12 @@ export default function NavigationStackScreen() {
                     ))}
                   </Section>
                 ))}
+                <Section title="Pushed screen">
+                  {/* Appends 'about' to the stack's path, which mounts the destination below. */}
+                  <NavigationLink value="about">
+                    <Text>About this list</Text>
+                  </NavigationLink>
+                </Section>
               </List>
             }>
             {/* A sheet has no navigation bar of its own. The stack adds one, which gives the
@@ -267,6 +276,19 @@ export default function NavigationStackScreen() {
             />
           </Toolbar.Content>
         </Toolbar>
+        <NavigationDestination value="about">
+          <VStack
+            alignment="leading"
+            spacing={12}
+            modifiers={[padding({ all: 20 }), navigationTitle('About')]}>
+            <Text modifiers={[font({ textStyle: 'headline' })]}>British garden birds</Text>
+            <Text>
+              Each habitat lists the species you are most likely to see there. Tap a bird to open
+              its description in a sheet.
+            </Text>
+            <Spacer />
+          </VStack>
+        </NavigationDestination>
       </NavigationStack>
     </Host>
   );

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [iOS] Added the `scrollClipDisabled` modifier, which lets content that draws outside a scrollable view's bounds, such as a shadow or a scaled-up card, stay visible instead of being clipped. ([#49780](https://github.com/expo/expo/pull/49780) by [@Den1Marshall](https://github.com/Den1Marshall))
 - [iOS] Taught the `tint`, `border`, `strokeBorder` and `containerBackground` modifiers to paint with any `ShapeStyle`, matching SwiftUI, where all four take a `ShapeStyle` rather than a color. The `color` parameter of `border` and `strokeBorder` is deprecated in favor of `content`, the name SwiftUI gives it. ([#49838](https://github.com/expo/expo/pull/49838) by [@Den1Marshall](https://github.com/Den1Marshall))
 - [iOS] Added the `NavigationStack` and `Toolbar` components, the `navigationTitle` modifier, and the `close` button role. ([#49940](https://github.com/expo/expo/pull/49940) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Added the `NavigationLink` component, and the `path` and `onPathChange` props and the `NavigationDestination` component, so a stack can push a destination that is built only when the link is followed. ([#49991](https://github.com/expo/expo/pull/49991) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-ui/ios/ExpoUIModule.swift
+++ b/packages/expo-ui/ios/ExpoUIModule.swift
@@ -157,6 +157,7 @@ public final class ExpoUIModule: Module {
     ExpoUIView(MenuView.self)
 
     ExpoUIView(NavigationStackView.self)
+    ExpoUIView(NavigationLinkView.self)
     ExpoUIView(ToolbarView.self)
 
     ExpoUIView(FormView.self)

--- a/packages/expo-ui/ios/NavigationLinkView.swift
+++ b/packages/expo-ui/ios/NavigationLinkView.swift
@@ -1,0 +1,22 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import SwiftUI
+import ExpoModulesCore
+
+internal final class NavigationLinkViewProps: UIBaseViewProps {
+  @Field var value: String = ""
+}
+
+internal struct NavigationLinkView: ExpoSwiftUI.View {
+  @ObservedObject var props: NavigationLinkViewProps
+
+  init(props: NavigationLinkViewProps) {
+    self.props = props
+  }
+
+  var body: some View {
+    NavigationLink(value: props.value) {
+      Children()
+    }
+  }
+}

--- a/packages/expo-ui/ios/NavigationStackView.swift
+++ b/packages/expo-ui/ios/NavigationStackView.swift
@@ -3,18 +3,61 @@
 import SwiftUI
 import ExpoModulesCore
 
-internal final class NavigationStackViewProps: UIBaseViewProps {}
+internal final class NavigationStackViewProps: UIBaseViewProps {
+  @Field var path: [String]?
+  var onPathChange = EventDispatcher()
+}
+
+private struct NavigationDestinationContent: View {
+  @ObservedObject var props: NavigationStackViewProps
+  let value: String
+
+  var body: some View {
+    props.children?
+      .slots("destination")
+      .first { $0.extra("value", as: String.self) == value }
+  }
+}
 
 internal struct NavigationStackView: ExpoSwiftUI.View {
   @ObservedObject var props: NavigationStackViewProps
+  @State private var uncontrolledPath: [String] = []
 
   init(props: NavigationStackViewProps) {
     self.props = props
   }
 
+  private var pathBinding: Binding<[String]> {
+    let props = props
+    let uncontrolled = $uncontrolledPath
+    return Binding(
+      get: { props.path ?? uncontrolled.wrappedValue },
+      set: { newPath in
+        guard (props.path ?? uncontrolled.wrappedValue) != newPath else {
+          return
+        }
+        if props.path == nil {
+          uncontrolled.wrappedValue = newPath
+        }
+        props.onPathChange(["path": newPath])
+      }
+    )
+  }
+
   var body: some View {
-    NavigationStack {
-      Children()
+    NavigationStack(path: pathBinding) {
+      rootContent
+        .navigationDestination(for: String.self) { value in
+          NavigationDestinationContent(props: props, value: value)
+        }
+    }
+  }
+
+  @ViewBuilder
+  private var rootContent: some View {
+    ForEach(props.children?.withoutSlot("destination") ?? [], id: \.id) { child in
+      let view: any View = child.childView
+      AnyView(view)
     }
   }
 }

--- a/packages/expo-ui/ios/SlotView.swift
+++ b/packages/expo-ui/ios/SlotView.swift
@@ -30,6 +30,11 @@ extension [any ExpoSwiftUI.AnyChild] {
       .first { $0.props.name == name }
   }
 
+  func slots(_ name: String) -> [SlotView] {
+    compactMap { $0.childView as? SlotView }
+      .filter { $0.props.name == name }
+  }
+
   func withoutSlot(_ name: String) -> [any ExpoSwiftUI.AnyChild] {
     filter {
       guard let slot = $0.childView as? SlotView else { return true }

--- a/packages/expo-ui/src/swift-ui/NavigationDestination/index.tsx
+++ b/packages/expo-ui/src/swift-ui/NavigationDestination/index.tsx
@@ -16,7 +16,7 @@ export interface NavigationDestinationProps {
 /**
  * Associates a destination view with a `NavigationLink` value, matching SwiftUI's
  * `navigationDestination(for:destination:)`. It must be a direct child of the `NavigationStack`,
- * wherever the link that pushes it sits.
+ * however deeply the link that pushes it is nested inside that stack.
  *
  * Keep it mounted so the pushed screen already carries its `navigationTitle` when the slide
  * starts, or render one for each value on the stack's `path` to build screens on demand.

--- a/packages/expo-ui/src/swift-ui/NavigationDestination/index.tsx
+++ b/packages/expo-ui/src/swift-ui/NavigationDestination/index.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode } from 'react';
+
+import { Slot } from '../SlotView';
+
+export interface NavigationDestinationProps {
+  /**
+   * The `NavigationLink` value this destination is presented for.
+   */
+  value: string;
+  /**
+   * The view pushed onto the stack for `value`.
+   */
+  children: ReactNode;
+}
+
+/**
+ * Associates a destination view with a `NavigationLink` value, matching SwiftUI's
+ * `navigationDestination(for:destination:)`. It must be a direct child of the `NavigationStack`,
+ * wherever the link that pushes it sits.
+ *
+ * Keep it mounted so the pushed screen already carries its `navigationTitle` when the slide
+ * starts, or render one for each value on the stack's `path` to build screens on demand.
+ *
+ * @example
+ * ```tsx
+ * <NavigationDestination value="settings">
+ *   <SettingsScreen />
+ * </NavigationDestination>
+ * ```
+ *
+ * @platform ios
+ */
+export function NavigationDestination(props: NavigationDestinationProps) {
+  return (
+    <Slot name="destination" extraProps={{ value: props.value }}>
+      {props.children}
+    </Slot>
+  );
+}

--- a/packages/expo-ui/src/swift-ui/NavigationLink/index.tsx
+++ b/packages/expo-ui/src/swift-ui/NavigationLink/index.tsx
@@ -25,6 +25,10 @@ const NavigationLinkNativeView: ComponentType<NavigationLinkProps> = requireNati
  * A view that controls a navigation presentation. In a `List` it renders as a row with a
  * disclosure chevron, and tapping it pushes the matching `NavigationDestination`.
  *
+ * The link has to be inside the `NavigationStack` itself. Content presented from the stack, such
+ * as a `BottomSheet` or a `Popover`, is its own presentation context and does not reach the
+ * stack's destinations, so give that content its own `NavigationStack`.
+ *
  * @example
  * ```tsx
  * <NavigationLink value="settings">

--- a/packages/expo-ui/src/swift-ui/NavigationLink/index.tsx
+++ b/packages/expo-ui/src/swift-ui/NavigationLink/index.tsx
@@ -1,0 +1,47 @@
+import { requireNativeView } from 'expo';
+import { type ComponentType, type ReactNode } from 'react';
+
+import { createViewModifierEventListener } from '../modifiers/utils';
+import { type CommonViewModifierProps } from '../types';
+
+export interface NavigationLinkProps extends CommonViewModifierProps {
+  /**
+   * The value to append to the enclosing `NavigationStack`'s path when the link is tapped. The
+   * stack presents the `NavigationDestination` whose `value` matches.
+   */
+  value: string;
+  /**
+   * A view that describes the link.
+   */
+  children: ReactNode;
+}
+
+const NavigationLinkNativeView: ComponentType<NavigationLinkProps> = requireNativeView(
+  'ExpoUI',
+  'NavigationLinkView'
+);
+
+/**
+ * A view that controls a navigation presentation. In a `List` it renders as a row with a
+ * disclosure chevron, and tapping it pushes the matching `NavigationDestination`.
+ *
+ * @example
+ * ```tsx
+ * <NavigationLink value="settings">
+ *   <Text>Settings</Text>
+ * </NavigationLink>
+ * ```
+ *
+ * @platform ios
+ */
+export function NavigationLink(props: NavigationLinkProps) {
+  const { modifiers, children, ...restProps } = props;
+  return (
+    <NavigationLinkNativeView
+      modifiers={modifiers}
+      {...(modifiers ? createViewModifierEventListener(modifiers) : undefined)}
+      {...restProps}>
+      {children}
+    </NavigationLinkNativeView>
+  );
+}

--- a/packages/expo-ui/src/swift-ui/NavigationStack/index.tsx
+++ b/packages/expo-ui/src/swift-ui/NavigationStack/index.tsx
@@ -1,16 +1,36 @@
 import { requireNativeView } from 'expo';
+import { type ComponentType, type ReactNode } from 'react';
+import { type NativeSyntheticEvent } from 'react-native';
 
 import { createViewModifierEventListener } from '../modifiers/utils';
 import { type CommonViewModifierProps } from '../types';
 
 export interface NavigationStackProps extends CommonViewModifierProps {
   /**
-   * The root view of the stack. It is displayed inside a navigation bar.
+   * The root view of the stack, and the `NavigationDestination` views the stack can push. It is
+   * displayed inside a navigation bar.
    */
-  children: React.ReactNode;
+  children: ReactNode;
+  /**
+   * The values of the views pushed on top of the root view, in the order they were pushed.
+   * Leave it undefined to let the stack manage its own path.
+   */
+  path?: string[];
+  /**
+   * Callback function that is called when the stack pushes or pops a view, for example when a
+   * `NavigationLink` is tapped or the user swipes back. Gets called with the new path.
+   *
+   * When `path` is set, the stack is controlled: a push takes effect once the new path comes back
+   * through this prop.
+   */
+  onPathChange?: (path: string[]) => void;
 }
 
-const NavigationStackNativeView: React.ComponentType<NavigationStackProps> = requireNativeView(
+type NativeNavigationStackProps = Omit<NavigationStackProps, 'onPathChange'> & {
+  onPathChange?: (event: NativeSyntheticEvent<{ path: string[] }>) => void;
+};
+
+const NavigationStackNativeView: ComponentType<NativeNavigationStackProps> = requireNativeView(
   'ExpoUI',
   'NavigationStackView'
 );
@@ -18,15 +38,38 @@ const NavigationStackNativeView: React.ComponentType<NavigationStackProps> = req
 /**
  * A view that displays a root view and enables you to present additional views over the root view.
  *
+ * @example
+ * ```tsx
+ * const [path, setPath] = useState<string[]>([]);
+ *
+ * <NavigationStack path={path} onPathChange={setPath}>
+ *   <List>
+ *     <NavigationLink value="settings">
+ *       <Text>Settings</Text>
+ *     </NavigationLink>
+ *   </List>
+ *   <NavigationDestination value="settings">
+ *     <SettingsScreen />
+ *   </NavigationDestination>
+ * </NavigationStack>
+ * ```
+ *
  * @platform ios
  */
 export function NavigationStack(props: NavigationStackProps) {
-  const { modifiers, ...restProps } = props;
+  const { modifiers, onPathChange, ...restProps } = props;
   return (
     <NavigationStackNativeView
       modifiers={modifiers}
       {...(modifiers ? createViewModifierEventListener(modifiers) : undefined)}
       {...restProps}
+      onPathChange={
+        onPathChange
+          ? ({ nativeEvent: { path } }) => {
+              onPathChange(path);
+            }
+          : undefined
+      }
     />
   );
 }

--- a/packages/expo-ui/src/swift-ui/index.tsx
+++ b/packages/expo-ui/src/swift-ui/index.tsx
@@ -25,6 +25,8 @@ export * from './ZStack';
 export * from './Group';
 export * from './List';
 export * from './Menu';
+export * from './NavigationDestination';
+export * from './NavigationLink';
 export * from './NavigationStack';
 export * from './Picker';
 export * from './ProgressView';


### PR DESCRIPTION
# Why

Adds ability to navigate stack screens in Expo UI SwiftUI. Follow up from #49968 

# How

Added [NavigationLink](https://developer.apple.com/documentation/swiftui/navigationlink) and [navigationDestination](https://developer.apple.com/documentation/swiftui/view/navigationdestination(for:destination:)) modifier which work with `NavigationStackView` to support stack navigation.

## API

```jsx
const [path, setPath] = React.useState([]);

<NavigationStack path={path} onPathChange={setPath}>
  {/* Navigate to about. Like <Link> */}
  <NavigationLink value="about">
    <Text>About</Text>
  </NavigationLink>

   {/* About UI. Like stack.screen */}
  <NavigationDestination value="about">
     <Text modifiers={[font({ textStyle: 'headline' })]}>About screen</Text>
   </NavigationDestination>
</NavigationStack>


```

# Test Plan

Added example in NCL.

https://github.com/user-attachments/assets/5f940453-fb54-47f2-83a5-e080836b9b13



# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
