### PR TITLE
[ios][updates] Apply bundle diffs against the embedded bundle in the app binary

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Apply bundle diffs against the embedded bundle in the app binary when the launched update is the embedded one, instead of failing to resolve a patch base and downloading the full bundle. ([#50018](https://github.com/expo/expo/pull/50018) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 ## 58.0.0 — 2026-09-10

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -84,6 +84,12 @@ public final class FileDownloader {
   private let updatesDirectory: URL
   private let database: UpdatesDatabase
 
+  /// Overridable for testing, where the fixture is not in `updatesBundle`.
+  internal var embeddedLaunchAssetUrl: URL? = updatesBundle.url(
+    forResource: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFilename,
+    withExtension: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFileType
+  )
+
   public convenience init(
     config: UpdatesConfig,
     logger: UpdatesLogger,
@@ -558,8 +564,7 @@ public final class FileDownloader {
       throw DiffError.assetNotLaunch
     }
 
-    let baseAsset = try resolveLaunchAsset(launchedUpdate: launchedUpdate)
-    let baseFileUrl = try loadAndVerifyAsset(baseAsset)
+    let baseFileUrl = try resolveBaseFileUrl(launchedUpdate: launchedUpdate)
     let requestedUpdateId = requestedUpdate?.updateId.uuidString
 
     return try createPatchedAsset(
@@ -570,6 +575,19 @@ public final class FileDownloader {
       expectedBase64URLEncodedSHA256Hash: expectedBase64URLEncodedSHA256Hash,
       requestedUpdateId: requestedUpdateId
     )
+  }
+
+  private func resolveBaseFileUrl(launchedUpdate: Update) throws -> URL {
+    if launchedUpdate.status == UpdateStatus.StatusEmbedded {
+      // StatusEmbedded only launches for this binary's embedded update.
+      guard let embeddedLaunchAssetUrl else {
+        throw DiffError.embeddedBaseAssetMissing
+      }
+      return embeddedLaunchAssetUrl
+    }
+
+    let baseAsset = try resolveLaunchAsset(launchedUpdate: launchedUpdate)
+    return try loadAndVerifyAsset(baseAsset)
   }
 
   private func resolveLaunchAsset(launchedUpdate: Update) throws -> UpdateAsset {
@@ -1239,6 +1257,7 @@ extension FileDownloader {
     case missingHeader(String)
     case invalidHeader(String)
     case launchAssetNotFound
+    case embeddedBaseAssetMissing
     case baseAssetMissing(path: String)
     case failedToReadBaseAsset(cause: Error)
     case failedToWritePatch(cause: Error, path: String)
@@ -1266,6 +1285,8 @@ extension FileDownloader.DiffError: CustomStringConvertible {
       return "Invalid \(header) header"
     case .launchAssetNotFound:
       return "Launch asset not found for current update"
+    case .embeddedBaseAssetMissing:
+      return "Embedded bundle not found in the app binary"
     case let .baseAssetMissing(path):
       return "Base asset is missing at path \(path)"
     case let .failedToReadBaseAsset(cause):

--- a/packages/expo-updates/ios/Tests/FileDownloaderTests.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderTests.swift
@@ -1057,6 +1057,88 @@ class HermesDiffApplicationTests {
     }
   }
 
+  private func embeddedLaunchedUpdate() -> Update {
+    return Update(
+      manifest: ManifestFactory.manifest(forManifestJSON: [:]),
+      config: config,
+      database: db,
+      updateId: UUID(),
+      scopeKey: config.scopeKey,
+      commitTime: Date(),
+      runtimeVersion: config.runtimeVersion,
+      keep: true,
+      status: UpdateStatus.StatusEmbedded,
+      isDevelopmentMode: false,
+      assetsFromManifest: [],
+      url: config.updateUrl,
+      requestHeaders: [:]
+    )
+  }
+
+  private func requestedUpdate() -> Update {
+    return Update(
+      manifest: ManifestFactory.manifest(forManifestJSON: [:]),
+      config: config,
+      database: db,
+      updateId: UUID(),
+      scopeKey: config.scopeKey,
+      commitTime: Date(),
+      runtimeVersion: config.runtimeVersion,
+      keep: true,
+      status: UpdateStatus.StatusReady,
+      isDevelopmentMode: false,
+      assetsFromManifest: [],
+      url: config.updateUrl,
+      requestHeaders: [:]
+    )
+  }
+
+  @Test
+  func `applies a Hermes diff against the embedded bundle in the app binary`() throws {
+    downloader.embeddedLaunchAssetUrl = URL(fileURLWithPath: bundle.path(forResource: "old", ofType: "hbc")!)
+
+    let targetAsset = UpdateAsset(key: "new-asset", type: "hbc")
+    targetAsset.isLaunchAsset = true
+
+    let (patchedData, patchedHash) = try downloader.applyHermesDiff(
+      asset: targetAsset,
+      diffData: patchData,
+      destinationPath: destinationURL.path,
+      launchedUpdate: embeddedLaunchedUpdate(),
+      requestedUpdate: requestedUpdate(),
+      expectedBase64URLEncodedSHA256Hash: expectedPatchedHash
+    )
+
+    #expect(patchedData == expectedPatchedData)
+    #expect(patchedHash == expectedPatchedHash)
+    let writtenData = try Data(contentsOf: destinationURL)
+    #expect(writtenData == expectedPatchedData)
+  }
+
+  @Test
+  func `throws when the embedded bundle is missing from the app binary`() {
+    downloader.embeddedLaunchAssetUrl = nil
+    let targetAsset = UpdateAsset(key: "new-asset", type: "hbc")
+    targetAsset.isLaunchAsset = true
+
+    #expect {
+      try downloader.applyHermesDiff(
+        asset: targetAsset,
+        diffData: patchData,
+        destinationPath: destinationURL.path,
+        launchedUpdate: embeddedLaunchedUpdate(),
+        requestedUpdate: requestedUpdate(),
+        expectedBase64URLEncodedSHA256Hash: expectedPatchedHash
+      )
+    } throws: { error in
+      guard let diffError = error as? FileDownloader.DiffError,
+            case .embeddedBaseAssetMissing = diffError else {
+        return false
+      }
+      return true
+    }
+  }
+
   @Test
   func `throws when launch asset hash mismatches expected value`() {
     let expectedHash = "incorrect-hash"


### PR DESCRIPTION
# Why
An app launching from the embedded update cannot apply a bundle diff. The no-copy embedded assets change in #47284 stopped writing asset rows for the embedded update, and patch base resolution starts by looking up the launch asset row. It throws launchAssetNotFound before it touches the filesystem. The failure is caught, logged as a warning, and followed by a full bundle download, so the update still lands correctly. Only the bandwidth saving is lost, which is why this went unnoticed.

# How
applyHermesDiff now resolves the base through resolveBaseFileUrl. When the launched update has StatusEmbedded, the base is the bundle in the app binary, resolved with the same two constants AppLauncherWithDatabase.ensureAllAssetsExist uses to launch it. Every other status keeps the existing database row and loadAndVerifyAsset path unchanged.

The embedded path skips the base hash check on purpose. There is no asset row and so no expected hash to compare against, and two existing invariants already make the check unnecessary. A StatusEmbedded update can only launch when it is the current binary's embedded update, because the launcher filters stale rows from earlier
binaries. Separately, validatePatchResponseMetadata rejects any patch whose base id differs from the launched update. Together, the binary's bundle is the base the diff was built from.

The bundle URL is a stored internal var so tests can point it at a fixture, matching the embeddedAssetsBundle seam already on AppLoader. A new DiffError.embeddedBaseAssetMissing covers a binary with no bundle.

# Test Plan
Two tests added to HermesDiffApplicationTests. One points the resolver at the old.hbc fixture with a StatusEmbedded launched update and asserts the patched output equals new.hbc. The other sets the resolver to nil and asserts embeddedBaseAssetMissing. The existing database-row and hash-mismatch tests are unchanged and still pass.