### PR TITLE
[image-manipulator][iOS] Fix renderAsync on 10-bit HDR images

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `renderAsync()` failing with `ERR_IMAGE_CONTEXT_LOST` on 10-bit HDR images, such as an iPhone HDR screenshot, whose pixel format has no `CGContext` equivalent. ([#50001](https://github.com/expo/expo/pull/50001) by [@LizunovSergey](https://github.com/LizunovSergey))
+
 ### 💡 Others
 
 ## 58.0.0 — 2026-09-10

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `renderAsync()` failing with `ERR_IMAGE_CONTEXT_LOST` on 10-bit HDR images, such as an iPhone HDR screenshot, whose pixel format has no `CGContext` equivalent. ([#50001](https://github.com/expo/expo/pull/50001) by [@LizunovSergey](https://github.com/LizunovSergey))
+- [iOS] Fix `renderAsync()` failing with `ERR_IMAGE_CONTEXT_LOST` on 10-bit HDR images, such as an iPhone HDR screenshot, whose pixel format has no `CGContext` equivalent. ([#50009](https://github.com/expo/expo/pull/50009) by [@LizunovSergey](https://github.com/LizunovSergey))
 
 ### 💡 Others
 

--- a/packages/expo-image-manipulator/ios/Transformers/ImageFixOrientationTransformer.swift
+++ b/packages/expo-image-manipulator/ios/Transformers/ImageFixOrientationTransformer.swift
@@ -44,15 +44,28 @@ internal struct ImageFixOrientationTransformer: ImageTransformer {
       break
     }
 
-    let context = CGContext(
-      data: nil,
-      width: Int(image.size.width),
-      height: Int(image.size.height),
-      bitsPerComponent: cgImage.bitsPerComponent,
-      bytesPerRow: 0,
-      space: colorSpace,
-      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-    )
+    func makeContext(bitsPerComponent: Int, colorSpace: CGColorSpace) -> CGContext? {
+      return CGContext(
+        data: nil,
+        width: Int(image.size.width),
+        height: Int(image.size.height),
+        bitsPerComponent: bitsPerComponent,
+        bytesPerRow: 0,
+        space: colorSpace,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    }
+
+    // A `CGContext` accepts only a fixed set of pixel formats, and a decoded image's own
+    // format is not always among them: a 10-bit HDR HEIC decodes to `bitsPerComponent == 10`,
+    // which has no context equivalent, so a file that decoded perfectly well yields no
+    // context at all. Widening to 16 keeps the image's colour space and every bit of its
+    // precision; the 8-bit device RGB last resort covers a colour space that is rejected as
+    // a drawing destination even though it reports `supportsOutput`, as the extended-range
+    // ones do.
+    let context = makeContext(bitsPerComponent: cgImage.bitsPerComponent, colorSpace: colorSpace)
+      ?? makeContext(bitsPerComponent: 16, colorSpace: colorSpace)
+      ?? makeContext(bitsPerComponent: 8, colorSpace: CGColorSpaceCreateDeviceRGB())
 
     guard let context = context else {
       throw ImageContextLostException()


### PR DESCRIPTION
# Why

Fixes #49953.

`ImageManipulator.manipulate(uri).renderAsync()` rejects with `ERR_IMAGE_CONTEXT_LOST` for a 10-bit HDR HEIC, so no manipulation of an iPhone HDR screenshot can run at all.

`ImageFixOrientationTransformer` derives its `CGContext` from the decoded image's own `bitsPerComponent`. A `CGContext` accepts only a fixed set of pixel formats, and a 10-bit HDR image is not one of them, so the initializer returns nil and the `guard` throws — on a file that decoded perfectly well.

I ran the exact sample linked in the issue ([matrix4.HEIC](https://github.com/user-attachments/files/21392852/matrix4.HEIC.zip)) through `CGImageSourceCreateImageAtIndex` and then through the transformer's own context construction:

```
decoded HEIC:
  size                = 2752 x 2064
  bitsPerComponent    = 10
  bitsPerPixel        = 32
  colorSpace          = kCGColorSpaceDisplayP3
  supportsOutput      = true

current code -> CGContext is nil  => throws ImageContextLostException
```

Two things that narrows down:

- The colour space is ordinary Display P3 and reports `supportsOutput == true`, so the existing `if !colorSpace.supportsOutput` fallback never fires and is not what is missing here. The sole cause is the bit depth.
- Probing the initializer directly, `premultipliedLast` is accepted at 8 and 16 bits per component and rejected at 10 and 32. 10 is exactly what this file decodes to.

# How

The context now widens to a depth a context does accept, instead of insisting on the image's own:

```swift
let context = makeContext(bitsPerComponent: cgImage.bitsPerComponent, colorSpace: colorSpace)
  ?? makeContext(bitsPerComponent: 16, colorSpace: colorSpace)
  ?? makeContext(bitsPerComponent: 8, colorSpace: CGColorSpaceCreateDeviceRGB())
```

Widening to 16 rather than dropping to 8 is deliberate: 10 bits fit in 16, so the retry keeps the image's colour space **and** loses no precision. Only if that is refused too does it fall back to 8-bit device RGB — which covers the other way this exception can be reached, a colour space that reports `supportsOutput` but is still rejected as a drawing destination. `kCGColorSpaceExtendedLinearSRGB` behaves exactly that way, so the current `supportsOutput` check does not catch it.

An image whose own format is already accepted takes the first branch, unchanged.

# Test Plan

Verified against the reporter's own file, with the same selection chain that is now in the source:

```
fixed: context ok, drew, produced 2752x2064 at 16bpc, colour space kCGColorSpaceDisplayP3
ordinary 8-bit sRGB still takes the first branch: true at 8bpc
```

So the HDR screenshot now produces an image instead of throwing, the wide-gamut colour space survives the round trip, and an ordinary 8-bit sRGB image still resolves on the first attempt — the existing path is untouched.

What I did **not** do: I did not run the reproduction app end to end on a simulator, so `renderAsync()` → `saveAsync()` returning a JPEG is inferred from the transformer no longer throwing, not observed. The failing call is the one measured above, and it is measured with the exact file from the issue rather than a synthetic stand-in.
