### PR TITLE
[widgets][iOS] Fix Live Activity environment resolution

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Preserve SwiftUI view identity across widget and Live Activity updates so system update animations can run. ([#49810](https://github.com/expo/expo/pull/49810) by [@jakex7](https://github.com/jakex7))
+- [iOS] Fix Live Activity `colorScheme` and `isLuminanceReduced` always reporting default values. ([#50034](https://github.com/expo/expo/pull/50034) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/ios/Widgets/LiveActivityNodesProvider.swift
+++ b/packages/expo-widgets/ios/Widgets/LiveActivityNodesProvider.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+@MainActor
+final class LiveActivityNodesProvider {
+  typealias Renderer = ([String: Any]) -> WidgetJavaScriptResult<[String: Any]>
+
+  private static let cacheLimit = 2
+
+  private struct CacheEntry {
+    let environment: NSDictionary
+    let nodes: [String: Any]
+  }
+
+  private let render: Renderer
+  private var cache: [CacheEntry] = []
+
+  convenience init(forName name: String, props: String?) {
+    let layout = WidgetsStorage.getString(forKey: "__expo_widgets_live_activity_\(name)_layout") ?? ""
+    let parsedProps = props.flatMap { props in
+      props.data(using: .utf8).flatMap {
+        try? JSONSerialization.jsonObject(with: $0, options: []) as? [String: Any]
+      }
+    }
+
+    self.init { environment in
+      evaluateWidgetLayout(layout: layout, props: parsedProps, environment: environment)
+    }
+  }
+
+  init(render: @escaping Renderer) {
+    self.render = render
+  }
+
+  func nodes(for environment: [String: Any]) -> [String: Any] {
+    if let index = cache.firstIndex(where: { $0.environment.isEqual(to: environment) }) {
+      let cached = cache.remove(at: index)
+      cache.append(cached)
+      return cached.nodes
+    }
+
+    let nodes: [String: Any]
+    switch render(environment) {
+    case .success(let result):
+      nodes = result
+    case .failure(let error):
+      print("[ExpoWidgets] Layout evaluation failed: \(error.message)")
+      nodes = ["banner": createRedBox(message: error.message)]
+    }
+
+    cache.append(CacheEntry(environment: NSDictionary(dictionary: environment), nodes: nodes))
+    if cache.count > Self.cacheLimit {
+      cache.removeFirst(cache.count - Self.cacheLimit)
+    }
+    return nodes
+  }
+}

--- a/packages/expo-widgets/ios/Widgets/Utils.swift
+++ b/packages/expo-widgets/ios/Widgets/Utils.swift
@@ -76,23 +76,6 @@ public func evaluateLayout(
   }
 }
 
-func getLiveActivityNodes(forName name: String, props: String? = nil, environment: [String: Any]) -> [String: Any] {
-  let layout = WidgetsStorage.getString(forKey: "__expo_widgets_live_activity_\(name)_layout") ?? ""
-  let propsDict = props.flatMap { props in
-    props.data(using: .utf8).flatMap {
-      try? JSONSerialization.jsonObject(with: $0, options: []) as? [String: Any]
-    }
-  }
-
-  switch evaluateWidgetLayout(layout: layout, props: propsDict, environment: environment) {
-  case .success(let result):
-    return result
-  case .failure(let error):
-    print("[ExpoWidgets] Layout evaluation failed: \(error.message)")
-    return ["banner": createRedBox(message: error.message)]
-  }
-}
-
 public func getWidgetEnvironment(environment: EnvironmentValues) -> [String: Any] {
   var env: [String: Any] = [
     "showsContainerBackground": environment.showsWidgetContainerBackground,
@@ -117,7 +100,11 @@ public func getWidgetEnvironment(environment: EnvironmentValues) -> [String: Any
   return env
 }
 
-func getLiveActivityEnvironment(for environment: EnvironmentValues, in context: ActivityViewContext<LiveActivityAttributes>) -> [String: Any] {
+@MainActor
+func getLiveActivityEnvironment(
+  for environment: EnvironmentValues,
+  in context: ActivityViewContext<LiveActivityAttributes>
+) -> [String: Any] {
   var env: [String: Any] = [
     "colorScheme": "\(environment.colorScheme)",
     "isLuminanceReduced": environment.isLuminanceReduced,

--- a/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
+++ b/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
@@ -19,53 +19,49 @@ struct LiveActivityAttributes: ActivityAttributes {
 }
 
 public struct WidgetLiveActivity: Widget {
-  @Environment(\.self) var env
-  
   let widgetContext: AppContext = AppContext()
 
   public init() {}
 
   public var body: some WidgetConfiguration {
     ActivityConfiguration(for: LiveActivityAttributes.self) { context in
-      let nodes = getLiveActivityNodes(
+      let nodesProvider = LiveActivityNodesProvider(
         forName: context.state.name,
-        props: context.state.props,
-        environment: getLiveActivityEnvironment(for: env, in: context)
+        props: context.state.props
       )
       // Only apply widgetURL when the activity has one: a hierarchy with more than one
       // widgetURL modifier is undefined behavior, and layouts can set their own through
       // the widgetURL modifier from @expo/ui.
-      let banner = LiveActivityBannerView(context: context, nodes: nodes)
+      let banner = LiveActivityBannerView(context: context, nodesProvider: nodesProvider)
       if let url = context.attributes.url.flatMap(URL.init(string:)) {
         banner.widgetURL(url)
       } else {
         banner
       }
     } dynamicIsland: { context in
-      let nodes = getLiveActivityNodes(
+      let nodesProvider = LiveActivityNodesProvider(
         forName: context.state.name,
-        props: context.state.props,
-        environment: getLiveActivityEnvironment(for: env, in: context)
+        props: context.state.props
       )
       let island = DynamicIsland {
         DynamicIslandExpandedRegion(.center) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedCenter")
+          LiveActivitySectionView(context: context, nodesProvider: nodesProvider, sectionName: "expandedCenter")
         }
         DynamicIslandExpandedRegion(.leading) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedLeading")
+          LiveActivitySectionView(context: context, nodesProvider: nodesProvider, sectionName: "expandedLeading")
         }
         DynamicIslandExpandedRegion(.trailing) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedTrailing")
+          LiveActivitySectionView(context: context, nodesProvider: nodesProvider, sectionName: "expandedTrailing")
         }
         DynamicIslandExpandedRegion(.bottom) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedBottom")
+          LiveActivitySectionView(context: context, nodesProvider: nodesProvider, sectionName: "expandedBottom")
         }
       } compactLeading: {
-        LiveActivitySectionView(context: context, nodes: nodes, sectionName: "compactLeading")
+        LiveActivitySectionView(context: context, nodesProvider: nodesProvider, sectionName: "compactLeading")
       } compactTrailing: {
-        LiveActivitySectionView(context: context, nodes: nodes, sectionName: "compactTrailing")
+        LiveActivitySectionView(context: context, nodesProvider: nodesProvider, sectionName: "compactTrailing")
       } minimal: {
-        LiveActivitySectionView(context: context, nodes: nodes, sectionName: "minimal")
+        LiveActivitySectionView(context: context, nodesProvider: nodesProvider, sectionName: "minimal")
       }
       if let url = context.attributes.url.flatMap(URL.init(string:)) {
         return island.widgetURL(url)
@@ -77,11 +73,15 @@ public struct WidgetLiveActivity: Widget {
 }
 
 private struct LiveActivitySectionView: View {
+  @Environment(\.self) private var env
   let context: ActivityViewContext<LiveActivityAttributes>
-  let nodes: [String: Any]
+  let nodesProvider: LiveActivityNodesProvider
   let sectionName: String
 
   var body: some View {
+    let nodes = nodesProvider.nodes(
+      for: getLiveActivityEnvironment(for: env, in: context)
+    )
     if let node = nodes[sectionName] as? [String: Any] {
       WidgetsDynamicView(name: context.activityID, kind: .liveActivity, node: node)
     } else {
@@ -91,10 +91,14 @@ private struct LiveActivitySectionView: View {
 }
 
 private struct LiveActivityBannerView: View {
+  @Environment(\.self) private var env
   var context: ActivityViewContext<LiveActivityAttributes>
-  let nodes: [String: Any]
+  let nodesProvider: LiveActivityNodesProvider
 
   var body: some View {
+    let nodes = nodesProvider.nodes(
+      for: getLiveActivityEnvironment(for: env, in: context)
+    )
     if #available(iOS 18.0, *) {
       LiveActivityBanner(context: context, nodes: nodes)
     } else if let node = nodes["banner"] as? [String: Any] {


### PR DESCRIPTION
# Why

Live Activities read default `colorScheme` and `isLuminanceReduced` values from the widget. Related: #49050.

# How

Read the environment inside SwiftUI views and share a two-entry layout cache across Dynamic Island regions, including failed evaluations, to avoid repeated JS renders for matching environments.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
