### PR TITLE
[docs] Derive API platform tag version list from versions.json

### DIFF
--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -3,6 +3,7 @@ import { mergeClasses } from '@expo/styleguide';
 import { STYLES_SECONDARY } from '~/components/plugins/api/styles';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import { usePageMetadata } from '~/providers/page-metadata';
+import versions from '~/public/static/constants/versions.json';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 import { StatusTag } from '~/ui/components/Tag/StatusTag';
 import { isClientPlatformTag } from '~/ui/components/Tag/helpers';
@@ -30,9 +31,7 @@ export const APISectionPlatformTags = ({
   const { platforms: defaultPlatforms } = usePageMetadata();
   const { version } = usePageApiVersion();
 
-  const isCompatibleVersion = ['unversioned', 'latest', 'v56.0.0', 'v55.0.0', 'v54.0.0'].includes(
-    version
-  );
+  const isCompatibleVersion = versions.VERSIONS.includes(version);
   const platformsData = platforms ?? getAllTagData('platform', comment);
   const experimentalData = getAllTagData('experimental', comment);
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26720

# How

<!--
How did you build this feature or fix this bug and why?
-->

Derive API platform tag version list from versions.json instead of hard coded values.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Platform tags show up for latest and SDK 57 docs:

<img width="2328" height="828" alt="CleanShot 2026-09-11 at 16 35 27@2x" src="https://github.com/user-attachments/assets/a8088c6a-0847-46a3-9574-7f804d99f849" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
