### PR TITLE
[ios][precompile] Keep unit tests out of prebuilt frameworks

### DIFF
--- a/packages/precompile/README.md
+++ b/packages/precompile/README.md
@@ -447,7 +447,7 @@ Version specifiers: `{ "exact": "4.5.0" }`, `{ "from": "4.0.0" }`, `{ "branch": 
 | `path`               | string          | Source path relative to package root               |
 | `pattern`            | string          | Glob pattern for source files                      |
 | `headerPattern`      | string          | Glob pattern for header files (objc/cpp only)      |
-| `exclude`            | array           | Paths to exclude from sources                      |
+| `exclude`            | array           | Paths to exclude from sources. `**/Tests/**` is always excluded, and generated `.swiftinterface` files are rejected if they import test-only modules such as `Testing` |
 | `dependencies`       | array           | Target dependencies                                |
 | `linkedFrameworks`   | array           | System frameworks to link                          |
 | `includeDirectories` | array           | Header search paths (objc/cpp only, default: `["include"]`) |

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -20,6 +20,7 @@ import { BuiltFramework } from './SPMBuild.types';
 import { BuildPlatform, SPMConfig, SPMProduct } from './SPMConfig.types';
 import { SPMGenerator } from './SPMGenerator';
 import { assertSafeSPMIdentifier } from './SPMIdentifier';
+import { findTestOnlyImports } from './SwiftInterfaceChecks';
 import { createAsyncSpinner, SpinnerError } from './Utils';
 import { spawnXcodeBuildWithSpinner } from './XCodeRunner';
 
@@ -1308,6 +1309,19 @@ const copySwiftModuleInterfacesAsync = async (
     // Post-process .swiftinterface files to fix internal module references
     if (file.endsWith('.swiftinterface')) {
       await fixSwiftInterfaceModuleReferencesAsync(destFile, spmConfig);
+
+      const testOnlyImports = findTestOnlyImports(await fs.readFile(destFile, 'utf8'));
+      if (testOnlyImports.length > 0) {
+        spinner.fail(`Test-only imports in ${product.name}.swiftinterface (${slice})`);
+        throw new Error(
+          `The ${product.name}.swiftinterface for slice ${slice} imports test-only modules ` +
+            `(${testOnlyImports.join(', ')}), so every app linking this prebuilt framework would fail ` +
+            `with "unable to resolve module dependency: Testing". Unit tests were compiled into the ` +
+            `framework — usually a \`Tests/\` directory outside the pipeline's default exclusion, or a ` +
+            `non-test source importing Testing. Move test sources under \`Tests/\`, or add the directory ` +
+            `to the target's \`exclude\` in spm.config.json, then rebuild.`
+        );
+      }
     }
   }
 

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -20,7 +20,6 @@ import { BuiltFramework } from './SPMBuild.types';
 import { BuildPlatform, SPMConfig, SPMProduct } from './SPMConfig.types';
 import { SPMGenerator } from './SPMGenerator';
 import { assertSafeSPMIdentifier } from './SPMIdentifier';
-import { findTestOnlyImports } from './SwiftInterfaceChecks';
 import { createAsyncSpinner, SpinnerError } from './Utils';
 import { spawnXcodeBuildWithSpinner } from './XCodeRunner';
 
@@ -1309,19 +1308,6 @@ const copySwiftModuleInterfacesAsync = async (
     // Post-process .swiftinterface files to fix internal module references
     if (file.endsWith('.swiftinterface')) {
       await fixSwiftInterfaceModuleReferencesAsync(destFile, spmConfig);
-
-      const testOnlyImports = findTestOnlyImports(await fs.readFile(destFile, 'utf8'));
-      if (testOnlyImports.length > 0) {
-        spinner.fail(`Test-only imports in ${product.name}.swiftinterface (${slice})`);
-        throw new Error(
-          `The ${product.name}.swiftinterface for slice ${slice} imports test-only modules ` +
-            `(${testOnlyImports.join(', ')}), so every app linking this prebuilt framework would fail ` +
-            `with "unable to resolve module dependency: Testing". Unit tests were compiled into the ` +
-            `framework — usually a \`Tests/\` directory outside the pipeline's default exclusion, or a ` +
-            `non-test source importing Testing. Move test sources under \`Tests/\`, or add the directory ` +
-            `to the target's \`exclude\` in spm.config.json, then rebuild.`
-        );
-      }
     }
   }
 

--- a/tools/src/prebuilds/SPMConfig.types.ts
+++ b/tools/src/prebuilds/SPMConfig.types.ts
@@ -91,7 +91,9 @@ export interface SourceTarget {
   headerPattern?: string;
   /** Names of other targets this target depends on */
   dependencies?: string[];
