### PR TITLE
[dev-menu][tvOS] Attach deferred menu windows to a scene

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [tvOS] Attach the developer-menu window to an active scene before showing it when initialized before scene activation.
+- [tvOS] Attach the developer-menu window to an active scene before showing it when initialized before scene activation. ([#50036](https://github.com/expo/expo/pull/50036) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [tvOS] Attach the developer-menu window to an active scene before showing it when initialized before scene activation.
+
 ### 💡 Others
 
 ## 58.0.0 — 2026-09-10

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -433,10 +433,10 @@ open class DevMenuManager: NSObject {
       DispatchQueue.main.async {
 #if os(macOS)
         self.window?.makeKeyAndOrderFront(nil)
-#elseif os(tvOS)
-        self.window?.makeKeyAndVisible()
 #else
+#if !os(tvOS)
         self.updateFABVisibility()
+#endif
 
         if self.window?.windowScene == nil {
           self.window?.windowScene = SceneGeometry.foregroundActiveScene()


### PR DESCRIPTION
# Why

If the developer-menu window is initialized before a scene becomes foreground-active, its initializer creates a zero-sized window without a scene. On tvOS, showing the menu previously skipped the deferred scene attachment used on iOS, leaving that window unattached.

Found while validating the scene lifecycle backport in #50026. That PR now includes the same correction.

# How

Share deferred scene attachment and `makeKeyAndVisible()` between iOS and tvOS. Keep floating-button updates excluded on tvOS and retain the macOS path.

# Test Plan

- Focused review of the change passed.
- Xcode 27 RC Swift parser check with a tvOS simulator target passed; `git diff --check` passed.
- The equivalent SDK 57 change compiled successfully in an iOS 27 simulator app with the real expo-dev-menu source.
- tvOS runtime validation (initialize before scene activation, then open the menu) remains outstanding. Kept as a draft for this check.
