### PR TITLE
[ios][core] Update to expo-modules-macros-plugin 0.10.0

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,9 +6,14 @@
 
 ### 🎉 New features
 
+- [iOS] Added the `@Union` macro that turns an enum whose cases each carry one associated value into a typed union (`A | B` in TypeScript), usable as a `@JS` argument or return value. ([#50037](https://github.com/expo/expo/pull/50037) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Added the `.concurrent` option to `@JS` (`@JS(.concurrent)`), which runs the body of an async function off the JavaScript thread. ([#50037](https://github.com/expo/expo/pull/50037) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others
+
+- [iOS] Bumped `@expo/expo-modules-macros-plugin` to `0.10.0`. ([#50037](https://github.com/expo/expo/pull/50037) by [@tsapeta](https://github.com/tsapeta))
 
 ## 58.0.0 — 2026-09-10
 

--- a/packages/expo-modules-core/ios/Core/Exceptions/CommonExceptions.swift
+++ b/packages/expo-modules-core/ios/Core/Exceptions/CommonExceptions.swift
@@ -79,6 +79,18 @@ public struct Exceptions {
   }
 
   /**
+   An exception to throw when a value does not match any case of a `@Union` enum. The synthesized
+   `decode` throws it when no case decodes the JavaScript value (`received` is the JS kind, such as
+   `number`). The synthesized `as(_:)` throws it when the union holds a different case (`received` is
+   that case's payload type).
+   */
+  public final class UnionCaseMismatch: GenericException<(unionName: String, received: String, expected: [String])> {
+    override public var reason: String {
+      "'\(param.unionName)' expected \(param.expected.joined(separator: " or ")), but received \(param.received)"
+    }
+  }
+
+  /**
    An exception to throw when there is no module implementing the `EXFileSystemInterface` interface.
    */
   public final class FileSystemModuleNotFound: Exception {

--- a/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
@@ -24,6 +24,20 @@
 public macro OptimizedFunction() =
   #externalMacro(module: "ExpoModulesMacros", type: "OptimizedFunctionAttachedMacro")
 
+/// Options passed to `@JS` after the optional JS name, e.g. `@JS(.concurrent)` or
+/// `@JS("doWork", .concurrent)`. The macro reads them from the source, so spell them as `.option`
+/// literals rather than constants.
+public enum JSOptions {
+  /// Runs the body of an `async` function on the concurrent thread pool instead of the JavaScript
+  /// thread. Arguments are still decoded and the result encoded on the JavaScript thread, so only
+  /// the function's own work moves. Use it for work that never touches JavaScript values, such as
+  /// hashing or file IO. Only valid on an `async` function.
+  ///
+  /// The call sends the module or shared object off the JavaScript thread, so in Swift 6 language
+  /// mode the enclosing class must be `Sendable`.
+  case concurrent
+}
+
 /// Marker macro applied to module / shared-object members that should be exposed to JavaScript.
 /// The accompanying `@ExpoModule` and `@SharedObject` macros discover `@JS`-marked declarations
 /// and generate the matching `Function` / `AsyncFunction` / `Property` / `Constructor` registrations.
@@ -39,12 +53,25 @@ public macro OptimizedFunction() =
 ///     @JS
 ///     var status: String { "ok" }
 ///
+///     @JS(.concurrent)
+///     func digest(data: Data) async -> Data { ... }
+///
+///     @JS("doWork", .concurrent)
+///     func performHeavyWork() async throws { ... }
+///
 /// Also emits a never-called `_assertTypesConformance_<member>` peer that statically asserts every
 /// type crossing the JS boundary conforms to the JS-convertible protocol, so a non-conforming type
 /// fails to compile on the user's declaration. The peer name embeds the member name, hence
 /// `names: arbitrary`.
+///
+/// Trailing `JSOptions` tune the binding. The options-only overload exists because `.concurrent`
+/// can't fill the unlabeled `jsName` slot.
 @attached(peer, names: arbitrary)
-public macro JS(_ jsName: String? = nil) =
+public macro JS(_ jsName: String? = nil, _ options: JSOptions...) =
+  #externalMacro(module: "ExpoModulesMacros", type: "JSMacro")
+
+@attached(peer, names: arbitrary)
+public macro JS(_ options: JSOptions...) =
   #externalMacro(module: "ExpoModulesMacros", type: "JSMacro")
 
 /// Turns a function-typed `var` on a module or shared object into a typed JavaScript event.
@@ -155,3 +182,42 @@ public macro SharedObject(_ name: String? = nil) =
 @attached(extension, conformances: Record)
 public macro Record() =
   #externalMacro(module: "ExpoModulesMacros", type: "RecordMacro")
+
+/// Member + extension macro applied to an `enum` whose cases each carry one associated value. The enum
+/// becomes a typed union of the payload types (`A | B` in TypeScript), the named, N-case counterpart
+/// of `Either`. It can be a `@JS` argument or return value, an `@Event` payload, or nested in an
+/// optional, array or dictionary. Synthesized members:
+///
+/// - `decode(_:in:)` tries the cases in declaration order and returns the first whose payload decodes.
+///   Overlapping payloads (`Int` and `Double`, records with compatible fields) resolve to the earlier
+///   case, so put the more specific case first. Throws `Exceptions.UnionCaseMismatch` when none match.
+/// - `encode(_:in:)` encodes the payload of the held case.
+/// - `as(_:)`, one overload per payload type: `try source.as(String.self)` unwraps the payload without
+///   naming the case and throws `Exceptions.UnionCaseMismatch` when a different case is held.
+///
+/// The type is conformed to `JavaScriptDecodable` and `JavaScriptEncodable`, and every payload type
+/// must conform to both. Generic enums, payload-less cases, multiple associated values, defaults on an
+/// associated value and repeated payload types are compile errors.
+///
+/// Usage:
+///
+///     @Union
+///     enum Source {
+///       case text(String)
+///       case options(SourceOptions)   // a @Record
+///     }
+///
+///     @JS
+///     func load(_ source: Source) {       // JS: string | SourceOptions
+///       switch source {
+///       case .text(let text): ...
+///       case .options(let options): ...
+///       }
+///     }
+@attached(
+  member,
+  names: named(decode), named(encode), named(`as`), named(_payloadTypeName),
+  named(_assertTypesConformance))
+@attached(extension, conformances: JavaScriptDecodable, JavaScriptEncodable)
+public macro Union() =
+  #externalMacro(module: "ExpoModulesMacros", type: "UnionMacro")

--- a/packages/expo-modules-core/ios/Tests/Macros/MacroModuleTests.swift
+++ b/packages/expo-modules-core/ios/Tests/Macros/MacroModuleTests.swift
@@ -12,8 +12,10 @@ private struct MacroOptions {
   var count: Int = 0
 }
 
+// `@unchecked Sendable`: the `@JS(.concurrent)` members send `self` off the JavaScript thread,
+// which Swift 6 mode allows only for a `Sendable` module.
 @ExpoModule
-private final class MacroGreeter: Module {
+private final class MacroGreeter: Module, @unchecked Sendable {
   @JS
   func greet(name: String) -> String {
     return "Hi, \(name)"
@@ -49,6 +51,18 @@ private final class MacroGreeter: Module {
   @JS
   @JavaScriptActor
   func delayed(value: String) async throws -> String {
+    return value
+  }
+
+  // An async function whose body runs off the JS thread, on the concurrent pool.
+  @JS(.concurrent)
+  func offThread(value: String) async throws -> String {
+    return value
+  }
+
+  // The `.concurrent` option combined with a JS name override.
+  @JS("renamedOffThread", .concurrent)
+  func offThreadWithName(value: String) async throws -> String {
     return value
   }
 }
@@ -146,6 +160,21 @@ private struct MacroModuleTests {
     register(MacroGreeter(appContext: appContext))
     let result = try await runtime.evalAsync("expo.modules.MacroGreeter.delayed('done')")
     #expect(try await result.asString() == "done")
+  }
+
+  @Test
+  func `binds a @JS(.concurrent) async function that returns a promise`() async throws {
+    register(MacroGreeter(appContext: appContext))
+    let result = try await runtime.evalAsync("expo.modules.MacroGreeter.offThread('done')")
+    #expect(try await result.asString() == "done")
+  }
+
+  @Test
+  func `honors the @JS name override combined with .concurrent`() async throws {
+    register(MacroGreeter(appContext: appContext))
+    let result = try await runtime.evalAsync("expo.modules.MacroGreeter.renamedOffThread('done')")
+    #expect(try await result.asString() == "done")
+    #expect(try runtime.eval("'offThreadWithName' in expo.modules.MacroGreeter").asBool() == false)
   }
 
   // MARK: - Non-primitive decode/encode

--- a/packages/expo-modules-core/ios/Tests/Macros/MacroUnionTests.swift
+++ b/packages/expo-modules-core/ios/Tests/Macros/MacroUnionTests.swift
@@ -1,0 +1,181 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+// MARK: - Test types
+
+@Record
+private struct UnionSourceOptions: Equatable {
+  var url: String = ""
+  var retries: Int = 0
+}
+
+// A union of a primitive and a record. The string case comes first, so a JS string decodes as
+// `.text` and an object as `.options`.
+@Union
+private enum UnionSource: Equatable {
+  case text(String)
+  case options(UnionSourceOptions)
+}
+
+// Covers a labeled associated value.
+@Union
+private enum UnionLabeled: Equatable {
+  case integer(value: Int)
+  case text(String)
+}
+
+@ExpoModule
+private final class MacroUnionModule: Module {
+  @JS
+  func describe(source: UnionSource) -> String {
+    switch source {
+    case .text(let text):
+      return "text:\(text)"
+    case .options(let options):
+      return "options:\(options.url):\(options.retries)"
+    }
+  }
+
+  @JS
+  func echo(source: UnionSource) -> UnionSource {
+    return source
+  }
+
+  @JS
+  func fromText(text: String) -> UnionSource {
+    return .text(text)
+  }
+
+  @JS
+  func fromOptions(url: String) -> UnionSource {
+    return .options(UnionSourceOptions(url: url, retries: 1))
+  }
+}
+
+@Suite("Macro union")
+@JavaScriptActor
+private struct MacroUnionTests {
+  let appContext: AppContext
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  init() {
+    appContext = AppContext.create()
+    appContext.moduleRegistry.register(module: MacroUnionModule(appContext: appContext), name: nil)
+  }
+
+  // MARK: - Decoding
+
+  @Test
+  func `decodes the first case whose payload matches`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("'hello'")
+    #expect(try UnionSource.decode(value, in: runtime) == .text("hello"))
+  }
+
+  @Test
+  func `decodes a later case when the earlier ones do not match`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("({ url: 'https://expo.dev', retries: 3 })")
+    #expect(try UnionSource.decode(value, in: runtime) == .options(UnionSourceOptions(url: "https://expo.dev", retries: 3)))
+  }
+
+  @Test
+  func `decodes into a case with a labeled associated value`() throws {
+    let runtime = try runtime
+    #expect(try UnionLabeled.decode(runtime.eval("7"), in: runtime) == .integer(value: 7))
+    #expect(try UnionLabeled.decode(runtime.eval("'7'"), in: runtime) == .text("7"))
+  }
+
+  @Test
+  func `decodes a union nested in an array and an optional`() throws {
+    let runtime = try runtime
+    let array = try [UnionSource].decode(runtime.eval("['a', { url: 'b' }]"), in: runtime)
+    #expect(array == [.text("a"), .options(UnionSourceOptions(url: "b", retries: 0))])
+    #expect(try Optional<UnionSource>.decode(runtime.eval("null"), in: runtime) == nil)
+  }
+
+  @Test
+  func `throws UnionCaseMismatch when no case matches`() throws {
+    let runtime = try runtime
+    let value = try runtime.eval("42")
+    let error = #expect(throws: Exceptions.UnionCaseMismatch.self) {
+      _ = try UnionSource.decode(value, in: runtime)
+    }
+    #expect(error?.param.unionName == "UnionSource")
+    #expect(error?.param.received == "number")
+    #expect(error?.param.expected == ["String", "UnionSourceOptions"])
+    #expect(error?.reason == "'UnionSource' expected String or UnionSourceOptions, but received number")
+  }
+
+  // MARK: - Encoding
+
+  @Test
+  func `encodes each case through its payload type`() throws {
+    let runtime = try runtime
+    let text = try UnionSource.encode(.text("hello"), in: runtime)
+    #expect(text.getString() == "hello")
+
+    let options = try UnionSource.encode(.options(UnionSourceOptions(url: "u", retries: 2)), in: runtime)
+    let object = options.getObject()
+    #expect(object.getProperty("url").getString() == "u")
+    #expect(object.getProperty("retries").getInt() == 2)
+  }
+
+  // MARK: - Typed accessors
+
+  @Test
+  func `as(_:) unwraps the held payload by type`() throws {
+    let source = UnionSource.options(UnionSourceOptions(url: "u", retries: 0))
+    #expect(try source.as(UnionSourceOptions.self) == UnionSourceOptions(url: "u", retries: 0))
+    #expect((try? source.as(String.self)) == nil)
+  }
+
+  @Test
+  func `as(_:) throws UnionCaseMismatch for a different case`() throws {
+    let source = UnionSource.text("hello")
+    let error = #expect(throws: Exceptions.UnionCaseMismatch.self) {
+      _ = try source.as(UnionSourceOptions.self)
+    }
+    #expect(error?.param.received == "String")
+    #expect(error?.param.expected == ["UnionSourceOptions"])
+  }
+
+  // MARK: - Across the @JS boundary
+
+  @Test
+  func `decodes a union argument of a @JS function`() throws {
+    #expect(try runtime.eval("expo.modules.MacroUnionModule.describe('hi')").asString() == "text:hi")
+    #expect(try runtime.eval("expo.modules.MacroUnionModule.describe({ url: 'u', retries: 2 })").asString() == "options:u:2")
+  }
+
+  @Test
+  func `encodes a union return value of a @JS function`() throws {
+    #expect(try runtime.eval("expo.modules.MacroUnionModule.fromText('hi')").asString() == "hi")
+    let object = try runtime.eval("expo.modules.MacroUnionModule.fromOptions('u')").asObject()
+    #expect(try object.getProperty("url").asString() == "u")
+    #expect(try object.getProperty("retries").asInt() == 1)
+  }
+
+  @Test
+  func `round-trips a union through a @JS function`() throws {
+    #expect(try runtime.eval("expo.modules.MacroUnionModule.echo('hi')").asString() == "hi")
+    #expect(try runtime.eval("expo.modules.MacroUnionModule.echo({ url: 'u' }).url").asString() == "u")
+  }
+
+  @Test
+  func `a mismatched union argument surfaces a coded JS error`() throws {
+    let message = try runtime.eval(
+      """
+      try { expo.modules.MacroUnionModule.describe(42); '' } catch (error) { error.message }
+      """)
+    #expect(try message.asString().contains("'UnionSource' expected String or UnionSourceOptions, but received number"))
+  }
+}

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -77,7 +77,7 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@expo/expo-modules-macros-plugin": "0.8.0",
+    "@expo/expo-modules-macros-plugin": "0.10.0",
     "expo-modules-jsi": "workspace:~",
     "invariant": "^2.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5327,8 +5327,8 @@ importers:
   packages/expo-modules-core:
     dependencies:
       '@expo/expo-modules-macros-plugin':
-        specifier: 0.8.0
-        version: 0.8.0
+        specifier: 0.10.0
+        version: 0.10.0
       expo-modules-jsi:
         specifier: workspace:~
         version: link:../expo-modules-jsi
@@ -7953,8 +7953,8 @@ packages:
   '@expo/devcert@1.2.1':
     resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
 
-  '@expo/expo-modules-macros-plugin@0.8.0':
-    resolution: {integrity: sha512-wqDBF+24o8iWGuQece+qkN4js0XjKyxLEQ8Lo4aMQgu8ENXPxwPNz1xGrMxXciMQVOZStWda/u9IVJNG1xI3yw==}
+  '@expo/expo-modules-macros-plugin@0.10.0':
+    resolution: {integrity: sha512-wwwymYWtlTyn9nDcn39/HkbZvFd9eBGBJezJaz+WW+f9HU8K/Ps669PUYCwCNy0Ry1d42eP5qPth33sQRoGFtQ==}
 
   '@expo/material-symbols@0.1.1':
     resolution: {integrity: sha512-ruA6hZATOPKxo1qSd1NE3HI9FrmEDwcMDhsvzTAdMkP9AapdHfJ/0tKmBMWFJir85voxs1twYxLVrGW9OLGaOg==}
@@ -16839,7 +16839,7 @@ snapshots:
       '@expo/sudo-prompt': 9.3.2
       debug: 3.2.7
 
-  '@expo/expo-modules-macros-plugin@0.8.0': {}
+  '@expo/expo-modules-macros-plugin@0.10.0': {}
 
   '@expo/material-symbols@0.1.1': {}
 


### PR DESCRIPTION
# Why

`@expo/expo-modules-macros-plugin` 0.9.0 and 0.10.0 ship two macro features that need matching declarations in `expo-modules-core`:

- expo/expo-modules-macros-plugin#43 adds the `@Union` macro for typed N-case unions.
- expo/expo-modules-macros-plugin#46 adds a `.concurrent` option to `@JS` that runs an async member off the JS thread.

# How

- Bumped the plugin dependency to `0.10.0`.
- Declared the `@Union` macro in `ExpoModulesMacros.swift` and added `Exceptions.UnionCaseMismatch`, which the synthesized `decode` and `as(_:)` throw.
- Added the `JSOptions` enum with the `.concurrent` case and a second `@JS` overload that takes options alone, since `.concurrent` cannot be passed in the unlabeled `jsName` slot. Bare `@JS`, `@JS("name")`, `@JS(.concurrent)` and `@JS("name", .concurrent)` all resolve without ambiguity.

One thing to be aware of: `expo-modules-core` builds in Swift 6 language mode, and there a `@JS(.concurrent)` member on a non-`Sendable` module fails with "sending 'self' risks causing data races", because the synthesized binding sends the module from the JS actor into the nonisolated `@concurrent` method. Modules in Swift 5 language mode are unaffected. The test module is marked `@unchecked Sendable` and the constraint is documented on `JSOptions.concurrent`. Making `BaseModule` `@unchecked Sendable` in core would remove the requirement, but that is a separate decision.

# Test Plan

- New `MacroUnionTests` suite: decoding in declaration order, labeled associated values, nesting in arrays and optionals, `UnionCaseMismatch` from `decode` and `as(_:)`, encoding, and round trips through `@JS` functions.
- `MacroModuleTests` gains `@JS(.concurrent)` and `@JS("name", .concurrent)` async functions.
- `xcodebuild test -scheme ExpoModulesCore-Unit-Tests` on bare-expo: 801 tests in 107 suites passed.
- Typechecked the new `@JS` overloads and `@Union` against the 0.10.0 plugin binary with `swiftc -load-plugin-executable`; the only diagnostic is the intended one for `.concurrent` on a synchronous function.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