-  /** Paths to exclude from compilation */
+  /** Paths to exclude from compilation. Any `Tests` directory is always excluded (glob
+   * `**\/Tests\/**`), and the generated `.swiftinterface` files are checked for test-only
+   * imports such as `Testing`. */
   exclude?: string[];
   /** Header search paths relative to the target path */
   includeDirectories?: string[];

--- a/tools/src/prebuilds/SPMGenerator.testExclusion.test.ts
+++ b/tools/src/prebuilds/SPMGenerator.testExclusion.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import path from 'path';
 
 import { getExpoRepositoryRootDir } from '../Directories';
+import type { SPMConfig } from './SPMConfig.types';
 import { getTargetExcludePatterns } from './SPMGenerator';
 
 describe('getTargetExcludePatterns', () => {
@@ -46,14 +47,10 @@ describe('getTargetExcludePatterns', () => {
 describe('expo-camera source selection', () => {
   it('excludes ios/Tests even though spm.config.json does not list it', async () => {
     const packagePath = path.join(getExpoRepositoryRootDir(), 'packages/expo-camera');
-    const config = await fs.readJson(path.join(packagePath, 'spm.config.json'));
-    const product = config.products.find(
-      (candidate: { name: string }) => candidate.name === 'ExpoCamera'
-    );
+    const config: SPMConfig = await fs.readJson(path.join(packagePath, 'spm.config.json'));
+    const product = config.products.find(({ name }) => name === 'ExpoCamera');
     assert.ok(product, 'expo-camera must declare an ExpoCamera product');
-    const target = product.targets.find(
-      (candidate: { type: string }) => candidate.type === 'swift'
-    );
+    const target = product.targets.find((candidate) => candidate.type === 'swift');
     assert.ok(target, 'expo-camera must declare a Swift target');
     assert.ok(
       !(target.exclude ?? []).includes('Tests/**'),

--- a/tools/src/prebuilds/SPMGenerator.testExclusion.test.ts
+++ b/tools/src/prebuilds/SPMGenerator.testExclusion.test.ts
@@ -1,0 +1,74 @@
+import fs from 'fs-extra';
+import { glob } from 'glob';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import { describe, it } from 'node:test';
+import path from 'path';
+
+import { getExpoRepositoryRootDir } from '../Directories';
+import { getTargetExcludePatterns } from './SPMGenerator';
+
+describe('getTargetExcludePatterns', () => {
+  it('appends the default test exclusion to the target excludes', () => {
+    assert.deepEqual(getTargetExcludePatterns({ exclude: ['barcode-scanning/**'] }), [
+      'barcode-scanning/**',
+      '**/Tests/**',
+    ]);
+  });
+
+  it('excludes tests for a target without any excludes', () => {
+    assert.deepEqual(getTargetExcludePatterns({}), ['**/Tests/**']);
+  });
+
+  it('keeps unit test sources out of a globbed source tree', async () => {
+    const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spm-test-exclusion-'));
+    try {
+      await fs.outputFile(path.join(sourceDir, 'Foo.swift'), 'struct Foo {}');
+      await fs.outputFile(path.join(sourceDir, 'Tests', 'FooTests.swift'), 'import Testing');
+      await fs.outputFile(path.join(sourceDir, 'Nested', 'Bar.swift'), 'struct Bar {}');
+      await fs.outputFile(
+        path.join(sourceDir, 'Nested', 'Tests', 'BarTests.swift'),
+        'import Testing'
+      );
+
+      const files = await glob('**/*.swift', {
+        cwd: sourceDir,
+        ignore: getTargetExcludePatterns({}),
+      });
+
+      assert.deepEqual(files.sort(), ['Foo.swift', 'Nested/Bar.swift']);
+    } finally {
+      await fs.remove(sourceDir);
+    }
+  });
+});
+
+describe('expo-camera source selection', () => {
+  it('excludes ios/Tests even though spm.config.json does not list it', async () => {
+    const packagePath = path.join(getExpoRepositoryRootDir(), 'packages/expo-camera');
+    const config = await fs.readJson(path.join(packagePath, 'spm.config.json'));
+    const product = config.products.find(
+      (candidate: { name: string }) => candidate.name === 'ExpoCamera'
+    );
+    assert.ok(product, 'expo-camera must declare an ExpoCamera product');
+    const target = product.targets.find(
+      (candidate: { type: string }) => candidate.type === 'swift'
+    );
+    assert.ok(target, 'expo-camera must declare a Swift target');
+    assert.ok(
+      !(target.exclude ?? []).includes('Tests/**'),
+      'this regression test is pointless once the config excludes tests itself'
+    );
+
+    const files = await glob(target.pattern ?? '**/*.swift', {
+      cwd: path.join(packagePath, target.path),
+      ignore: getTargetExcludePatterns(target),
+    });
+
+    assert.deepEqual(
+      files.filter((file) => file.startsWith('Tests/')),
+      []
+    );
+    assert.ok(files.length > 0, 'expo-camera must still contribute Swift sources');
+  });
+});

--- a/tools/src/prebuilds/SPMGenerator.ts
+++ b/tools/src/prebuilds/SPMGenerator.ts
@@ -7,7 +7,7 @@ import logger from '../Logger';
 import type { DownloadedDependencies } from './Artifacts.types';
 import type { SPMPackageSource } from './ExternalPackage';
 import { BuildFlavor } from './Prebuilder.types';
-import { SPMProduct, SPMTarget } from './SPMConfig.types';
+import { SourceTarget, SPMProduct, SPMTarget } from './SPMConfig.types';
 import { SPMPackage } from './SPMPackage';
 import { createAsyncSpinner, hasFileContentChanged } from './Utils';
 
@@ -51,6 +51,14 @@ function writeFileIfChanged(filePath: string, content: string): boolean {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, content, 'utf-8');
   return true;
+}
+
+/**
+ * Unit tests are always kept out of prebuilt frameworks: compiling them in leaks
+ * `import Testing` into the shipped `.swiftinterface`, which no consumer app can resolve.
+ */
+export function getTargetExcludePatterns(target: Pick<SourceTarget, 'exclude'>): string[] {
+  return [...(target.exclude ?? []), '**/Tests/**'];
 }
 
 export const SPMGenerator = {
@@ -123,7 +131,7 @@ export const SPMGenerator = {
         : target.path;
       const targetSourcePath = path.resolve(targetRoot, resolvedTargetPath);
 
-      const targetExcludes = target.exclude || [];
+      const targetExcludes = getTargetExcludePatterns(target);
       const pattern =
         target.pattern ??
         (target.type === 'cpp'

--- a/tools/src/prebuilds/SwiftInterfaceChecks.test.ts
+++ b/tools/src/prebuilds/SwiftInterfaceChecks.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { findTestOnlyImports } from './SwiftInterfaceChecks';
+
+describe('findTestOnlyImports', () => {
+  it('reports every test-only module imported by the interface', () => {
+    const contents = [
+      '// swift-interface-format-version: 1.0',
+      'import AVFoundation',
+      'import Foundation',
+      'import Testing',
+      '@_exported import ExpoCamera',
+      'import UIKit',
+      'import _Testing_CoreGraphics',
+      'import _Testing_Foundation',
+      'import _Testing_UIKit',
+      'import _Concurrency',
+    ].join('\n');
+
+    assert.deepEqual(findTestOnlyImports(contents), [
+      'Testing',
+      '_Testing_CoreGraphics',
+      '_Testing_Foundation',
+      '_Testing_UIKit',
+    ]);
+  });
+
+  it('reports indented and @testable imports', () => {
+    assert.deepEqual(findTestOnlyImports('  @testable import Testing\n'), ['Testing']);
+  });
+
+  it('reports imports carrying attributes or an access modifier', () => {
+    const contents = [
+      '@_exported @preconcurrency import Testing',
+      '@_implementationOnly import _Testing_Foundation',
+      'public import Testing',
+      '@_spi(Experimental) import Testing',
+    ].join('\n');
+
+    assert.deepEqual(findTestOnlyImports(contents), ['Testing', '_Testing_Foundation']);
+  });
+
+  it('returns nothing for an interface without test imports', () => {
+    const contents = ['import Foundation', '@_exported @preconcurrency import UIKit'].join('\n');
+    assert.deepEqual(findTestOnlyImports(contents), []);
+  });
+
+  it('does not match modules that merely start with Testing', () => {
+    assert.deepEqual(findTestOnlyImports('import TestingUtils\n'), []);
+  });
+
+  it('does not match imports inside comments', () => {
+    assert.deepEqual(findTestOnlyImports('// import Testing\n'), []);
+  });
+});

--- a/tools/src/prebuilds/SwiftInterfaceChecks.test.ts
+++ b/tools/src/prebuilds/SwiftInterfaceChecks.test.ts
@@ -1,7 +1,18 @@
+import fs from 'fs-extra';
 import assert from 'node:assert/strict';
+import os from 'node:os';
 import { describe, it } from 'node:test';
+import path from 'path';
 
-import { findTestOnlyImports } from './SwiftInterfaceChecks';
+import { findTestOnlyImports, verifyNoTestOnlyImports } from './SwiftInterfaceChecks';
+
+async function createFrameworkFixture(interfaces: Record<string, string>): Promise<string> {
+  const frameworkPath = await fs.mkdtemp(path.join(os.tmpdir(), 'swiftinterface-checks-'));
+  for (const [relativePath, contents] of Object.entries(interfaces)) {
+    await fs.outputFile(path.join(frameworkPath, relativePath), contents);
+  }
+  return frameworkPath;
+}
 
 describe('findTestOnlyImports', () => {
   it('reports every test-only module imported by the interface', () => {
@@ -52,5 +63,51 @@ describe('findTestOnlyImports', () => {
 
   it('does not match imports inside comments', () => {
     assert.deepEqual(findTestOnlyImports('// import Testing\n'), []);
+  });
+});
+
+describe('verifyNoTestOnlyImports', () => {
+  it('fails and names the interface and its test-only modules', async () => {
+    const frameworkPath = await createFrameworkFixture({
+      'Modules/Foo.swiftmodule/arm64-apple-ios.private.swiftinterface': [
+        'import Foundation',
+        'import Testing',
+        'import _Testing_UIKit',
+      ].join('\n'),
+    });
+    try {
+      const result = verifyNoTestOnlyImports(frameworkPath);
+
+      assert.equal(result.success, false);
+      assert.match(result.message, /arm64-apple-ios\.private\.swiftinterface/);
+      assert.match(result.message, /Testing/);
+      assert.match(result.message, /_Testing_UIKit/);
+      assert.ok(result.details, 'a failure must explain how to fix it');
+    } finally {
+      await fs.remove(frameworkPath);
+    }
+  });
+
+  it('succeeds for an interface without test-only imports', async () => {
+    const frameworkPath = await createFrameworkFixture({
+      'Modules/Foo.swiftmodule/arm64-apple-ios.swiftinterface': 'import Foundation\n',
+    });
+    try {
+      assert.deepEqual(verifyNoTestOnlyImports(frameworkPath), {
+        success: true,
+        message: 'No test-only imports',
+      });
+    } finally {
+      await fs.remove(frameworkPath);
+    }
+  });
+
+  it('succeeds for an ObjC-only framework without a Modules directory', async () => {
+    const frameworkPath = await createFrameworkFixture({ 'Headers/Foo.h': '' });
+    try {
+      assert.equal(verifyNoTestOnlyImports(frameworkPath).success, true);
+    } finally {
+      await fs.remove(frameworkPath);
+    }
   });
 });

--- a/tools/src/prebuilds/SwiftInterfaceChecks.ts
+++ b/tools/src/prebuilds/SwiftInterfaceChecks.ts
@@ -1,3 +1,8 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import type { XCFrameworkVerificationResult } from './Verifier.types';
+
 /**
  * Swift Testing modules ship with the toolchain, not with the SDK, so an app that links a
  * prebuilt framework cannot resolve them. Any of them reaching a shipped `.swiftinterface`
@@ -5,6 +10,12 @@
  */
 const TEST_ONLY_IMPORT_REGEX =
   /^[ \t]*(?:@\w+(?:\([^)]*\))?[ \t]+)*(?:public|package|internal)?[ \t]*import[ \t]+(Testing|_Testing_\w+)\b/;
+
+const HOW_TO_FIX =
+  'Unit tests were compiled into the framework: a test directory not named `Tests` ' +
+  '(for example `Test/`, `tests/`, `UnitTests/`), or a non-test source that imports Testing. ' +
+  'Move test sources under `Tests/`, or add the directory to the target’s `exclude` in ' +
+  'spm.config.json, then rebuild.';
 
 /**
  * Returns the test-only modules imported by a `.swiftinterface`, in order of first appearance.
@@ -18,4 +29,52 @@ export function findTestOnlyImports(interfaceContents: string): string[] {
     }
   }
   return [...modules];
+}
+
+/**
+ * Checks every `.swiftinterface` inside a built `.framework` for test-only imports. Apps linking
+ * the framework cannot resolve those modules, so shipping one breaks every consumer's build.
+ */
+export function verifyNoTestOnlyImports(frameworkPath: string): XCFrameworkVerificationResult {
+  const modules = new Map<string, string[]>();
+
+  for (const interfacePath of findSwiftInterfaces(frameworkPath)) {
+    const testOnlyImports = findTestOnlyImports(fs.readFileSync(interfacePath, 'utf8'));
+    if (testOnlyImports.length > 0) {
+      modules.set(path.basename(interfacePath), testOnlyImports);
+    }
+  }
+
+  if (modules.size === 0) {
+    return { success: true, message: 'No test-only imports' };
+  }
+
+  const interfaceNames = [...modules.keys()].join(', ');
+  const importedModules = [...new Set([...modules.values()].flat())].join(', ');
+  return {
+    success: false,
+    message: `Test-only imports in ${interfaceNames}: ${importedModules}`,
+    details:
+      `${interfaceNames} imports test-only modules (${importedModules}), so every app linking ` +
+      `this prebuilt framework would fail with "unable to resolve module dependency: Testing". ` +
+      HOW_TO_FIX,
+  };
+}
+
+function findSwiftInterfaces(frameworkPath: string): string[] {
+  const modulesPath = path.join(frameworkPath, 'Modules');
+  if (!fs.existsSync(modulesPath)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(modulesPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.endsWith('.swiftmodule'))
+    .flatMap((swiftModule) => {
+      const swiftModulePath = path.join(modulesPath, swiftModule.name);
+      return fs
+        .readdirSync(swiftModulePath)
+        .filter((file) => file.endsWith('.swiftinterface'))
+        .map((file) => path.join(swiftModulePath, file));
+    });
 }

--- a/tools/src/prebuilds/SwiftInterfaceChecks.ts
+++ b/tools/src/prebuilds/SwiftInterfaceChecks.ts
@@ -1,0 +1,21 @@
+/**
+ * Swift Testing modules ship with the toolchain, not with the SDK, so an app that links a
+ * prebuilt framework cannot resolve them. Any of them reaching a shipped `.swiftinterface`
+ * means unit tests were compiled into the framework.
+ */
+const TEST_ONLY_IMPORT_REGEX =
+  /^[ \t]*(?:@\w+(?:\([^)]*\))?[ \t]+)*(?:public|package|internal)?[ \t]*import[ \t]+(Testing|_Testing_\w+)\b/;
+
+/**
+ * Returns the test-only modules imported by a `.swiftinterface`, in order of first appearance.
+ */
+export function findTestOnlyImports(interfaceContents: string): string[] {
+  const modules = new Set<string>();
+  for (const line of interfaceContents.split('\n')) {
+    const match = line.match(TEST_ONLY_IMPORT_REGEX);
+    if (match) {
+      modules.add(match[1]);
+    }
+  }
+  return [...modules];
+}

--- a/tools/src/prebuilds/Verifier.ts
+++ b/tools/src/prebuilds/Verifier.ts
@@ -12,6 +12,7 @@ import { Frameworks } from './Frameworks';
 import { getPackageLocalBuildPath, usesPackageLocalBuildPath } from './PackageLocalBuild';
 import { BuildFlavor } from './Prebuilder.types';
 import { SPMProduct } from './SPMConfig.types';
+import { verifyNoTestOnlyImports } from './SwiftInterfaceChecks';
 import { AsyncSpinner, createAsyncSpinner } from './Utils';
 import type {
   XCFrameworkVerificationResult,
@@ -74,6 +75,9 @@ export const FrameworkVerifier = {
           if (!slice.swiftInterfaceTypecheck.success) {
             failures.push(`Swift typecheck failed (${slice.sliceId})`);
           }
+          if (!slice.testOnlyImports.success) {
+            failures.push(`Test-only imports (${slice.sliceId})`);
+          }
           if (!slice.dsymPresent.success) {
             failures.push(`dSYM missing (${slice.sliceId})`);
           }
@@ -120,6 +124,18 @@ export const FrameworkVerifier = {
             logger.log(
               chalk.gray(
                 slice.swiftInterfaceTypecheck.details
+                  .split('\n')
+                  .slice(0, 10)
+                  .map((l) => `        ${l}`)
+                  .join('\n')
+              )
+            );
+          }
+          if (!slice.testOnlyImports.success && slice.testOnlyImports.details) {
+            logger.log(chalk.gray(`      Test-only imports (${slice.sliceId}):`));
+            logger.log(
+              chalk.gray(
+                slice.testOnlyImports.details
                   .split('\n')
                   .slice(0, 10)
                   .map((l) => `        ${l}`)
@@ -1366,7 +1382,8 @@ const verifyAsync = async (
     (r) =>
       !r.modulesPresent.success ||
       !r.modularHeadersValid.success ||
-      !r.swiftInterfaceTypecheck.success
+      !r.swiftInterfaceTypecheck.success ||
+      !r.testOnlyImports.success
   );
 
   return {
@@ -1484,6 +1501,7 @@ const collectSliceIssues = (report: XCFrameworkSliceVerificationReport): string[
   if (!report.modularHeadersValid.success) issues.push('non-modular-headers');
   if (!report.clangModuleImport.success) issues.push('clang');
   if (!report.swiftInterfaceTypecheck.success) issues.push('swift');
+  if (!report.testOnlyImports.success) issues.push('test-only-imports');
   if (!report.dsymPresent.success) issues.push('dsym-missing');
   if (!report.dsymUuidMatch.success) issues.push('dsym-uuid-mismatch');
   if (!report.dsymDebugPrefixMapping.success) issues.push('dsym-bad-paths');
@@ -1550,6 +1568,8 @@ const verifySlice = async (
     );
   }
 
+  const testOnlyImports = verifyNoTestOnlyImports(slice.frameworkPath);
+
   // dSYM verification: presence, UUID match, and debug prefix mapping
   let dsymPresent: XCFrameworkVerificationResult = { success: true, message: 'Skipped' };
   let dsymUuidMatch: XCFrameworkVerificationResult = { success: true, message: 'Skipped' };
@@ -1577,6 +1597,7 @@ const verifySlice = async (
     modularHeadersValid,
     clangModuleImport,
     swiftInterfaceTypecheck,
+    testOnlyImports,
     dsymPresent,
     dsymUuidMatch,
     dsymDebugPrefixMapping,

--- a/tools/src/prebuilds/Verifier.types.ts
+++ b/tools/src/prebuilds/Verifier.types.ts
@@ -46,6 +46,8 @@ export interface XCFrameworkSliceVerificationReport {
   modularHeadersValid: XCFrameworkVerificationResult;
   clangModuleImport: XCFrameworkVerificationResult;
   swiftInterfaceTypecheck: XCFrameworkVerificationResult;
+  /** Whether the shipped swiftinterfaces are free of test-only imports (Swift Testing) */
+  testOnlyImports: XCFrameworkVerificationResult;
   /** Whether a matching dSYM bundle exists for this slice */
   dsymPresent: XCFrameworkVerificationResult;
   /** Whether dSYM UUIDs match the framework binary UUIDs */

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -26,6 +26,7 @@ import { withPackageLocalBuildPath } from '../PackageLocalBuild';
 import type { BuildFlavor } from '../Prebuilder.types';
 import { buildSharedSPMDependencyAsync } from '../SPMBuild';
 import type { SPMPackageDependencyConfig, SPMProduct, SPMTarget } from '../SPMConfig.types';
+import { getTargetExcludePatterns } from '../SPMGenerator';
 import {
   getVersionsInfoAsync,
   setForceNonInteractive,
@@ -301,7 +302,7 @@ function collectTargetInputPaths(pkg: SPMPackageSource, target: SPMTarget): stri
   return glob
     .sync('**/*', {
       cwd: targetSourcePath,
-      ignore: target.exclude ?? [],
+      ignore: getTargetExcludePatterns(target),
       nodir: true,
     })
     .map((file) => path.join(targetSourcePath, file));

--- a/tools/src/prebuilds/schemas/spm.config.schema.json
+++ b/tools/src/prebuilds/schemas/spm.config.schema.json
@@ -332,7 +332,7 @@
                 "exclude": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Paths to exclude from compilation",
+                    "description": "Paths to exclude from compilation. Any `Tests` directory is always excluded, and generated swiftinterfaces are rejected if they import test-only modules.",
                     "default": [ ]
                 },
                 "includeDirectories": {
@@ -419,7 +419,7 @@
                 "exclude": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Paths to exclude from compilation",
+                    "description": "Paths to exclude from compilation. Any `Tests` directory is always excluded, and generated swiftinterfaces are rejected if they import test-only modules.",
                     "default": [ ]
                 },
                 "includeDirectories": {
@@ -506,7 +506,7 @@
                 "exclude": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Paths to exclude from compilation",
+                    "description": "Paths to exclude from compilation. Any `Tests` directory is always excluded, and generated swiftinterfaces are rejected if they import test-only modules.",
                     "default": [ ]
                 },
                 "includeDirectories": {


### PR DESCRIPTION
# Why

Getting an error message when prebuilding the `expo-camera` modules on `main` when publishing.

```
❌  Compilation search paths unable to resolve module dependency: 'Testing'
   └─ ExpoCamera.swiftmodule/arm64-apple-ios-simulator.private.swiftinterface:14:8
   (and _Testing_CoreGraphics, _Testing_Foundation, _Testing_UIKit at lines 21–23)
```

# How

The problem is that Test folders are included in the camera package and this was excluded in the prebuild scripts.

- Add default exclusion to `**/Tests/**`
- Scan `.swiftinterface` files for `import Testing`/`import _Testing_*` and fail if found
- Emits errors in the verifier steps if the above is found
- README with exclude description

# Test Plan

🔴 **Red (end to end) on `main`:**  `et prebuild expo-camera --flavor Debug --platform iOS` on `main` produces interface with `import Testing` and `_Testing_*`
✅ `cd tools && pnpm test` → 406 tests, 403 pass, 3 skipped; 
✅ `prebuild expo-camera --flavor Debug --platform iOS --clean`

## Follow-up (not in this PR)

The 58.0.0 artifacts of expo-camera, expo-contacts, expo-image-manipulator, expo-maps and expo-video on the `next` tag carry the leaked imports and need to be rebuilt and republished once this lands.

# Checklist

- [x] No CHANGELOG entry: `tools` is not published.
- [x] `pnpm test`, `tsc --noEmit`, `lint` clean in `tools/`; end-to-end verified with `et prebuild expo-camera`.
- [x] No `spm.config.json` changes needed.
