### PR TITLE
[widgets][Android] Pin work-runtime-ktx past the copy Glance requests

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [iOS] Preserve SwiftUI view identity across widget and Live Activity updates so system update animations can run. ([#49810](https://github.com/expo/expo/pull/49810) by [@jakex7](https://github.com/jakex7))
 - [Android] Fix Gradle build failure when no Android widget is configured. ([#50038](https://github.com/expo/expo/pull/50038) by [@keith-kurak](https://github.com/keith-kurak))
+- [Android] Fix a release build failing `checkReleaseDuplicateClasses` when another dependency brings WorkManager 2.8 or newer, by pinning `work-runtime-ktx` forward from the 2.7.1 that Glance requests. ([#50010](https://github.com/expo/expo/pull/50010) by [@LizunovSergey](https://github.com/LizunovSergey))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/android/build.gradle
+++ b/packages/expo-widgets/android/build.gradle
@@ -145,4 +145,10 @@ dependencies {
   implementation expoModule.getExpoDependency("expo-ui")
   api 'io.github.jakex7.peek:peek-emittables:0.2.0'
   implementation "androidx.glance:glance:1.2.0-rc01"
+  // Glance asks for work-runtime-ktx 2.7.1, which still carries the Kotlin extensions.
+  // WorkManager 2.8.0 moved those into work-runtime and left the ktx artifact empty, so
+  // as soon as anything in the graph pulls work-runtime 2.8+ the two ship the same
+  // classes and the release duplicate-class check fails. Pinning ktx forward, to the
+  // version expo-background-task and expo-observe already use, keeps it the empty shim.
+  implementation 'androidx.work:work-runtime-ktx:2.9.1'
 }


### PR DESCRIPTION
# Why

Fixes #49890.

A release build of any app combining `expo-widgets` with something that brings WorkManager 2.8+ fails:

```
Duplicate class androidx.work.OneTimeWorkRequestKt found in modules
  work-runtime-2.8.1.aar (androidx.work:work-runtime:2.8.1) and
  work-runtime-ktx-2.7.1.aar (androidx.work:work-runtime-ktx:2.7.1)
```

`androidx.glance` depends on `androidx.work:work-runtime-ktx:2.7.1`. Nothing else in a typical graph asks for the ktx artifact, so Gradle resolves `work-runtime` forward to 2.8+ and leaves `work-runtime-ktx` behind at 2.7.1. Both then contain the same classes.

I unpacked the artifacts rather than taking the release notes' word for it:

| artifact | classes | carries `OneTimeWorkRequestKt` / `PeriodicWorkRequestKt` |
| --- | --- | --- |
| `work-runtime-ktx:2.7.1` | 15 | yes |
| `work-runtime-ktx:2.9.1` | 0 | no |
| `work-runtime:2.9.1` | — | yes |

So WorkManager 2.8.0 really did move the Kotlin extensions into `work-runtime` and leave the ktx artifact empty, and the collision is exactly old-ktx against new-runtime.

**One correction to the issue:** bumping Glance does not fix this. `androidx.glance:glance:1.2.0` stable is available, and its POM requests the same `work-runtime-ktx:2.7.1` as `1.2.0-rc01` — I diffed both POMs. The pin has to move on the WorkManager side.

# How

Pin `work-runtime-ktx` forward in `expo-widgets`, to the version that is an empty shim:

```gradle
implementation 'androidx.work:work-runtime-ktx:2.9.1'
```

2.9.1 rather than an arbitrary newer one because `expo-background-task` and `expo-observe` already declare exactly that coordinate and version, so this adds no new version to the graph and stays consistent with the rest of the repo. The extensions themselves are not lost — they come from `work-runtime`, which resolves forward on its own.

I left `androidx.glance` on `1.2.0-rc01`. Moving it to stable is worth doing, but it is a separate change that does not affect this bug, and bundling it would muddy the fix.

# Test Plan

Evidence is the artifact contents above, obtained by downloading each `.aar` from `dl.google.com` and listing `classes.jar`: 2.7.1 has the two classes named in the error, 2.9.1 has no classes at all, and `work-runtime` supplies them from 2.8 onward. With ktx resolving to 2.9.1 there is no second copy for `checkReleaseDuplicateClasses` to find.

What I did **not** do: I did not run `./gradlew :app:checkReleaseDuplicateClasses` against the reproduction. The check compares classes across resolved artifacts, and the table above is the input it compares, but a maintainer running the repro would turn this from a dependency-graph argument into an observed green build. The repro in the issue is a blank SDK 57 app plus `expo-widgets` and `react-native-android-widget`.
