### PR TITLE
[android][ios][dev-menu] Detect QuickJS as the JavaScript engine

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [iOS] Replace dev-menu swizzling and reflection into React Native internals with public APIs. ([#47638](https://github.com/expo/expo/pull/47638) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Remove the manual packager socket reconnect now that the bundle configuration resolves the dev server host. ([#48098](https://github.com/expo/expo/pull/48098) by [@alanjhughes](https://github.com/alanjhughes))
 - Removed Quick and Nimble in favor of Swift Testing. ([#48530](https://github.com/expo/expo/pull/48530) by [@tsapeta](https://github.com/tsapeta))
+- Show QuickJS as the JavaScript engine in the dev menu on Android and iOS. ([#49994](https://github.com/expo/expo/pull/49994) by [@ammarahm-ed](https://github.com/ammarahm-ed))
 
 ## 57.0.10 - 2026-07-29
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/AppInfo.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/AppInfo.kt
@@ -59,6 +59,7 @@ object AppInfo {
     val engine = when {
       jsExecutorName.contains("Hermes") -> "Hermes"
       jsExecutorName.contains("V8") -> "V8"
+      jsExecutorName.contains("QuickJS") -> "QuickJS"
       else -> "JSC"
     }
 

--- a/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
+++ b/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
@@ -38,6 +38,8 @@
   NSString *engine;
 #if USE_HERMES
   engine = @"Hermes";
+#elif USE_QUICKJS
+  engine = @"QuickJS";
 #else
   engine = @"JSC";
 #endif


### PR DESCRIPTION
# Why

QuickJS-based applications currently appear as JSC in the Expo Dev Menu. This makes the displayed JavaScript engine inaccurate when using QuickJS. Follow up of https://github.com/expo/expo/pull/49686

# How

Updated Expo Dev Menu engine detection:

- Android recognizes `QuickJSInstance` and reports `QuickJS`.
- iOS checks the `USE_QUICKJS` compile-time flag before falling back to JSC.
- Existing Hermes and JSC detection remains unchanged.

# Test Plan

- Built the apps/bare-expo successfully on iOS and Android.
- Confirmed both platform changes are isolated to Expo Dev Menu engine detection.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
