### PR TITLE
[android][updates] Apply bundle diffs against the embedded bundle in the app binary

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Apply bundle diffs against the embedded bundle in the app binary when the launched update is the embedded one, instead of failing to resolve a patch base and downloading the full bundle. ([#50018](https://github.com/expo/expo/pull/50018) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Apply bundle diffs against the embedded bundle in the app binary when the launched update is the embedded one, instead of failing to resolve a patch base and downloading the full bundle. ([#50019](https://github.com/expo/expo/pull/50019) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/assets/embedded-launch-asset.bundle
+++ b/packages/expo-updates/android/src/androidTest/assets/embedded-launch-asset.bundle
@@ -1,0 +1,1 @@
+embedded launch asset fixture for RemoteLoaderTest

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/LoaderStressTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/LoaderStressTest.kt
@@ -70,7 +70,7 @@ class LoaderStressTest {
           manifestUpdateResponsePart = UpdateResponsePart.ManifestUpdateResponsePart(manifest),
           directiveUpdateResponsePart = null
         )
-        coEvery { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) } coAnswers {
+        coEvery { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) } coAnswers {
           // jitter so download completions overlap instead of serializing
           delay((0..2).random().toLong())
           FileDownloader.AssetDownloadResult(firstArg<AssetEntity>(), true)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -1,5 +1,6 @@
 package expo.modules.updates.loader
 
+import android.content.Context
 import android.net.Uri
 import androidx.room.Room
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
@@ -34,6 +35,7 @@ import java.util.*
 
 @RunWith(AndroidJUnit4ClassRunner::class)
 class RemoteLoaderTest {
+  private lateinit var context: Context
   private lateinit var db: UpdatesDatabase
   private lateinit var configuration: UpdatesConfiguration
   private lateinit var logger: UpdatesLogger
@@ -50,7 +52,7 @@ class RemoteLoaderTest {
       "runtimeVersion" to "1.0"
     )
     configuration = UpdatesConfiguration(null, configMap)
-    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    context = InstrumentationRegistry.getInstrumentation().targetContext
     logger = UpdatesLogger(context.filesDir)
     db = Room.inMemoryDatabaseBuilder(context, UpdatesDatabase::class.java).build()
     mockLoaderFiles = mockk(relaxed = true)
@@ -76,7 +78,7 @@ class RemoteLoaderTest {
       directiveUpdateResponsePart = null
     )
 
-    coEvery { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) } answers {
+    coEvery { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) } answers {
       val asset = firstArg<AssetEntity>()
       FileDownloader.AssetDownloadResult(asset, true)
     }
@@ -89,7 +91,7 @@ class RemoteLoaderTest {
     }
 
     Assert.assertNotNull(result.updateEntity)
-    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) }
+    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -100,7 +102,7 @@ class RemoteLoaderTest {
 
   @Test
   fun testRemoteLoader_FailureToDownloadAssets() = runTest {
-    coEvery { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) } throws IOException("mock failed to download asset")
+    coEvery { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) } throws IOException("mock failed to download asset")
 
     try {
       loader.load { _ ->
@@ -110,7 +112,7 @@ class RemoteLoaderTest {
       Assert.assertEquals("mock failed to download asset", e.message)
     }
 
-    coVerify(atLeast = 1) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) }
+    coVerify(atLeast = 1) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -137,7 +139,7 @@ class RemoteLoaderTest {
     Assert.assertNotNull(result.updateEntity)
 
     // only 1 asset (bundle) should be downloaded since the other asset already exists
-    coVerify(exactly = 1) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) }
+    coVerify(exactly = 1) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -166,7 +168,7 @@ class RemoteLoaderTest {
     Assert.assertNotNull(result.updateEntity)
 
     // both assets should be downloaded regardless of what the database says
-    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) }
+    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -205,7 +207,7 @@ class RemoteLoaderTest {
     }
 
     Assert.assertNotNull(result.updateEntity)
