### PR TITLE
[router-tester] Add eas:build script

### DIFF
--- a/apps/router-tester/README.md
+++ b/apps/router-tester/README.md
@@ -2,6 +2,8 @@
 
 Run `pnpm prebuild` to generate the native projects, then run `pnpm ios` or `pnpm android` to build and launch the dev client.
 
+Run `pnpm eas:build -p ios --profile development` to build on EAS. It uploads only the files this app needs from the monorepo.
+
 Run the Maestro test with:
 
 ```bash

--- a/apps/router-tester/eas.json
+++ b/apps/router-tester/eas.json
@@ -5,7 +5,7 @@
   },
   "build": {
     "development": {
-      "pnpm": "10.33.0",
+      "pnpm": "12.2.1",
       "developmentClient": true,
       "distribution": "internal",
       "ios": {
@@ -13,21 +13,21 @@
       }
     },
     "android-apk": {
-      "pnpm": "10.33.0",
+      "pnpm": "12.2.1",
       "distribution": "internal",
       "android": {
         "buildType": "apk"
       }
     },
     "ios-simulator": {
-      "pnpm": "10.33.0",
+      "pnpm": "12.2.1",
       "distribution": "internal",
       "ios": {
         "simulator": true
       }
     },
     "ios-testflight": {
-      "pnpm": "10.33.0",
+      "pnpm": "12.2.1",
       "distribution": "store",
       "autoIncrement": true
     }

--- a/apps/router-tester/package.json
+++ b/apps/router-tester/package.json
@@ -8,6 +8,7 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
+    "eas:build": "./scripts/eas-build.sh",
     "lint": "expo lint",
     "test:e2e": "./maestro/test.sh"
   },

--- a/apps/router-tester/scripts/eas-build.sh
+++ b/apps/router-tester/scripts/eas-build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Runs `eas build` with a temporary root `.easignore` so the upload contains only
+# what this app needs. eas-cli archives the whole git root, and once `.easignore`
+# exists it replaces every `.gitignore`, so the file must also list what git
+# currently ignores on disk.
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+EASIGNORE="$ROOT_DIR/.easignore"
+
+if [ -e "$EASIGNORE" ]; then
+  echo "$EASIGNORE already exists, remove it first" >&2
+  exit 1
+fi
+trap 'rm -f "$EASIGNORE"' EXIT
+
+{
+  printf '%s\n' '/docs/' '/guides/' '/apps/*' '!/apps/router-tester'
+  # Paths git ignores right now, anchored to the root with glob characters escaped.
+  git -C "$ROOT_DIR" ls-files --others --ignored --exclude-standard --directory |
+    sed -e 's/[][*?]/\\&/g' -e 's|^|/|'
+} > "$EASIGNORE"
+
+eas build "$@"

--- a/apps/router-tester/scripts/eas-build.sh
+++ b/apps/router-tester/scripts/eas-build.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Runs `eas build` with a temporary root `.easignore` so the upload contains only
-# what this app needs. eas-cli archives the whole git root, and once `.easignore`
-# exists it replaces every `.gitignore`, so the file must also list what git
-# currently ignores on disk.
+# what this app needs. eas-cli archives the whole git root plus the `.git` pack of
+# the shallow clone, and once `.easignore` exists it replaces every `.gitignore`,
+# so the file must also list what git currently ignores on disk.
 
 set -euo pipefail
 
@@ -17,7 +17,7 @@ fi
 trap 'rm -f "$EASIGNORE"' EXIT
 
 {
-  printf '%s\n' '/docs/' '/guides/' '/apps/*' '!/apps/router-tester'
+  printf '%s\n' '/.git' '/docs/' '/guides/' '/apps/*' '!/apps/router-tester'
   # Paths git ignores right now, anchored to the root with glob characters escaped.
   git -C "$ROOT_DIR" ls-files --others --ignored --exclude-standard --directory |
     sed -e 's/[][*?]/\\&/g' -e 's|^|/|'


### PR DESCRIPTION
# Why

To reduce the upload size to EAS from 200 MB to 37 MB

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
