### PR TITLE
[babel-preset-expo] Update snapshots for Worklets 0.12.2

### DIFF
--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
@@ -260,11 +260,11 @@ console.log("Hey I'm running on the UI thread");
 `;
 
 exports[`metro supports reanimated worklets 1`] = `
-"var _worklet_14307677064221_init_data={code:"function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}"};var someWorklet=
-function someWorklet_workletJs1Factory(_ref){var _worklet_14307677064221_init_data=_ref._worklet_14307677064221_init_data;var _e=[new global.Error(),1,-27];var someWorklet=function(greeting){
+"var _worklet_12052387590108_init_data={code:"(function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");})",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}"};var someWorklet=
+function someWorklet_workletJs1Factory(_ref){var _worklet_12052387590108_init_data=_ref._worklet_12052387590108_init_data;var _e=[new global.Error(),1,-27];var someWorklet=function(greeting){"use no memo";
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="[GLOBAL]";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
+};someWorklet.__closure={};someWorklet.__workletHash=12052387590108;someWorklet.__pluginVersion="[GLOBAL]";someWorklet.__initData=_worklet_12052387590108_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_12052387590108_init_data});"
 `;
 
 exports[`metro transpiles non-standard exports 1`] = `
@@ -292,11 +292,11 @@ console.log("Hey I'm running on the UI thread");
 `;
 
 exports[`metro+hermes supports reanimated worklets 1`] = `
-"var _worklet_14307677064221_init_data={code:"function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}"};var someWorklet=
-function someWorklet_workletJs1Factory({_worklet_14307677064221_init_data}){var _e=[new global.Error(),1,-27];var someWorklet=function(greeting){
+"var _worklet_12052387590108_init_data={code:"(function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");})",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}"};var someWorklet=
+function someWorklet_workletJs1Factory({_worklet_12052387590108_init_data}){var _e=[new global.Error(),1,-27];var someWorklet=function(greeting){"use no memo";
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="[GLOBAL]";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
+};someWorklet.__closure={};someWorklet.__workletHash=12052387590108;someWorklet.__pluginVersion="[GLOBAL]";someWorklet.__initData=_worklet_12052387590108_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_12052387590108_init_data});"
 `;
 
 exports[`metro+hermes transpiles non-standard exports 1`] = `
@@ -324,11 +324,11 @@ console.log("Hey I'm running on the UI thread");
 `;
 
 exports[`webpack supports reanimated worklets 1`] = `
-"const _worklet_14307677064221_init_data={code:"function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}"};const someWorklet=
-function someWorklet_workletJs1Factory({_worklet_14307677064221_init_data}){const _e=[new global.Error(),1,-27];const someWorklet=function(greeting){
+"const _worklet_12052387590108_init_data={code:"(function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");})",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}"};const someWorklet=
+function someWorklet_workletJs1Factory({_worklet_12052387590108_init_data}){const _e=[new global.Error(),1,-27];const someWorklet=function(greeting){"use no memo";
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="[GLOBAL]";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
+};someWorklet.__closure={};someWorklet.__workletHash=12052387590108;someWorklet.__pluginVersion="[GLOBAL]";someWorklet.__initData=_worklet_12052387590108_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_12052387590108_init_data});"
 `;
 
 exports[`webpack transpiles non-standard exports 1`] = `


### PR DESCRIPTION
Updates three Babel preset snapshots after #49968 upgraded `react-native-worklets` from 0.10.1 to 0.12.2. The plugin now adds function parentheses and `"use no memo"`, which also changes the worklet hash.

Reproduced the CI failures locally. All 31 tests and 20 snapshots in `index.test.ts` pass with the updated expectations. No runtime code changes.