-    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) }
+    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -233,7 +235,7 @@ class RemoteLoaderTest {
     Assert.assertNotNull(result.updateEntity)
 
     // missing assets should still be downloaded
-    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) }
+    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -266,7 +268,7 @@ class RemoteLoaderTest {
     }
 
     Assert.assertNotNull(result.updateEntity)
-    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) }
+    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -292,7 +294,7 @@ class RemoteLoaderTest {
     }
 
     Assert.assertNotNull(result.updateEntity)
-    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) }
+    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -314,7 +316,7 @@ class RemoteLoaderTest {
 
     Assert.assertEquals(updateDirective, result.updateDirective)
     Assert.assertNull(result.updateEntity)
-    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) }
+    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(0, updates.size)
@@ -331,10 +333,70 @@ class RemoteLoaderTest {
       Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
     }
 
-    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any()) }
+    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), any()) }
 
     Assert.assertEquals(2, progressUpdates.size)
     Assert.assertEquals(0.5, progressUpdates[0], 0.001)
     Assert.assertEquals(1.0, progressUpdates[1], 0.001)
+  }
+
+  @Test
+  fun testRemoteLoader_EmbeddedAssetExtractor_CopiesTheEmbeddedLaunchAssetFromTheApk() = runTest {
+    val extractor = captureEmbeddedAssetExtractor()
+
+    val launchAssetRow = AssetEntity("bundle-embedded", "js").apply {
+      isLaunchAsset = true
+      relativePath = "file:///android_asset/index.android.bundle.js"
+    }
+    every { mockLoaderFiles.readEmbeddedUpdate(any(), any()) } returns mockk {
+      every { assetEntityList } returns listOf(
+        AssetEntity("bundle-embedded", "js").apply {
+          isLaunchAsset = true
+          embeddedAssetFilename = "embedded-launch-asset.bundle"
+        }
+      )
+    }
+
+    val destination = File(context.cacheDir, "extracted-base")
+    destination.delete()
+    extractor(launchAssetRow, destination)
+
+    val expected = context.assets.open("embedded-launch-asset.bundle").use { it.readBytes() }
+    Assert.assertArrayEquals(expected, destination.readBytes())
+  }
+
+  @Test
+  fun testRemoteLoader_EmbeddedAssetExtractor_ThrowsWhenNoEmbeddedAssetMatches() = runTest {
+    val extractor = captureEmbeddedAssetExtractor()
+
+    val launchAssetRow = AssetEntity("bundle-unknown", "js").apply {
+      isLaunchAsset = true
+      relativePath = "file:///android_asset/index.android.bundle.js"
+    }
+    every { mockLoaderFiles.readEmbeddedUpdate(any(), any()) } returns mockk {
+      every { assetEntityList } returns emptyList()
+    }
+
+    val destination = File(context.cacheDir, "extracted-base")
+    try {
+      extractor(launchAssetRow, destination)
+      Assert.fail("Expected an IOException")
+    } catch (e: IOException) {
+      Assert.assertTrue(e.message!!.contains("bundle-unknown"))
+    }
+  }
+
+  /** Runs a load so RemoteLoader hands its extractor to the mocked downloader, then returns it. */
+  private suspend fun captureEmbeddedAssetExtractor(): EmbeddedAssetExtractor {
+    val extractors = mutableListOf<EmbeddedAssetExtractor?>()
+    coEvery {
+      mockFileDownloader.downloadAsset(any(), any(), any(), any(), any(), any(), captureNullable(extractors))
+    } answers {
+      FileDownloader.AssetDownloadResult(firstArg<AssetEntity>(), true)
+    }
+    loader.load {
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
+    return extractors.firstOrNull() ?: throw AssertionError("RemoteLoader did not supply an embedded asset extractor")
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -60,7 +60,6 @@ private const val EXPO_CURRENT_UPDATE_ID_HEADER = "Expo-Current-Update-ID"
 private const val EXPO_REQUESTED_UPDATE_ID_HEADER = "Expo-Requested-Update-ID"
 private const val EXPO_EMBEDDED_UPDATE_ID_HEADER = "Expo-Embedded-Update-ID"
 
-/** Supplied by callers that hold a `Context`, so the downloader needs no APK access of its own. */
 internal typealias EmbeddedAssetExtractor = (AssetEntity, File) -> Unit
 
 /**

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -23,6 +23,7 @@ import expo.modules.updates.manifest.ResponsePartHeaderData
 import expo.modules.updates.manifest.ResponsePartInfo
 import expo.modules.updates.manifest.UpdateFactory
 import expo.modules.updates.selectionpolicy.SelectionPolicies
+import expo.modules.updates.utils.AndroidResourceAssetUtils
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Cache
 import okhttp3.Headers
@@ -51,12 +52,16 @@ import kotlin.math.min
 
 private const val PATCH_TEMP_SUFFIX = ".patch"
 private const val PATCHED_TEMP_SUFFIX = ".patched"
+private const val PATCH_BASE_TEMP_SUFFIX = ".base"
 private const val A_IM_HEADER = "A-IM"
 private const val IM_HEADER = "im"
 private const val EXPO_BASE_UPDATE_ID_RESPONSE_HEADER = "expo-base-update-id"
 private const val EXPO_CURRENT_UPDATE_ID_HEADER = "Expo-Current-Update-ID"
 private const val EXPO_REQUESTED_UPDATE_ID_HEADER = "Expo-Requested-Update-ID"
 private const val EXPO_EMBEDDED_UPDATE_ID_HEADER = "Expo-Embedded-Update-ID"
+
+/** Supplied by callers that hold a `Context`, so the downloader needs no APK access of its own. */
+internal typealias EmbeddedAssetExtractor = (AssetEntity, File) -> Unit
 
 /**
  * Utility class that holds all the logic for downloading data and files, such as update manifests
@@ -107,7 +112,8 @@ class FileDownloader(
     progressListener: FileDownloadProgressListener? = null,
     allowPatch: Boolean,
     launchedUpdate: UpdateEntity? = null,
-    requestedUpdate: UpdateEntity? = null
+    requestedUpdate: UpdateEntity? = null,
+    embeddedAssetExtractor: EmbeddedAssetExtractor? = null
   ): FileDownloadResult {
     try {
       val response = downloadData(request, progressListener)
@@ -176,7 +182,8 @@ class FileDownloader(
                 updatesDirectory = updatesDirectory,
                 launchedUpdate = launchedUpdate,
                 requestedUpdate = requestedUpdate,
-                expectedBase64URLEncodedSHA256Hash = expectedBase64URLEncodedSHA256Hash
+                expectedBase64URLEncodedSHA256Hash = expectedBase64URLEncodedSHA256Hash,
+                embeddedAssetExtractor = embeddedAssetExtractor
               )
             }.getOrElse {
               logger.warn(
@@ -294,36 +301,47 @@ class FileDownloader(
     updatesDirectory: File,
     launchedUpdate: UpdateEntity,
     requestedUpdate: UpdateEntity?,
-    expectedBase64URLEncodedSHA256Hash: String?
+    expectedBase64URLEncodedSHA256Hash: String?,
+    embeddedAssetExtractor: EmbeddedAssetExtractor? = null
   ): ByteArray {
     val launchAssetContext = prepareAssetForDiff(
       asset = asset,
       responseBody = responseBody,
+      destination = destination,
       updatesDirectory = updatesDirectory,
-      launchedUpdate = launchedUpdate
+      launchedUpdate = launchedUpdate,
+      embeddedAssetExtractor = embeddedAssetExtractor
     )
 
-    return applyHermesDiff(
-      baseFile = launchAssetContext.baseFile,
-      diffBody = responseBody,
-      destination = destination,
-      expectedBase64URLEncodedSHA256Hash = expectedBase64URLEncodedSHA256Hash,
-      asset = asset,
-      requestedUpdateId = requestedUpdate?.id?.toString()
-    )
+    try {
+      return applyHermesDiff(
+        baseFile = launchAssetContext.baseFile,
+        diffBody = responseBody,
+        destination = destination,
+        expectedBase64URLEncodedSHA256Hash = expectedBase64URLEncodedSHA256Hash,
+        asset = asset,
+        requestedUpdateId = requestedUpdate?.id?.toString()
+      )
+    } finally {
+      if (launchAssetContext.isTemporary) {
+        launchAssetContext.baseFile.delete()
+      }
+    }
   }
 
-  internal data class LaunchAssetContext(val baseFile: File)
+  internal data class LaunchAssetContext(val baseFile: File, val isTemporary: Boolean = false)
 
   @VisibleForTesting
   internal fun prepareAssetForDiff(
     asset: AssetEntity,
     responseBody: ResponseBody,
+    destination: File,
     updatesDirectory: File,
-    launchedUpdate: UpdateEntity
+    launchedUpdate: UpdateEntity,
+    embeddedAssetExtractor: EmbeddedAssetExtractor? = null
   ): LaunchAssetContext {
     return try {
-      preparePatchBaseAsset(asset, updatesDirectory, launchedUpdate)
+      preparePatchBaseAsset(asset, destination, updatesDirectory, launchedUpdate, embeddedAssetExtractor)
     } catch (e: Exception) {
       responseBody.close()
       if (e is IOException) {
@@ -336,8 +354,10 @@ class FileDownloader(
 
   private fun preparePatchBaseAsset(
     asset: AssetEntity,
+    destination: File,
     updatesDirectory: File,
-    launchedUpdate: UpdateEntity
+    launchedUpdate: UpdateEntity,
+    embeddedAssetExtractor: EmbeddedAssetExtractor? = null
   ): LaunchAssetContext {
     if (!asset.isLaunchAsset) {
       throw IOException("Received patch for non-launch asset ${asset.key}")
@@ -351,29 +371,60 @@ class FileDownloader(
     val launchAssetRelativePath = launchAssetEntity.relativePath
       ?: throw IOException("Launch asset for update $currentUpdateId is missing a relative path")
 
-    val baseFile = File(updatesDirectory, launchAssetRelativePath)
+    // BSPatch needs a real path, so an asset inside the APK is extracted first.
+    val isEmbeddedLaunchAsset = AndroidResourceAssetUtils.isAndroidResourceAsset(launchAssetRelativePath)
+    val baseFile = if (isEmbeddedLaunchAsset) {
+      extractEmbeddedPatchBaseAsset(launchAssetEntity, destination, embeddedAssetExtractor)
+    } else {
+      File(updatesDirectory, launchAssetRelativePath)
+    }
     if (!baseFile.exists()) {
       throw IOException("Base asset $baseFile is missing; cannot apply patch")
     }
 
-    val actualBaseHash = try {
-      UpdatesUtils.toBase64Url(UpdatesUtils.sha256(baseFile))
-    } catch (_: Exception) {
-      null
-    }
-
     val expectedBaseHash = launchAssetEntity.expectedHash
-    if (expectedBaseHash != null && actualBaseHash != null && expectedBaseHash != actualBaseHash) {
-      logger.warn(
-        "Asset hash mismatch for update $currentUpdateId; expected=$expectedBaseHash actual=$actualBaseHash",
-        UpdatesErrorCode.AssetsFailedToLoad,
-        currentUpdateId.toString(),
-        asset.key
-      )
-      throw IOException("Asset hash mismatch for update $currentUpdateId; expected=$expectedBaseHash actual=$actualBaseHash")
+    if (expectedBaseHash != null) {
+      val actualBaseHash = try {
+        UpdatesUtils.toBase64Url(UpdatesUtils.sha256(baseFile))
+      } catch (_: Exception) {
+        null
+      }
+      if (actualBaseHash != null && expectedBaseHash != actualBaseHash) {
+        logger.warn(
+          "Asset hash mismatch for update $currentUpdateId; expected=$expectedBaseHash actual=$actualBaseHash",
+          UpdatesErrorCode.AssetsFailedToLoad,
+          currentUpdateId.toString(),
+          asset.key
+        )
+        if (isEmbeddedLaunchAsset) {
+          baseFile.delete()
+        }
+        throw IOException("Asset hash mismatch for update $currentUpdateId; expected=$expectedBaseHash actual=$actualBaseHash")
+      }
     }
 
-    return LaunchAssetContext(baseFile)
+    return LaunchAssetContext(baseFile, isTemporary = isEmbeddedLaunchAsset)
+  }
+
+  @Throws(IOException::class)
+  private fun extractEmbeddedPatchBaseAsset(
+    launchAssetEntity: AssetEntity,
+    destination: File,
+    embeddedAssetExtractor: EmbeddedAssetExtractor?
+  ): File {
+    if (embeddedAssetExtractor == null) {
+      throw IOException("The launch asset lives in the app binary and cannot be extracted without an extractor")
+    }
+
+    val baseFile = File(destination.absolutePath + PATCH_BASE_TEMP_SUFFIX)
+    try {
+      baseFile.parentFile?.mkdirs()
+      embeddedAssetExtractor(launchAssetEntity, baseFile)
+    } catch (e: Exception) {
+      baseFile.delete()
+      throw e as? IOException ?: IOException("Failed to extract the embedded launch asset", e)
+    }
+    return baseFile
   }
 
   @VisibleForTesting
@@ -678,7 +729,8 @@ class FileDownloader(
     extraHeaders: JSONObject,
     launchedUpdate: UpdateEntity?,
     requestedUpdate: UpdateEntity?,
-    assetLoadProgressListener: ((Double) -> Unit)? = null
+    assetLoadProgressListener: ((Double) -> Unit)? = null,
+    embeddedAssetExtractor: EmbeddedAssetExtractor? = null
   ): AssetDownloadResult {
     if (asset.url == null) {
       val message = "Failed to download asset ${asset.key}"
@@ -722,7 +774,8 @@ class FileDownloader(
           assetLoadProgressListener?.let { listener -> { listener.invoke(it) } },
           allowPatch = canApplyPatch,
           launchedUpdate = launchedUpdate,
-          requestedUpdate = requestedUpdate
+          requestedUpdate = requestedUpdate,
+          embeddedAssetExtractor = embeddedAssetExtractor
         )
 
         asset.downloadTime = Date()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import java.io.File
+import java.io.IOException
 
 data class ProcessSuccessLoaderResult(
   val availableUpdate: UpdateEntity?,
@@ -66,9 +67,28 @@ class RemoteLoader internal constructor(
     embeddedUpdate: UpdateEntity?
   ): FileDownloader.AssetDownloadResult {
     val extraHeaders = FileDownloader.getExtraHeadersForRemoteAssetRequest(launchedUpdate, embeddedUpdate, requestedUpdate)
-    return mFileDownloader.downloadAsset(assetEntity, updatesDirectory, extraHeaders, launchedUpdate, requestedUpdate) { progress ->
-      assetLoadProgressListener(assetEntity, progress)
-    }
+    return mFileDownloader.downloadAsset(
+      asset = assetEntity,
+      destinationDirectory = updatesDirectory,
+      extraHeaders = extraHeaders,
+      launchedUpdate = launchedUpdate,
+      requestedUpdate = requestedUpdate,
+      embeddedAssetExtractor = { launchAsset, destination ->
+        // The stored path is not the APK asset name; resolve it through the embedded manifest by key.
+        val embeddedLaunchAsset = loaderFiles.readEmbeddedUpdate(context, configuration)
+          ?.assetEntityList
+          ?.find { it.key == launchAsset.key }
+          ?: throw IOException("No embedded asset matches launch asset ${launchAsset.key}")
+        val assetName = embeddedLaunchAsset.embeddedAssetFilename
+          ?: throw IOException("Embedded launch asset ${launchAsset.key} has no APK asset filename")
+        context.assets.open(assetName).use { input ->
+          destination.outputStream().use { output -> input.copyTo(output) }
+        }
+      },
+      assetLoadProgressListener = { progress ->
+        assetLoadProgressListener(assetEntity, progress)
+      }
+    )
   }
 
   companion object {

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderAssetDiffTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderAssetDiffTest.kt
@@ -10,6 +10,9 @@ import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.logging.UpdatesLogger
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
@@ -22,8 +25,11 @@ import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -265,7 +271,7 @@ class FileDownloaderAssetDiffTest {
     val response = "patch".toResponseBody("application/vnd.bsdiff".toMediaTypeOrNull())
 
     val launchedUpdate = createUpdate(currentUpdateId)
-    val context = downloader.prepareAssetForDiff(asset, response, updatesDirectory, launchedUpdate)
+    val context = downloader.prepareAssetForDiff(asset, response, patchDestination(), updatesDirectory, launchedUpdate)
     assertEquals(baseFile, context.baseFile)
   }
 
@@ -299,7 +305,39 @@ class FileDownloaderAssetDiffTest {
 
     val launchedUpdate = createUpdate(currentUpdateId)
     assertThrows(IOException::class.java) {
-      downloader.prepareAssetForDiff(asset, responseBody, updatesDirectory, launchedUpdate)
+      downloader.prepareAssetForDiff(asset, responseBody, patchDestination(), updatesDirectory, launchedUpdate)
+    }
+  }
+
+  @Test
+  fun prepareAssetForDiff_skipsTheBaseHashWhenTheRowHasNoExpectedHash() {
+    val currentUpdateId = UUID.randomUUID()
+    val baseRelativePath = "bundles/base.hbc"
+    val baseFile = File(updatesDirectory, baseRelativePath)
+    baseFile.parentFile?.mkdirs()
+    baseFile.writeBytes(loadFixture("old.hbc"))
+
+    val launchEntity = AssetEntity("launch", "hbc").apply {
+      relativePath = baseRelativePath
+      expectedHash = null
+    }
+    val updateDao = mockk<UpdateDao> {
+      every { loadLaunchAssetForUpdate(currentUpdateId) } returns launchEntity
+    }
+    val database = mockk<UpdatesDatabase> {
+      every { updateDao() } returns updateDao
+    }
+    val downloader = FileDownloader(filesDirectory, "test-eas-client", configuration, logger, database)
+    val asset = AssetEntity("new", "hbc").apply { isLaunchAsset = true }
+    val response = "patch".toResponseBody("application/vnd.bsdiff".toMediaTypeOrNull())
+
+    mockkObject(UpdatesUtils)
+    try {
+      val context = downloader.prepareAssetForDiff(asset, response, patchDestination(), updatesDirectory, createUpdate(currentUpdateId))
+      assertEquals(baseFile, context.baseFile)
+      verify(exactly = 0) { UpdatesUtils.sha256(any<File>()) }
+    } finally {
+      unmockkObject(UpdatesUtils)
     }
   }
 
@@ -342,6 +380,150 @@ class FileDownloaderAssetDiffTest {
     assertFalse(File(destination.absolutePath + ".patch").exists())
     assertFalse(File(destination.absolutePath + ".patched").exists())
   }
+
+  @Test
+  fun prepareAssetForDiff_extractsEmbeddedLaunchAssetFromApk() {
+    val currentUpdateId = UUID.randomUUID()
+    val baseBytes = loadFixture("old.hbc")
+
+    val launchEntity = AssetEntity("launch", "hbc").apply {
+      relativePath = "file:///android_asset/index.android.bundle.js"
+    }
+
+    val updateDao = mockk<UpdateDao> {
+      every { loadLaunchAssetForUpdate(currentUpdateId) } returns launchEntity
+    }
+    val database = mockk<UpdatesDatabase> {
+      every { updateDao() } returns updateDao
+    }
+    val downloader = FileDownloader(filesDirectory, "test-eas-client", configuration, logger, database)
+
+    val asset = AssetEntity("new", "hbc").apply { isLaunchAsset = true }
+    val response = "patch".toResponseBody("application/vnd.bsdiff".toMediaTypeOrNull())
+
+    var extractedInto: File? = null
+    val extractor: EmbeddedAssetExtractor = { _, destination ->
+      destination.parentFile?.mkdirs()
+      destination.writeBytes(baseBytes)
+      extractedInto = destination
+    }
+
+    val context = downloader.prepareAssetForDiff(
+      asset,
+      response,
+      patchDestination(),
+      updatesDirectory,
+      createUpdate(currentUpdateId),
+      extractor
+    )
+
+    assertEquals(extractedInto, context.baseFile)
+    assertArrayEquals(baseBytes, context.baseFile.readBytes())
+    assertTrue("the extracted base is temporary and must be cleaned up", context.isTemporary)
+  }
+
+  @Test
+  fun downloadAssetAndVerifyHashAndWriteToPath_patchesAgainstTheEmbeddedBundleAndCleansUp() = runTest {
+    val currentUpdateId = UUID.randomUUID()
+    val baseBytes = loadFixture("old.hbc")
+    val patchedBytes = loadFixture("new.hbc")
+    val expected = temporaryFolder.newFile("expected-embedded.hbc").apply {
+      writeBytes(patchedBytes)
+    }
+    val expectedHash = UpdatesUtils.toBase64Url(UpdatesUtils.sha256(expected))
+
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(226)
+        .setHeader("Content-Type", "application/javascript")
+        .setHeader("im", "bsdiff")
+        .setHeader("expo-base-update-id", currentUpdateId.toString())
+        .setBody("diff payload")
+    )
+
+    val launchEntity = AssetEntity("launch", "hbc").apply {
+      relativePath = "file:///android_asset/index.android.bundle.js"
+    }
+    val updateDao = mockk<UpdateDao> {
+      every { loadLaunchAssetForUpdate(currentUpdateId) } returns launchEntity
+    }
+    val database = mockk<UpdatesDatabase> {
+      every { updateDao() } returns updateDao
+    }
+
+    val asset = AssetEntity("bundle", "hbc").apply {
+      url = Uri.parse(server.url("/bundle.hbc").toString())
+      isLaunchAsset = true
+    }
+
+    val downloader = FileDownloader(filesDirectory, "test-eas-client", configuration, logger, database, OkHttpClient())
+    downloader.applyPatch = { baseFilePath, newFilePath, _ ->
+      assertArrayEquals(baseBytes, File(baseFilePath).readBytes())
+      File(newFilePath).writeBytes(patchedBytes)
+      0
+    }
+
+    var extractedInto: File? = null
+    var extractedFrom: AssetEntity? = null
+    val extractor: EmbeddedAssetExtractor = { row, base ->
+      extractedFrom = row
+      base.writeBytes(baseBytes)
+      extractedInto = base
+    }
+
+    val destination = File(updatesDirectory, "downloaded.hbc")
+    val result = downloader.downloadAssetAndVerifyHashAndWriteToPath(
+      asset = asset,
+      extraHeaders = JSONObject(),
+      request = downloader.createRequestForAsset(asset, JSONObject(), configuration, allowPatch = true),
+      expectedBase64URLEncodedSHA256Hash = expectedHash,
+      destination = destination,
+      updatesDirectory = updatesDirectory,
+      progressListener = null,
+      allowPatch = true,
+      launchedUpdate = createUpdate(currentUpdateId),
+      requestedUpdate = createUpdate(UUID.randomUUID()),
+      embeddedAssetExtractor = extractor
+    )
+
+    assertArrayEquals(patchedBytes, destination.readBytes())
+    assertArrayEquals(UpdatesUtils.sha256(expected), result.hash)
+    assertEquals("no full-bundle fallback download", 1, server.requestCount)
+    assertSame(launchEntity, extractedFrom)
+    assertNotNull(extractedInto)
+    assertFalse("the extracted base must not be left behind", extractedInto!!.exists())
+    assertFalse(File(destination.absolutePath + ".base").exists())
+  }
+
+  @Test
+  fun prepareAssetForDiff_throwsForEmbeddedLaunchAssetWithoutAnExtractor() {
+    val currentUpdateId = UUID.randomUUID()
+
+    val launchEntity = AssetEntity("launch", "hbc").apply {
+      relativePath = "file:///android_asset/index.android.bundle.js"
+    }
+
+    val updateDao = mockk<UpdateDao> {
+      every { loadLaunchAssetForUpdate(currentUpdateId) } returns launchEntity
+    }
+    val database = mockk<UpdatesDatabase> {
+      every { updateDao() } returns updateDao
+    }
+    val downloader = FileDownloader(filesDirectory, "test-eas-client", configuration, logger, database)
+
+    val asset = AssetEntity("new", "hbc").apply { isLaunchAsset = true }
+    val response = "patch".toResponseBody("application/vnd.bsdiff".toMediaTypeOrNull())
+
+    val error = assertThrows(IOException::class.java) {
+      downloader.prepareAssetForDiff(asset, response, patchDestination(), updatesDirectory, createUpdate(currentUpdateId))
+    }
+    assertTrue(
+      "expected the message to name the missing extractor, got: ${error.message}",
+      error.message!!.contains("cannot be extracted")
+    )
+  }
+
+  private fun patchDestination() = File(updatesDirectory, "patched.hbc")
 
   private fun loadFixture(name: String): ByteArray {
     val stream = javaClass.classLoader?.getResourceAsStream(name)

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -454,7 +454,7 @@ class FileDownloaderTest {
       JSONObject("{}"),
       null,
       null,
-      assetLoadProgressListener
+      assetLoadProgressListener = assetLoadProgressListener
     )
 
     Assert.assertTrue("Progress listener should have been called", progressValues.isNotEmpty())
@@ -510,7 +510,7 @@ class FileDownloaderTest {
       JSONObject("{}"),
       null,
       null,
-      assetLoadProgressListener
+      assetLoadProgressListener = assetLoadProgressListener
     )
 
     Assert.assertTrue("Progress listener should not have been called", progressValues.isEmpty())


### PR DESCRIPTION
# Why

Same class of failure as #50018, but on Android it never worked.

With copying off, the embedded launch asset row records the `file:///android_asset/app.bundle`. preparePatchBaseAsset joined that onto the updates directory and looked for `.../updates/file:/android_asset/app.bundle`, found nothing, and fell back to a full bundle download. As on iOS, the update still lands correctly and only the bandwidth saving is lost.

# How
preparePatchBaseAsset now branches on the locator rather than the update status. When `AndroidResourceAssetUtils.isAndroidResourceAsset(relativePath)` is true, the base is extracted from the APK into a temporary file. This is the same guard every other join site in the codebase already uses, in DatabaseLauncher and Reaper, and the patch site was the one place missing it. Branching on the locator also keeps copy mode working unchanged, since an embedded row with a real path takes the existing branch.

FileDownloader has no `Context` and I didn't want to add it. downloadAsset gains an optional EmbeddedAssetExtractor callback, which `RemoteLoader` supplies from the LoaderFiles.copyAssetAndGetHash it already has. The default is null, and a null extractor on the embedded path throws an IOException that the existing fallback catches, so a caller that does not supply one gets the old behaviour rather than a crash. DatabaseLauncher needs no extractor because it passes no requested update, so no patch can arrive on that path.

# Test Plan
Three tests added to FileDownloaderAssetDiffTest.
