### PR TITLE
[updates][e2e] Route cold-start links through the scene delegate

### DIFF
--- a/packages/expo-updates/e2e/fixtures/custom_init/SceneDelegate.swift
+++ b/packages/expo-updates/e2e/fixtures/custom_init/SceneDelegate.swift
@@ -34,7 +34,7 @@ class SceneDelegate: ExpoAppSceneDelegate {
     window.makeKeyAndVisible()
 
     // Deep links / universal links.
-    Self.route(urlContexts: connectionOptions.urlContexts)
-    connectionOptions.userActivities.forEach { Self.route(userActivity: $0) }
+    self.scene(scene, openURLContexts: connectionOptions.urlContexts)
+    connectionOptions.userActivities.forEach { self.scene(scene, continue: $0) }
   }
 }


### PR DESCRIPTION
# Why
#49925 removed the public static helpers ExpoAppSceneDelegate.route(urlContexts:) and route(userActivity:) and moved link routing onto an internal forwarder. The custom-init E2E fixture was the last remaining caller, and it was not part of that change. 

# How
The base class still exposes open func scene(_:openURLContexts:) and open func scene(_:continue:), which reach the same forwarder. The fixture now calls those on self in place of the removed statics. The forwarder itself is internal to the Expo module and not reachable from the E2E app, so this is the only public path that preserves cold-start link routing.

# Test Plan
CI

