### PR TITLE
[metro-config] Add nice support for shared Metro cache

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Support separate output and restored Metro transform cache directories for EAS jobs.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Support separate output and restored Metro transform cache directories for EAS jobs.
+- Add support for separate restored and output Metro transform cache directories.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add support for separate restored and output Metro transform cache directories.
+- Add support for separate restored and output Metro transform cache directories. ([#50023](https://github.com/expo/expo/pull/50023) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/metro-config/README.md
+++ b/packages/@expo/metro-config/README.md
@@ -14,25 +14,6 @@ const config = getDefaultConfig(__dirname);
 module.exports = config;
 ```
 
-## EAS cache directories
-
-EAS workers can set both `EAS_METRO_CACHE_OUTPUT_DIR` and `EAS_METRO_CACHE_RESTORE_DIR`
-before loading the Metro config. The default config then creates two Expo binary
-file stores, with the output store first and the restored store second. If either
-variable is empty or unset, the default remains a single store in
-`path.join(os.tmpdir(), 'metro-cache')`.
-
-The worker must supply distinct absolute paths, start each job with an empty output
-directory, and extract the previous cache into the restored directory. Metro copies
-reused results into the output store and also writes newly computed results there.
-After bundling processes and cache writes finish, the worker can archive only the
-output directory. Unused restored entries are excluded from that archive.
-
-These variables only configure the stores. The worker owns archive transfer,
-size limits, and directory cleanup. Both stores are writable, and Metro's cache
-reset clears both. Projects that replace `cacheStores` must configure their own
-integration.
-
 ## Exotic
 
 > As of SDK 51, the exotic transformer has been fully removed in favor of the default `@expo/metro-config` transformer. The export `@expo/metro-config/transformer` no longer exists.

--- a/packages/@expo/metro-config/README.md
+++ b/packages/@expo/metro-config/README.md
@@ -14,6 +14,25 @@ const config = getDefaultConfig(__dirname);
 module.exports = config;
 ```
 
+## EAS cache directories
+
+EAS workers can set both `EAS_METRO_CACHE_OUTPUT_DIR` and `EAS_METRO_CACHE_RESTORE_DIR`
+before loading the Metro config. The default config then creates two Expo binary
+file stores, with the output store first and the restored store second. If either
+variable is empty or unset, the default remains a single store in
+`path.join(os.tmpdir(), 'metro-cache')`.
+
+The worker must supply distinct absolute paths, start each job with an empty output
+directory, and extract the previous cache into the restored directory. Metro copies
+reused results into the output store and also writes newly computed results there.
+After bundling processes and cache writes finish, the worker can archive only the
+output directory. Unused restored entries are excluded from that archive.
+
+These variables only configure the stores. The worker owns archive transfer,
+size limits, and directory cleanup. Both stores are writable, and Metro's cache
+reset clears both. Projects that replace `cacheStores` must configure their own
+integration.
+
 ## Exotic
 
 > As of SDK 51, the exotic transformer has been fully removed in favor of the default `@expo/metro-config` transformer. The export `@expo/metro-config/transformer` no longer exists.

--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -283,8 +283,10 @@ export function getDefaultConfig(
 
   const outputCacheRoot = env.EAS_METRO_CACHE_OUTPUT_DIR;
   const restoredCacheRoot = env.EAS_METRO_CACHE_RESTORE_DIR;
-  // Metro promotes restored hits into earlier stores. An empty output directory therefore
-  // collects only results used by this job, which EAS can archive without unused entries.
+  // EAS supplies distinct absolute paths and starts each job with an empty output directory.
+  // Metro promotes restored hits into the first store and writes new transforms there too.
+  // After bundling processes exit, EAS archives only the output directory, excluding unused
+  // restored entries. Both stores remain writable and are cleared by Metro's cache reset.
   const cacheStores =
     outputCacheRoot && restoredCacheRoot
       ? [
@@ -465,9 +467,7 @@ export function getDefaultConfig(
   // See: https://github.com/facebook/metro/blob/b9c243f/packages/metro/src/node-haste/DependencyGraph/createFileMap.js#L109
   (metroConfig.resolver as { useWatchman?: boolean | null }).useWatchman = null;
 
-  return withExpoSerializers(metroConfig, {
-    unstable_beforeAssetSerializationPlugins,
-  });
+  return withExpoSerializers(metroConfig, { unstable_beforeAssetSerializationPlugins });
 }
 
 /** Use to access the Expo Metro transformer path */

--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -284,11 +284,6 @@ export function getDefaultConfig(
 
   const restoredRoot = env.EXPO_METRO_CACHE_RESTORE_DIR;
   const outputRoot = env.EXPO_METRO_CACHE_OUTPUT_DIR;
-  if (!!restoredRoot !== !!outputRoot) {
-    throw new Error(
-      'EXPO_METRO_CACHE_RESTORE_DIR and EXPO_METRO_CACHE_OUTPUT_DIR must be set together'
-    );
-  }
   // The build runner supplies separate absolute directories and starts each job with
   // an empty output directory. Keep output across Metro invocations in the same job.
   // After bundling processes exit, archive only output to exclude unused restored entries.
@@ -296,7 +291,7 @@ export function getDefaultConfig(
   const cacheStores =
     restoredRoot && outputRoot
       ? [new BuildCacheStore<any>({ restoredRoot, outputRoot })]
-      : [new FileStore<any>({ root: path.join(os.tmpdir(), 'metro-cache') })];
+      : [new FileStore<any>({ root: outputRoot || path.join(os.tmpdir(), 'metro-cache') })];
 
   const serverRoot = getMetroServerRoot(projectRoot);
 

--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -282,14 +282,21 @@ export function getDefaultConfig(
 
   const metroDefaultValues = getDefaultMetroConfig.getDefaultValues(projectRoot);
 
-  const cacheRoot = env.EXPO_METRO_CACHE_DIR;
-  // The build runner restores an archive into root/restored and starts each job with
-  // an empty root/output. Keep output across Metro invocations in the same job.
+  const restoredRoot = env.EXPO_METRO_CACHE_RESTORE_DIR;
+  const outputRoot = env.EXPO_METRO_CACHE_OUTPUT_DIR;
+  if (!!restoredRoot !== !!outputRoot) {
+    throw new Error(
+      'EXPO_METRO_CACHE_RESTORE_DIR and EXPO_METRO_CACHE_OUTPUT_DIR must be set together'
+    );
+  }
+  // The build runner supplies separate absolute directories and starts each job with
+  // an empty output directory. Keep output across Metro invocations in the same job.
   // After bundling processes exit, archive only output to exclude unused restored entries.
   // One store keeps these directories together when projects reorder cacheStores.
-  const cacheStores = cacheRoot
-    ? [new BuildCacheStore<any>({ root: cacheRoot })]
-    : [new FileStore<any>({ root: path.join(os.tmpdir(), 'metro-cache') })];
+  const cacheStores =
+    restoredRoot && outputRoot
+      ? [new BuildCacheStore<any>({ restoredRoot, outputRoot })]
+      : [new FileStore<any>({ root: path.join(os.tmpdir(), 'metro-cache') })];
 
   const serverRoot = getMetroServerRoot(projectRoot);
 

--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -17,6 +17,7 @@ import path from 'path';
 import resolveFrom from 'resolve-from';
 
 import { FileStore } from './binary-file-store';
+import { BuildCacheStore } from './build-cache-store';
 import { getDefaultCustomizeFrame, INTERNAL_CALLSITES_REGEX } from './customizeFrame';
 import { env } from './env';
 import { event } from './events';
@@ -281,19 +282,14 @@ export function getDefaultConfig(
 
   const metroDefaultValues = getDefaultMetroConfig.getDefaultValues(projectRoot);
 
-  const outputCacheRoot = env.EAS_METRO_CACHE_OUTPUT_DIR;
-  const restoredCacheRoot = env.EAS_METRO_CACHE_RESTORE_DIR;
-  // EAS supplies distinct absolute paths and starts each job with an empty output directory.
-  // Metro promotes restored hits into the first store and writes new transforms there too.
-  // After bundling processes exit, EAS archives only the output directory, excluding unused
-  // restored entries. Both stores remain writable and are cleared by Metro's cache reset.
-  const cacheStores =
-    outputCacheRoot && restoredCacheRoot
-      ? [
-          new FileStore<any>({ root: outputCacheRoot }),
-          new FileStore<any>({ root: restoredCacheRoot }),
-        ]
-      : [new FileStore<any>({ root: path.join(os.tmpdir(), 'metro-cache') })];
+  const cacheRoot = env.EXPO_METRO_CACHE_DIR;
+  // The build runner restores an archive into root/restored and starts each job with
+  // an empty root/output. Keep output across Metro invocations in the same job.
+  // After bundling processes exit, archive only output to exclude unused restored entries.
+  // One store keeps these directories together when projects reorder cacheStores.
+  const cacheStores = cacheRoot
+    ? [new BuildCacheStore<any>({ root: cacheRoot })]
+    : [new FileStore<any>({ root: path.join(os.tmpdir(), 'metro-cache') })];
 
   const serverRoot = getMetroServerRoot(projectRoot);
 

--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -281,9 +281,17 @@ export function getDefaultConfig(
 
   const metroDefaultValues = getDefaultMetroConfig.getDefaultValues(projectRoot);
 
-  const cacheStore = new FileStore<any>({
-    root: path.join(os.tmpdir(), 'metro-cache'),
-  });
+  const outputCacheRoot = env.EAS_METRO_CACHE_OUTPUT_DIR;
+  const restoredCacheRoot = env.EAS_METRO_CACHE_RESTORE_DIR;
+  // Metro promotes restored hits into earlier stores. An empty output directory therefore
+  // collects only results used by this job, which EAS can archive without unused entries.
+  const cacheStores =
+    outputCacheRoot && restoredCacheRoot
+      ? [
+          new FileStore<any>({ root: outputCacheRoot }),
+          new FileStore<any>({ root: restoredCacheRoot }),
+        ]
+      : [new FileStore<any>({ root: path.join(os.tmpdir(), 'metro-cache') })];
 
   const serverRoot = getMetroServerRoot(projectRoot);
 
@@ -331,7 +339,7 @@ export function getDefaultConfig(
         /^(?:android[\\/]app[\\/]build|android[\\/]\.gradle|ios[\\/]Pods)$/,
       ],
     },
-    cacheStores: [cacheStore],
+    cacheStores,
     watcher: {
       // strip starting dot from env files. We only support watching development variants of env files as production is inlined using a different system.
       additionalExts: ['env', 'local', 'development'],
@@ -457,7 +465,9 @@ export function getDefaultConfig(
   // See: https://github.com/facebook/metro/blob/b9c243f/packages/metro/src/node-haste/DependencyGraph/createFileMap.js#L109
   (metroConfig.resolver as { useWatchman?: boolean | null }).useWatchman = null;
 
-  return withExpoSerializers(metroConfig, { unstable_beforeAssetSerializationPlugins });
+  return withExpoSerializers(metroConfig, {
+    unstable_beforeAssetSerializationPlugins,
+  });
 }
 
 /** Use to access the Expo Metro transformer path */

--- a/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -56,8 +56,8 @@ describe(getDefaultConfig, () => {
         process.env.EXPO_METRO_CACHE_RESTORE_DIR = restoredRoot;
       }
       const stores = getDefaultConfig(projectRoot).cacheStores;
-      if (!Array.isArray(stores)) {
-        throw new Error('Expected an array of cache stores');
+      if (!Array.isArray(stores) || !stores[0]) {
+        throw new Error('Expected a non-empty array of cache stores');
       }
       expect(stores).toHaveLength(1);
       expect(stores[0]).toBeInstanceOf(FileStore);
@@ -76,8 +76,8 @@ describe(getDefaultConfig, () => {
     const value = Buffer.from('module');
     await fileStore.set(key, value);
     const stores = getDefaultConfig(projectRoot).cacheStores;
-    if (!Array.isArray(stores)) {
-      throw new Error('Expected an array of cache stores');
+    if (!Array.isArray(stores) || !stores[0]) {
+      throw new Error('Expected a non-empty array of cache stores');
     }
     expect(stores).toHaveLength(1);
     expect(stores[0]).toBeInstanceOf(FileStore);

--- a/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -1,5 +1,7 @@
 import { Cache } from '@expo/metro/metro-cache';
 import { vol } from 'memfs';
+import os from 'os';
+import path from 'path';
 
 import { getDefaultConfig, createStableModuleIdFactory } from '../ExpoMetroConfig';
 import { FileStore } from '../binary-file-store';
@@ -47,13 +49,43 @@ describe(getDefaultConfig, () => {
     expect(Array.isArray(stores) && stores[0]).toBeInstanceOf(FileStore);
   });
 
-  it.each(['EXPO_METRO_CACHE_RESTORE_DIR', 'EXPO_METRO_CACHE_OUTPUT_DIR'])(
-    'rejects partial configuration with only %s set',
-    (name) => {
-      process.env[name] = '/cache';
-      expect(() => getDefaultConfig(projectRoot)).toThrow('must be set together');
+  it.each([undefined, '/cache/restored'])(
+    'uses the default directory without output, with restored=%s',
+    async (restoredRoot) => {
+      if (restoredRoot) {
+        process.env.EXPO_METRO_CACHE_RESTORE_DIR = restoredRoot;
+      }
+      const stores = getDefaultConfig(projectRoot).cacheStores;
+      if (!Array.isArray(stores)) {
+        throw new Error('Expected an array of cache stores');
+      }
+      expect(stores).toHaveLength(1);
+      expect(stores[0]).toBeInstanceOf(FileStore);
+      const key = Buffer.from('aabb', 'hex');
+      const value = Buffer.from('module');
+      await stores[0].set(key, value);
+      const defaultStore = new FileStore({ root: path.join(os.tmpdir(), 'metro-cache') });
+      expect(await defaultStore.get(key)).toEqual(value);
     }
   );
+
+  it('uses output alone for regular file store reads and writes', async () => {
+    process.env.EXPO_METRO_CACHE_OUTPUT_DIR = '/cache/custom';
+    const fileStore = new FileStore({ root: '/cache/custom' });
+    const key = Buffer.from('aabb', 'hex');
+    const value = Buffer.from('module');
+    await fileStore.set(key, value);
+    const stores = getDefaultConfig(projectRoot).cacheStores;
+    if (!Array.isArray(stores)) {
+      throw new Error('Expected an array of cache stores');
+    }
+    expect(stores).toHaveLength(1);
+    expect(stores[0]).toBeInstanceOf(FileStore);
+    expect(await stores[0].get(key)).toEqual(value);
+    const updated = Buffer.from('updated module');
+    await stores[0].set(key, updated);
+    expect(await fileStore.get(key)).toEqual(updated);
+  });
 
   it('collects restored hits and new transforms without unused restored entries', async () => {
     process.env.EXPO_METRO_CACHE_RESTORE_DIR = '/cache/restored';

--- a/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -42,8 +42,12 @@ describe(getDefaultConfig, () => {
     ['/cache/output', undefined],
     [undefined, '/cache/restored'],
   ])('keeps one default store with output=%s and restored=%s', (output, restored) => {
-    if (output) process.env.EAS_METRO_CACHE_OUTPUT_DIR = output;
-    if (restored) process.env.EAS_METRO_CACHE_RESTORE_DIR = restored;
+    if (output) {
+      process.env.EAS_METRO_CACHE_OUTPUT_DIR = output;
+    }
+    if (restored) {
+      process.env.EAS_METRO_CACHE_RESTORE_DIR = restored;
+    }
     expect(getDefaultConfig(projectRoot).cacheStores).toHaveLength(1);
   });
 
@@ -61,7 +65,9 @@ describe(getDefaultConfig, () => {
     await restored.set(unusedKey, Buffer.from('unused module'));
 
     const stores = getDefaultConfig(projectRoot).cacheStores;
-    if (!Array.isArray(stores)) throw new Error('Expected an array of cache stores');
+    if (!Array.isArray(stores)) {
+      throw new Error('Expected an array of cache stores');
+    }
     expect(stores).toHaveLength(2);
     const cache = new Cache<Buffer>(stores);
     expect(await cache.get(reusedKey)).toEqual(reusedValue);
@@ -75,7 +81,9 @@ describe(getDefaultConfig, () => {
     expect(await output.get(unusedKey)).toBeNull();
     expect(await restored.get(unusedKey)).toEqual(Buffer.from('unused module'));
 
-    for (const store of stores) await store.clear();
+    for (const store of stores) {
+      await store.clear();
+    }
     expect(await output.get(reusedKey)).toBeNull();
     expect(await restored.get(reusedKey)).toBeNull();
   });

--- a/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -24,36 +24,28 @@ function mockProject() {
 }
 describe(getDefaultConfig, () => {
   beforeEach(() => {
-    delete process.env.EAS_METRO_CACHE_OUTPUT_DIR;
-    delete process.env.EAS_METRO_CACHE_RESTORE_DIR;
+    delete process.env.EXPO_METRO_CACHE_DIR;
     mockProject();
   });
   afterEach(() => {
-    delete process.env.EAS_METRO_CACHE_OUTPUT_DIR;
-    delete process.env.EAS_METRO_CACHE_RESTORE_DIR;
+    delete process.env.EXPO_METRO_CACHE_DIR;
     vol.reset();
   });
   afterAll(() => {
     console.error = consoleError;
   });
 
-  it.each([
-    [undefined, undefined],
-    ['/cache/output', undefined],
-    [undefined, '/cache/restored'],
-  ])('keeps one default store with output=%s and restored=%s', (output, restored) => {
-    if (output) {
-      process.env.EAS_METRO_CACHE_OUTPUT_DIR = output;
+  it.each([undefined, ''])('keeps the default store with cache root=%s', (root) => {
+    if (root !== undefined) {
+      process.env.EXPO_METRO_CACHE_DIR = root;
     }
-    if (restored) {
-      process.env.EAS_METRO_CACHE_RESTORE_DIR = restored;
-    }
-    expect(getDefaultConfig(projectRoot).cacheStores).toHaveLength(1);
+    const stores = getDefaultConfig(projectRoot).cacheStores;
+    expect(stores).toHaveLength(1);
+    expect(Array.isArray(stores) && stores[0]).toBeInstanceOf(FileStore);
   });
 
   it('collects restored hits and new transforms without unused restored entries', async () => {
-    process.env.EAS_METRO_CACHE_OUTPUT_DIR = '/cache/output';
-    process.env.EAS_METRO_CACHE_RESTORE_DIR = '/cache/restored';
+    process.env.EXPO_METRO_CACHE_DIR = '/cache';
     const restored = new FileStore<Buffer>({ root: '/cache/restored' });
     const output = new FileStore<Buffer>({ root: '/cache/output' });
     const reusedKey = Buffer.from('aabb', 'hex');
@@ -68,11 +60,11 @@ describe(getDefaultConfig, () => {
     if (!Array.isArray(stores)) {
       throw new Error('Expected an array of cache stores');
     }
-    expect(stores).toHaveLength(2);
+    expect(stores).toHaveLength(1);
     const cache = new Cache<Buffer>(stores);
     expect(await cache.get(reusedKey)).toEqual(reusedValue);
-    // Transformer calls set after both cache hits and newly computed transforms.
-    await cache.set(reusedKey, reusedValue);
+    // A read alone must collect the restored entry.
+    expect(await output.get(reusedKey)).toEqual(reusedValue);
     expect(await cache.get(newKey)).toBeNull();
     await cache.set(newKey, newValue);
 

--- a/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -1,6 +1,8 @@
+import { Cache } from '@expo/metro/metro-cache';
 import { vol } from 'memfs';
 
 import { getDefaultConfig, createStableModuleIdFactory } from '../ExpoMetroConfig';
+import { FileStore } from '../binary-file-store';
 
 const projectRoot = '/';
 const consoleError = console.error;
@@ -22,13 +24,60 @@ function mockProject() {
 }
 describe(getDefaultConfig, () => {
   beforeEach(() => {
+    delete process.env.EAS_METRO_CACHE_OUTPUT_DIR;
+    delete process.env.EAS_METRO_CACHE_RESTORE_DIR;
     mockProject();
   });
   afterEach(() => {
+    delete process.env.EAS_METRO_CACHE_OUTPUT_DIR;
+    delete process.env.EAS_METRO_CACHE_RESTORE_DIR;
     vol.reset();
   });
   afterAll(() => {
     console.error = consoleError;
+  });
+
+  it.each([
+    [undefined, undefined],
+    ['/cache/output', undefined],
+    [undefined, '/cache/restored'],
+  ])('keeps one default store with output=%s and restored=%s', (output, restored) => {
+    if (output) process.env.EAS_METRO_CACHE_OUTPUT_DIR = output;
+    if (restored) process.env.EAS_METRO_CACHE_RESTORE_DIR = restored;
+    expect(getDefaultConfig(projectRoot).cacheStores).toHaveLength(1);
+  });
+
+  it('collects restored hits and new transforms without unused restored entries', async () => {
+    process.env.EAS_METRO_CACHE_OUTPUT_DIR = '/cache/output';
+    process.env.EAS_METRO_CACHE_RESTORE_DIR = '/cache/restored';
+    const restored = new FileStore<Buffer>({ root: '/cache/restored' });
+    const output = new FileStore<Buffer>({ root: '/cache/output' });
+    const reusedKey = Buffer.from('aabb', 'hex');
+    const unusedKey = Buffer.from('aacc', 'hex');
+    const newKey = Buffer.from('aadd', 'hex');
+    const reusedValue = Buffer.from('unchanged module');
+    const newValue = Buffer.from('changed module');
+    await restored.set(reusedKey, reusedValue);
+    await restored.set(unusedKey, Buffer.from('unused module'));
+
+    const stores = getDefaultConfig(projectRoot).cacheStores;
+    if (!Array.isArray(stores)) throw new Error('Expected an array of cache stores');
+    expect(stores).toHaveLength(2);
+    const cache = new Cache<Buffer>(stores);
+    expect(await cache.get(reusedKey)).toEqual(reusedValue);
+    // Transformer calls set after both cache hits and newly computed transforms.
+    await cache.set(reusedKey, reusedValue);
+    expect(await cache.get(newKey)).toBeNull();
+    await cache.set(newKey, newValue);
+
+    expect(await output.get(reusedKey)).toEqual(reusedValue);
+    expect(await output.get(newKey)).toEqual(newValue);
+    expect(await output.get(unusedKey)).toBeNull();
+    expect(await restored.get(unusedKey)).toEqual(Buffer.from('unused module'));
+
+    for (const store of stores) await store.clear();
+    expect(await output.get(reusedKey)).toBeNull();
+    expect(await restored.get(reusedKey)).toBeNull();
   });
 
   it('loads default configuration', () => {

--- a/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/@expo/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -24,11 +24,13 @@ function mockProject() {
 }
 describe(getDefaultConfig, () => {
   beforeEach(() => {
-    delete process.env.EXPO_METRO_CACHE_DIR;
+    delete process.env.EXPO_METRO_CACHE_RESTORE_DIR;
+    delete process.env.EXPO_METRO_CACHE_OUTPUT_DIR;
     mockProject();
   });
   afterEach(() => {
-    delete process.env.EXPO_METRO_CACHE_DIR;
+    delete process.env.EXPO_METRO_CACHE_RESTORE_DIR;
+    delete process.env.EXPO_METRO_CACHE_OUTPUT_DIR;
     vol.reset();
   });
   afterAll(() => {
@@ -37,15 +39,25 @@ describe(getDefaultConfig, () => {
 
   it.each([undefined, ''])('keeps the default store with cache root=%s', (root) => {
     if (root !== undefined) {
-      process.env.EXPO_METRO_CACHE_DIR = root;
+      process.env.EXPO_METRO_CACHE_RESTORE_DIR = root;
+      process.env.EXPO_METRO_CACHE_OUTPUT_DIR = root;
     }
     const stores = getDefaultConfig(projectRoot).cacheStores;
     expect(stores).toHaveLength(1);
     expect(Array.isArray(stores) && stores[0]).toBeInstanceOf(FileStore);
   });
 
+  it.each(['EXPO_METRO_CACHE_RESTORE_DIR', 'EXPO_METRO_CACHE_OUTPUT_DIR'])(
+    'rejects partial configuration with only %s set',
+    (name) => {
+      process.env[name] = '/cache';
+      expect(() => getDefaultConfig(projectRoot)).toThrow('must be set together');
+    }
+  );
+
   it('collects restored hits and new transforms without unused restored entries', async () => {
-    process.env.EXPO_METRO_CACHE_DIR = '/cache';
+    process.env.EXPO_METRO_CACHE_RESTORE_DIR = '/cache/restored';
+    process.env.EXPO_METRO_CACHE_OUTPUT_DIR = '/cache/output';
     const restored = new FileStore<Buffer>({ root: '/cache/restored' });
     const output = new FileStore<Buffer>({ root: '/cache/output' });
     const reusedKey = Buffer.from('aabb', 'hex');

--- a/packages/@expo/metro-config/src/__tests__/build-cache-store.test.ts
+++ b/packages/@expo/metro-config/src/__tests__/build-cache-store.test.ts
@@ -1,0 +1,45 @@
+import { Cache } from '@expo/metro/metro-cache';
+import { vol } from 'memfs';
+
+import { FileStore } from '../binary-file-store';
+import { BuildCacheStore } from '../build-cache-store';
+
+const key = Buffer.from('aabb', 'hex');
+const value = { code: 'unchanged' };
+
+describe(BuildCacheStore, () => {
+  afterEach(() => vol.reset());
+
+  it('writes only to output and preserves it across instances', async () => {
+    const store = new BuildCacheStore({ root: '/cache' });
+    await store.set(key, value);
+    expect(await new FileStore({ root: '/cache/restored' }).get(key)).toBeNull();
+    expect(await new BuildCacheStore({ root: '/cache' }).get(key)).toEqual(value);
+  });
+
+  it('prefers output over restored entries', async () => {
+    await new FileStore({ root: '/cache/restored' }).set(key, { code: 'old' });
+    const store = new BuildCacheStore({ root: '/cache' });
+    await store.set(key, value);
+    expect(await store.get(key)).toEqual(value);
+  });
+
+  it('preserves the binary store cache exclusion rules', async () => {
+    const store = new BuildCacheStore({ root: '/cache' });
+    await store.set(key, { output: [{ data: { skipCache: true } }] });
+    expect(await store.get(key)).toBeNull();
+  });
+
+  it.each([true, false])('collects another store hit only when placed first=%s', async (first) => {
+    const store = new BuildCacheStore({ root: '/cache' });
+    const other = { get: async () => value, set: async () => {}, clear() {} };
+    const cache = new Cache(first ? [store, other] : [other, store]);
+    expect(await cache.get(key)).toEqual(value);
+    await cache.set(key, value);
+    expect(await new FileStore({ root: '/cache/output' }).get(key)).toEqual(first ? value : null);
+  });
+
+  it('rejects relative roots', () => {
+    expect(() => new BuildCacheStore({ root: 'relative' })).toThrow('absolute');
+  });
+});

--- a/packages/@expo/metro-config/src/__tests__/build-cache-store.test.ts
+++ b/packages/@expo/metro-config/src/__tests__/build-cache-store.test.ts
@@ -11,27 +11,44 @@ describe(BuildCacheStore, () => {
   afterEach(() => vol.reset());
 
   it('writes only to output and preserves it across instances', async () => {
-    const store = new BuildCacheStore({ root: '/cache' });
+    const store = new BuildCacheStore({
+      restoredRoot: '/cache/restored',
+      outputRoot: '/cache/output',
+    });
     await store.set(key, value);
     expect(await new FileStore({ root: '/cache/restored' }).get(key)).toBeNull();
-    expect(await new BuildCacheStore({ root: '/cache' }).get(key)).toEqual(value);
+    expect(
+      await new BuildCacheStore({
+        restoredRoot: '/cache/restored',
+        outputRoot: '/cache/output',
+      }).get(key)
+    ).toEqual(value);
   });
 
   it('prefers output over restored entries', async () => {
     await new FileStore({ root: '/cache/restored' }).set(key, { code: 'old' });
-    const store = new BuildCacheStore({ root: '/cache' });
+    const store = new BuildCacheStore({
+      restoredRoot: '/cache/restored',
+      outputRoot: '/cache/output',
+    });
     await store.set(key, value);
     expect(await store.get(key)).toEqual(value);
   });
 
   it('preserves the binary store cache exclusion rules', async () => {
-    const store = new BuildCacheStore({ root: '/cache' });
+    const store = new BuildCacheStore({
+      restoredRoot: '/cache/restored',
+      outputRoot: '/cache/output',
+    });
     await store.set(key, { output: [{ data: { skipCache: true } }] });
     expect(await store.get(key)).toBeNull();
   });
 
   it.each([true, false])('collects another store hit only when placed first=%s', async (first) => {
-    const store = new BuildCacheStore({ root: '/cache' });
+    const store = new BuildCacheStore({
+      restoredRoot: '/cache/restored',
+      outputRoot: '/cache/output',
+    });
     const other = { get: async () => value, set: async () => {}, clear() {} };
     const cache = new Cache(first ? [store, other] : [other, store]);
     expect(await cache.get(key)).toEqual(value);
@@ -40,6 +57,16 @@ describe(BuildCacheStore, () => {
   });
 
   it('rejects relative roots', () => {
-    expect(() => new BuildCacheStore({ root: 'relative' })).toThrow('absolute');
+    expect(
+      () => new BuildCacheStore({ restoredRoot: 'relative', outputRoot: '/cache/output' })
+    ).toThrow('absolute');
+  });
+  it.each([
+    ['/cache', '/cache'],
+    ['/cache', '/cache/output'],
+    ['/cache/restored', '/cache'],
+    ['/cache/a/..', '/cache'],
+  ])('rejects overlapping directories %s and %s', (restoredRoot, outputRoot) => {
+    expect(() => new BuildCacheStore({ restoredRoot, outputRoot })).toThrow('distinct');
   });
 });

--- a/packages/@expo/metro-config/src/__tests__/build-cache-store.test.ts
+++ b/packages/@expo/metro-config/src/__tests__/build-cache-store.test.ts
@@ -55,18 +55,4 @@ describe(BuildCacheStore, () => {
     await cache.set(key, value);
     expect(await new FileStore({ root: '/cache/output' }).get(key)).toEqual(first ? value : null);
   });
-
-  it('rejects relative roots', () => {
-    expect(
-      () => new BuildCacheStore({ restoredRoot: 'relative', outputRoot: '/cache/output' })
-    ).toThrow('absolute');
-  });
-  it.each([
-    ['/cache', '/cache'],
-    ['/cache', '/cache/output'],
-    ['/cache/restored', '/cache'],
-    ['/cache/a/..', '/cache'],
-  ])('rejects overlapping directories %s and %s', (restoredRoot, outputRoot) => {
-    expect(() => new BuildCacheStore({ restoredRoot, outputRoot })).toThrow('distinct');
-  });
 });

--- a/packages/@expo/metro-config/src/build-cache-store.ts
+++ b/packages/@expo/metro-config/src/build-cache-store.ts
@@ -1,0 +1,41 @@
+import path from 'node:path';
+
+import { FileStore } from './binary-file-store';
+
+/** Collects only results used by this build in root/output. */
+export class BuildCacheStore<T> {
+  private readonly output: FileStore<T>;
+  private readonly restored: FileStore<T>;
+
+  constructor({ root }: { root: string }) {
+    if (!path.isAbsolute(root)) {
+      throw new Error('The Metro cache root must be an absolute path');
+    }
+    // The build runner creates an empty output directory once per job.
+    // Do not clear it here: multiple Metro processes can share the same job.
+    this.output = new FileStore<T>({ root: path.join(root, 'output') });
+    this.restored = new FileStore<T>({ root: path.join(root, 'restored') });
+  }
+
+  async get(key: Buffer): Promise<T | null | undefined> {
+    const current = await this.output.get(key);
+    if (current != null) {
+      return current;
+    }
+    const previous = await this.restored.get(key);
+    if (previous != null) {
+      // Complete promotion here, even if Metro does not call set after a hit.
+      await this.output.set(key, previous);
+    }
+    return previous;
+  }
+
+  set(key: Buffer, value: T): Promise<void> {
+    return this.output.set(key, value);
+  }
+
+  clear(): void {
+    this.output.clear();
+    this.restored.clear();
+  }
+}

--- a/packages/@expo/metro-config/src/build-cache-store.ts
+++ b/packages/@expo/metro-config/src/build-cache-store.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { FileStore } from './binary-file-store';
 
 /** Collects only results used by this build in the output directory. */
@@ -8,19 +6,6 @@ export class BuildCacheStore<T> {
   private readonly restored: FileStore<T>;
 
   constructor({ restoredRoot, outputRoot }: { restoredRoot: string; outputRoot: string }) {
-    if (!path.isAbsolute(restoredRoot) || !path.isAbsolute(outputRoot)) {
-      throw new Error('Metro cache directories must be absolute paths');
-    }
-    const overlaps = (parent: string, child: string): boolean => {
-      const relative = path.relative(parent, child);
-      return (
-        relative === '' ||
-        (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith('..' + path.sep))
-      );
-    };
-    if (overlaps(restoredRoot, outputRoot) || overlaps(outputRoot, restoredRoot)) {
-      throw new Error('Metro cache directories must be distinct and must not contain each other');
-    }
     // The build runner creates an empty output directory once per job.
     // Do not clear it here: multiple Metro processes can share the same job.
     this.output = new FileStore<T>({ root: outputRoot });

--- a/packages/@expo/metro-config/src/build-cache-store.ts
+++ b/packages/@expo/metro-config/src/build-cache-store.ts
@@ -2,19 +2,29 @@ import path from 'node:path';
 
 import { FileStore } from './binary-file-store';
 
-/** Collects only results used by this build in root/output. */
+/** Collects only results used by this build in the output directory. */
 export class BuildCacheStore<T> {
   private readonly output: FileStore<T>;
   private readonly restored: FileStore<T>;
 
-  constructor({ root }: { root: string }) {
-    if (!path.isAbsolute(root)) {
-      throw new Error('The Metro cache root must be an absolute path');
+  constructor({ restoredRoot, outputRoot }: { restoredRoot: string; outputRoot: string }) {
+    if (!path.isAbsolute(restoredRoot) || !path.isAbsolute(outputRoot)) {
+      throw new Error('Metro cache directories must be absolute paths');
+    }
+    const overlaps = (parent: string, child: string): boolean => {
+      const relative = path.relative(parent, child);
+      return (
+        relative === '' ||
+        (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith('..' + path.sep))
+      );
+    };
+    if (overlaps(restoredRoot, outputRoot) || overlaps(outputRoot, restoredRoot)) {
+      throw new Error('Metro cache directories must be distinct and must not contain each other');
     }
     // The build runner creates an empty output directory once per job.
     // Do not clear it here: multiple Metro processes can share the same job.
-    this.output = new FileStore<T>({ root: path.join(root, 'output') });
-    this.restored = new FileStore<T>({ root: path.join(root, 'restored') });
+    this.output = new FileStore<T>({ root: outputRoot });
+    this.restored = new FileStore<T>({ root: restoredRoot });
   }
 
   async get(key: Buffer): Promise<T | null | undefined> {

--- a/packages/@expo/metro-config/src/env.ts
+++ b/packages/@expo/metro-config/src/env.ts
@@ -1,20 +1,9 @@
 import { boolish, int, string } from 'getenv';
 
 class Env {
-  /**
-   * Output directory for Metro transforms used or created during a build.
-   * Used together with EAS_METRO_CACHE_RESTORE_DIR.
-   */
-  get EAS_METRO_CACHE_OUTPUT_DIR(): string {
-    return string('EAS_METRO_CACHE_OUTPUT_DIR', '');
-  }
-
-  /**
-   * Directory containing Metro transforms restored from a previous build.
-   * Used together with EAS_METRO_CACHE_OUTPUT_DIR.
-   */
-  get EAS_METRO_CACHE_RESTORE_DIR(): string {
-    return string('EAS_METRO_CACHE_RESTORE_DIR', '');
+  /** Absolute parent directory for restored/ and output/ Metro transform caches. */
+  get EXPO_METRO_CACHE_DIR(): string {
+    return string('EXPO_METRO_CACHE_DIR', '');
   }
 
   /** Enable debug logging */

--- a/packages/@expo/metro-config/src/env.ts
+++ b/packages/@expo/metro-config/src/env.ts
@@ -1,9 +1,14 @@
 import { boolish, int, string } from 'getenv';
 
 class Env {
-  /** Absolute parent directory for restored/ and output/ Metro transform caches. */
-  get EXPO_METRO_CACHE_DIR(): string {
-    return string('EXPO_METRO_CACHE_DIR', '');
+  /** Absolute directory containing transforms restored from a previous build. Requires EXPO_METRO_CACHE_OUTPUT_DIR. */
+  get EXPO_METRO_CACHE_RESTORE_DIR(): string {
+    return string('EXPO_METRO_CACHE_RESTORE_DIR', '');
+  }
+
+  /** Absolute directory for transforms used by this build. Requires EXPO_METRO_CACHE_RESTORE_DIR. */
+  get EXPO_METRO_CACHE_OUTPUT_DIR(): string {
+    return string('EXPO_METRO_CACHE_OUTPUT_DIR', '');
   }
 
   /** Enable debug logging */

--- a/packages/@expo/metro-config/src/env.ts
+++ b/packages/@expo/metro-config/src/env.ts
@@ -1,12 +1,18 @@
 import { boolish, int, string } from 'getenv';
 
 class Env {
-  /** Fresh directory for transform results used by this EAS job. Requires EAS_METRO_CACHE_RESTORE_DIR. */
+  /**
+   * Output directory for Metro transforms used or created during a build.
+   * Used together with EAS_METRO_CACHE_RESTORE_DIR.
+   */
   get EAS_METRO_CACHE_OUTPUT_DIR(): string {
     return string('EAS_METRO_CACHE_OUTPUT_DIR', '');
   }
 
-  /** Directory restored from an earlier EAS job. Requires EAS_METRO_CACHE_OUTPUT_DIR. */
+  /**
+   * Directory containing Metro transforms restored from a previous build.
+   * Used together with EAS_METRO_CACHE_OUTPUT_DIR.
+   */
   get EAS_METRO_CACHE_RESTORE_DIR(): string {
     return string('EAS_METRO_CACHE_RESTORE_DIR', '');
   }

--- a/packages/@expo/metro-config/src/env.ts
+++ b/packages/@expo/metro-config/src/env.ts
@@ -1,6 +1,16 @@
-import { boolish, int } from 'getenv';
+import { boolish, int, string } from 'getenv';
 
 class Env {
+  /** Fresh directory for transform results used by this EAS job. Requires EAS_METRO_CACHE_RESTORE_DIR. */
+  get EAS_METRO_CACHE_OUTPUT_DIR(): string {
+    return string('EAS_METRO_CACHE_OUTPUT_DIR', '');
+  }
+
+  /** Directory restored from an earlier EAS job. Requires EAS_METRO_CACHE_OUTPUT_DIR. */
+  get EAS_METRO_CACHE_RESTORE_DIR(): string {
+    return string('EAS_METRO_CACHE_RESTORE_DIR', '');
+  }
+
   /** Enable debug logging */
   get EXPO_DEBUG() {
     return boolish('EXPO_DEBUG', false);

--- a/packages/@expo/metro-config/src/env.ts
+++ b/packages/@expo/metro-config/src/env.ts
@@ -1,12 +1,12 @@
 import { boolish, int, string } from 'getenv';
 
 class Env {
-  /** Absolute directory containing transforms restored from a previous build. Requires EXPO_METRO_CACHE_OUTPUT_DIR. */
+  /** Directory containing transforms restored from a previous build. Used when EXPO_METRO_CACHE_OUTPUT_DIR is also set. */
   get EXPO_METRO_CACHE_RESTORE_DIR(): string {
     return string('EXPO_METRO_CACHE_RESTORE_DIR', '');
   }
 
-  /** Absolute directory for transforms used by this build. Requires EXPO_METRO_CACHE_RESTORE_DIR. */
+  /** Directory for Metro transform cache reads and writes. With EXPO_METRO_CACHE_RESTORE_DIR, collects transforms used by this build. */
   get EXPO_METRO_CACHE_OUTPUT_DIR(): string {
     return string('EXPO_METRO_CACHE_OUTPUT_DIR', '');
   }


### PR DESCRIPTION
# Why

Sharing Metro transform cache between builds and other jobs is going to improve speed of bundling.

# How

Adds support for `EXPO_METRO_CACHE_OUTPUT_DIR` as "the Metro cache output directory".

It also adds support for passing both that and `EXPO_METRO_CACHE_RESTORE_DIR`, in which case we use not the regular `FileStore`, but a new `BuildCacheStore` which is a simple wrapper over `FileStore` which uses both "restored" and "output" directories as providing cache and tries to make "output" "cache-complete".

# Test Plan

Tested locally.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to the contribution guide. (Changelog added; build blocked as described above.)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build. (Worker integration remains separate.)
- [x] Conforms with the Documentation Writing Style Guide.



