### PR TITLE
Enhance navigation tutorial with Ionicons setup

### DIFF
--- a/docs/pages/tutorial/add-navigation.mdx
+++ b/docs/pages/tutorial/add-navigation.mdx
@@ -283,9 +283,19 @@ Right now, the bottom tab navigator looks the same on all platforms but doesn't 
 
 Modify the **src/app/(tabs)/\_layout.tsx** file to add tab bar icons:
 
-1. Import `Ionicons` icons set from [`@expo/vector-icons`](/guides/icons/#expovector-icons) — a library that includes popular icon sets.
-2. Add the `tabBarIcon` to both the `index` and `about` routes. This function takes `focused` and `color` as params and renders the icon component. From the icon set, we can provide custom icon names.
-3. Add `screenOptions.tabBarActiveTintColor` to the `Tabs` component and set its value to `#ffd33d`. This will change the color of the tab bar icon and label when active.
+1. Install the icon library by running the command for your preferred package manager:
+<Terminal
+cmd={{
+npm: ["$ npm install @expo/vector-icons --save"],
+yarn: ["$ yarn add @expo/vector-icons"],
+pnpm: ["$ pnpm add @expo/vector-icons"],
+bun: ["$ bun add @expo/vector-icons"],
+}}
+/>
+
+2. Import `Ionicons` icons set from [`@expo/vector-icons`](/guides/icons/#expovector-icons) — a library that includes popular icon sets.
+3. Add the `tabBarIcon` to both the `index` and `about` routes. This function takes `focused` and `color` as params and renders the icon component. From the icon set, we can provide custom icon names.
+4. Add `screenOptions.tabBarActiveTintColor` to the `Tabs` component and set its value to `#ffd33d`. This will change the color of the tab bar icon and label when active.
 
 {/* prettier-ignore */}
 ```tsx src/app/(tabs)/_layout.tsx


### PR DESCRIPTION
Added instructions for installing and using Ionicons in the tab navigator.

# Why

Added documentation explaining how to install `@expo/vector-icons` and use Ionicons in the tab navigator. This also includes installation commands for npm, Yarn, pnpm, and Bun.

The documentation was added because users may encounter the following error when Ionicons is not installed:

`UnableToResolveError: Unable to resolve module @expo/vector-icons/Ionicons`

# How

Added package installation instructions for all supported package managers:

* npm
* Yarn
* pnpm
* Bun

The instructions also show how to import and use `Ionicons` in the tab navigator after installing `@expo/vector-icons`.

# Test Plan

Tested the installation instructions with the supported package managers and verified that `Ionicons` can be resolved and used in the tab navigator.

The original issue was reproduced with:

`UnableToResolveError: Unable to resolve module @expo/vector-icons/Ionicons`

After installing `@expo/vector-icons`, the module resolves correctly and the tab navigator can use Ionicons without the error.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
