### PR TITLE
[android][widgets] Fix Gradle build failure when no Android widget is configured

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Preserve SwiftUI view identity across widget and Live Activity updates so system update animations can run. ([#49810](https://github.com/expo/expo/pull/49810) by [@jakex7](https://github.com/jakex7))
-- [Android] Fix Gradle build failure when no Android widget is configured. ([#50043](https://github.com/expo/expo/pull/50043) by [@keith-kurak](https://github.com/keith-kurak))
+- [Android] Fix Gradle build failure when no Android widget is configured. ([#50038](https://github.com/expo/expo/pull/50038) by [@keith-kurak](https://github.com/keith-kurak))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Preserve SwiftUI view identity across widget and Live Activity updates so system update animations can run. ([#49810](https://github.com/expo/expo/pull/49810) by [@jakex7](https://github.com/jakex7))
+- [Android] Fix Gradle build failure when no Android widget is configured. ([#50043](https://github.com/expo/expo/pull/50043) by [@keith-kurak](https://github.com/keith-kurak))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/android/build.gradle
+++ b/packages/expo-widgets/android/build.gradle
@@ -108,7 +108,10 @@ def generateExpoWidgetsLayoutRegistry = tasks.register("generateExpoWidgetsLayou
   inputs.file file("$expoWidgetsPackageDir/metro.config.js")
   inputs.file file("$expoWidgetsPackageDir/scripts/build-layout-registry.mjs")
   inputs.file file("$expoWidgetsPackageDir/bundle/layout-registry-entry.js")
-  inputs.file(expoWidgetsLayoutRegistryConfigFile).optional()
+  // The layout registry config is only written when the Android side of the config plugin runs
+  // (`enableAndroid: true`). Use a FileCollection so an absent file is not a validation error —
+  // build-layout-registry.mjs already treats a missing config as "no widgets".
+  inputs.files(expoWidgetsLayoutRegistryConfigFile)
   outputs.file(expoWidgetsLayoutRegistryOutput)
 
   def command = [

--- a/packages/expo-widgets/android/build.gradle
+++ b/packages/expo-widgets/android/build.gradle
@@ -108,9 +108,6 @@ def generateExpoWidgetsLayoutRegistry = tasks.register("generateExpoWidgetsLayou
   inputs.file file("$expoWidgetsPackageDir/metro.config.js")
   inputs.file file("$expoWidgetsPackageDir/scripts/build-layout-registry.mjs")
   inputs.file file("$expoWidgetsPackageDir/bundle/layout-registry-entry.js")
-  // The layout registry config is only written when the Android side of the config plugin runs
-  // (`enableAndroid: true`). Use a FileCollection so an absent file is not a validation error —
-  // build-layout-registry.mjs already treats a missing config as "no widgets".
   inputs.files(expoWidgetsLayoutRegistryConfigFile)
   outputs.file(expoWidgetsLayoutRegistryOutput)
 


### PR DESCRIPTION
# Why

`expo-widgets` fails every Android Gradle build when no Android widget is configured, which is the default (`enableAndroid` defaults to `false`). Apps that ship an iOS-only widget cannot build for Android at all.

```
* What went wrong:
A problem was found with the configuration of task ':expo-widgets:generateExpoWidgetsLayoutRegistry' (type 'Exec').
  - Type 'org.gradle.api.tasks.Exec' property '$6' specifies file
    '.../android/app/src/main/expo-widgets-layout-registry.config.json' which doesn't exist.

    Reason: An input file was expected to be present but it doesn't exist.
```

This is a regression in the 58 line. `expo-widgets@57.0.19` has no Gradle tasks at all; the layout registry task was added in 58.0.0.

# How

`:expo-widgets:generateExpoWidgetsLayoutRegistry` declared the layout registry config as `inputs.file(...).optional()`. In Gradle's runtime input API, `optional()` only permits a property with *no value*. `expoWidgetsLayoutRegistryConfigFile` is a plain `File` built with `file(...)` at configuration time, so the property always has a value. Gradle therefore validated that value and failed `input_file_does_not_exist`.

Switched to `inputs.files(...)`, a `FileCollection`. A `FileCollection` input does not validate per-entry existence: a missing entry contributes nothing to the fingerprint, and up-to-date checking still works — when the file is later created or edited, the fingerprint changes and the task re-runs.

`scripts/build-layout-registry.mjs` already treats an absent config as "no widgets" and writes an empty registry, so no script change is needed. The task simply never got to run.

Alternatives considered:

- A `providers.provider { ... }` wrapper keeps a single-file input and makes `optional()` meaningful, but is more verbose for the same result.
- Registering the input only when the file exists at configuration time breaks up-to-date checking and interacts badly with the configuration cache.
- Always writing the config file from the plugin would run the Android plugin path even when `enableAndroid` is `false`, changing documented behavior.

# Test Plan

- [ ] Android build with no Android widget configured: build succeeds, `build/generated/expo-widgets/res/raw/expo_widgets_layout_registry.json` contains `{"widgets": {}}`.
- [ ] Android build with `enableAndroid: true` and a widget with an `initialLayout`: registry contains that widget.
- [ ] Build twice: the task reports `UP-TO-DATE` on the second run. Creating or editing `android/app/src/main/expo-widgets-layout-registry.config.json` re-runs the task.
- [ ] iOS unaffected: the iOS path uses `ios/ExpoWidgetsTarget/ExpoWidgetsLayoutRegistry.config.json` and no Gradle.

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — n/a, no docs change.
- [ ] Ensured that the change works with `npx expo prebuild` & EAS Build.

# Follow-up (not part of this fix, unverified)

`generateExpoWidgetsBundle` appears to run unconditionally, and `build-bundle.mjs` shells out to `expo export:embed`. If that holds, every Android build of every app depending on `expo-widgets` pays for an extra Metro bundle even with zero Android widgets. Unlike `build-layout-registry.mjs`, `build-bundle.mjs` has no early return for the empty case. Not measured, and not the cause of this failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)