### PR TITLE
[router] Mock react-native-worklets in testing-library so gesture-handler loads in Jest

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Mock `react-native-worklets` in `expo-router/testing-library` so `react-native-gesture-handler` and `react-native-reanimated` load in Jest. ([#50013](https://github.com/expo/expo/pull/50013) by [@brentvatne](https://github.com/brentvatne))
+
 ### 💡 Others
 
 ## 58.0.0 — 2026-09-10

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -324,6 +324,7 @@
     "react-native-screens": "^4.27.0",
     "react-native-tab-view": "^4.3.0",
     "react-native-web": "~0.21.0",
+    "react-native-worklets": "0.12.2",
     "react-server-dom-webpack": "~19.0.8"
   },
   "peerDependencies": {
@@ -343,6 +344,7 @@
     "react-native-safe-area-context": ">= 5.4.0",
     "react-native-screens": "^4.27.0",
     "react-native-web": "*",
+    "react-native-worklets": "*",
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },
   "peerDependenciesMeta": {
@@ -365,6 +367,9 @@
       "optional": true
     },
     "react-native-web": {
+      "optional": true
+    },
+    "react-native-worklets": {
       "optional": true
     },
     "react-server-dom-webpack": {

--- a/packages/expo-router/src/testing-library/__tests__/mocks.test.native.tsx
+++ b/packages/expo-router/src/testing-library/__tests__/mocks.test.native.tsx
@@ -1,0 +1,7 @@
+// `react-native-gesture-handler` reads `react-native-reanimated` at import time to build its
+// Reanimated-backed gesture detectors. If the testing-library mocks leave Reanimated (or the
+// `react-native-worklets` module it depends on) in a broken state, every suite that renders a
+// Drawer or JS stack fails at import with "Cannot read properties of undefined".
+it('lets react-native-gesture-handler load under the testing-library mocks', () => {
+  expect(() => require('react-native-gesture-handler')).not.toThrow();
+});

--- a/packages/expo-router/src/testing-library/mocks.ts
+++ b/packages/expo-router/src/testing-library/mocks.ts
@@ -2,6 +2,15 @@ try {
   require('react-native-gesture-handler/jestSetup');
 } catch {}
 
+// `react-native-reanimated/mock` imports the real Reanimated entry point, which loads
+// `react-native-worklets`. Its native module throws when constructed under Jest, so mock worklets
+// first with the mock the package ships. Otherwise the fallback below returns an empty object and
+// `react-native-gesture-handler` crashes reading `default.createAnimatedComponent` from it.
+try {
+  require.resolve('react-native-worklets');
+  jest.mock('react-native-worklets', () => require('react-native-worklets/src/mock'));
+} catch {}
+
 try {
   require('react-native-reanimated');
   jest.mock('react-native-reanimated', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5682,6 +5682,9 @@ importers:
       react-native-web:
         specifier: ~0.21.0
         version: 0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-native-worklets:
+        specifier: 0.12.2
+        version: 0.12.2(patch_hash=0e7ca08ddb565252ea4479e4bb493c5c09756297ba0ec8845126edcfcc981b28)(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(react-native@0.87.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-server-dom-webpack:
         specifier: ~19.0.8
         version: 19.0.8(patch_hash=ba3362195bbec23b932749a969f0231184584999e30a5859dae27748b974c24a)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))


### PR DESCRIPTION
# Why

The `check-packages` job on `main` started failing after the SDK 58 vendored-module bump (#49968): https://github.com/expo/expo/actions/runs/34538474679/job/103075447235. Every expo-router suite that renders a Drawer or JS stack died at import with:

```
TypeError: Cannot read properties of undefined (reading 'createAnimatedComponent')
    at react-native-gesture-handler/src/v3/detectors/ReanimatedNativeDetector.tsx:94:24
```

Reanimated 4.6's Jest mock (`react-native-reanimated/mock`) imports the real Reanimated entry point, which loads `react-native-worklets`. The worklets native module throws when constructed under Jest, so `expo-router/testing-library`'s mock setup swallowed the error and fell back to an empty object. Gesture-handler 3.2 then crashed reading `Reanimated.default.createAnimatedComponent` from that empty object.

# How

- Mock `react-native-worklets` with the mock it ships (`react-native-worklets/src/mock`, per the worklets Jest guide) before setting up the reanimated mock in `src/testing-library/mocks.ts`.
- Declare `react-native-worklets` as a devDependency and optional peer of expo-router, mirroring `@expo/ui`, so the mock path resolves under pnpm and in user projects that use `expo-router/testing-library`.
- Add a native-only regression test that asserts requiring `react-native-gesture-handler` under the testing-library mocks does not throw. It fails without the fix and passes with it.

Two pre-existing gaps are left alone since they are outside this failure: on native Jest projects the reanimated mock still does not fully load with 4.6.0 (`setCSSEventHandler is not available in JSReanimated`; upstream fixes this with `react-native-reanimated/jest/resolver`, which 4.6.0 does not ship), and on web it hits jsdom's missing `window.matchMedia`. Neither affects gesture-handler, which finds `NativeEventsManager` through a subpath require.

# Test Plan

- `et check-packages expo-router` passes (build, typecheck, lint, all 7 Jest projects).
- The new test in `src/testing-library/__tests__/mocks.test.native.tsx` fails with the mocks change reverted and passes with it.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyX7hV27SWSVgbKE3n1nLn
