### PR TITLE
[metro-config] Don't rename require in tests/snapshots

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Bump to `@expo/metro@56.0.2` and `metro@0.84.5` ([#49161](https://github.com/expo/expo/pull/49161) by [@kitten](https://github.com/kitten))
 - Point Metro's `assetRegistryPath` at `react-native/asset-registry`, which replaces the `@react-native/assets-registry` package as of React Native 0.87. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Bump to `@expo/metro@56.1.0` and `metro@0.84.6` ([#49671](https://github.com/expo/expo/pull/49671) by [@robhogan](https://github.com/robhogan))
+- Don't rename require in tests/snapshots. ([#50039](https://github.com/expo/expo/pull/50039) by [@robhogan](https://github.com/robhogan))
 
 ## 57.0.7 - 2026-07-22
 

--- a/packages/@expo/metro-config/src/serializer/__tests__/optimize-graph.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/optimize-graph.test.ts
@@ -270,16 +270,16 @@ describe('cjs', () => {
       },
     ]);
     expect(artifacts[0].source).toMatch('subtract');
-    expect(artifacts[0].source).toMatch('_$$_REQUIRE(_dependencyMap[0]);');
+    expect(artifacts[0].source).toMatch('require(_dependencyMap[0]);');
 
     expect(artifacts[0].source).toMatchInlineSnapshot(`
-      "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+      "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         const {
           add
-        } = _$$_REQUIRE(_dependencyMap[0]);
+        } = require(_dependencyMap[0]);
         console.log('keep', add(1, 2));
       },"/app/index.js",["/app/math.js"]);
-      __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+      __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -369,39 +369,39 @@ it(`recursively expands export all statements with nested statements`, async () 
   expect(artifact.source).toMatch('z3');
   expect(artifact.source).toMatch('z2');
   expect(artifact.source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      console.log(_$$_REQUIRE(_dependencyMap[0]).z1, _$$_REQUIRE(_dependencyMap[0]).DDD);
+      console.log(require(_dependencyMap[0]).z1, require(_dependencyMap[0]).DDD);
     },"/app/index.js",["/app/x0.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
         value: true
       });
-      Object.keys(_$$_REQUIRE(_dependencyMap[0])).forEach(function (k) {
+      Object.keys(require(_dependencyMap[0])).forEach(function (k) {
         if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) {
           Object.defineProperty(exports, k, {
             enumerable: true,
             get: function () {
-              return _$$_REQUIRE(_dependencyMap[0])[k];
+              return require(_dependencyMap[0])[k];
             }
           });
         }
       });
-      Object.keys(_$$_REQUIRE(_dependencyMap[1])).forEach(function (k) {
+      Object.keys(require(_dependencyMap[1])).forEach(function (k) {
         if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) {
           Object.defineProperty(exports, k, {
             enumerable: true,
             get: function () {
-              return _$$_REQUIRE(_dependencyMap[1])[k];
+              return require(_dependencyMap[1])[k];
             }
           });
         }
       });
     },"/app/x0.js",["/app/x1.js","/app/x2.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -413,19 +413,19 @@ it(`recursively expands export all statements with nested statements`, async () 
           return z1;
         }
       });
-      Object.keys(_$$_REQUIRE(_dependencyMap[0])).forEach(function (k) {
+      Object.keys(require(_dependencyMap[0])).forEach(function (k) {
         if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) {
           Object.defineProperty(exports, k, {
             enumerable: true,
             get: function () {
-              return _$$_REQUIRE(_dependencyMap[0])[k];
+              return require(_dependencyMap[0])[k];
             }
           });
         }
       });
       const z1 = 0;
     },"/app/x1.js",["/app/x2.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {

--- a/packages/@expo/metro-config/src/serializer/__tests__/tree-shaking.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/tree-shaking.test.ts
@@ -257,7 +257,7 @@ describe('side-effecty imports', () => {
     );
     expect(artifacts[0].source).not.toMatch('side-effect');
     expect(artifacts[0].source).toMatchInlineSnapshot(`
-          "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
             "use strict";
           },"/app/index.js",[]);
           TEST_RUN_MODULE("/app/index.js");"
@@ -278,12 +278,12 @@ var hey = 0;
 
     expectSideEffects(graph, '/app/node_modules/foo/index.js').toBe(true);
     expect(artifact.source).toMatchInlineSnapshot(`
-          "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
             "use strict";
 
-            _$$_REQUIRE(_dependencyMap[0]);
+            require(_dependencyMap[0]);
           },"/app/index.js",["/app/node_modules/foo/index.js"]);
-          __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
             var hey = 0;
           },"/app/node_modules/foo/index.js",[]);
           TEST_RUN_MODULE("/app/index.js");"
@@ -305,7 +305,7 @@ var hey = 0;
     expectImports(graph, '/app/index.js').toEqual([]);
 
     expect(artifact.source).toMatchInlineSnapshot(`
-      "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+      "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
       },"/app/index.js",[]);
       TEST_RUN_MODULE("/app/index.js");"
@@ -612,16 +612,16 @@ describe('cjs', () => {
       },
     ]);
     expect(artifacts[0].source).toMatch('subtract');
-    expect(artifacts[0].source).toMatch('_$$_REQUIRE(_dependencyMap[0]);');
+    expect(artifacts[0].source).toMatch('require(_dependencyMap[0]);');
 
     expect(artifacts[0].source).toMatchInlineSnapshot(`
-      "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+      "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         const {
           add
-        } = _$$_REQUIRE(_dependencyMap[0]);
+        } = require(_dependencyMap[0]);
         console.log('keep', add(1, 2));
       },"/app/index.js",["/app/math.js"]);
-      __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+      __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -663,12 +663,12 @@ it(`export var with trailing exports`, async () => {
       `,
   });
   expect(artifacts[0].source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      console.log('keep', (0, _$$_REQUIRE(_dependencyMap[0]).add)(1, 2));
+      console.log('keep', (0, require(_dependencyMap[0]).add)(1, 2));
     },"/app/index.js",["/app/lib.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -685,10 +685,10 @@ it(`export var with trailing exports`, async () => {
           return add;
         }
       });
-      var client = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
+      var client = _interopDefault(require(_dependencyMap[0]));
       var add = client.default.add;
     },"/app/lib.js",["/app/b.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -734,12 +734,12 @@ it(`export var with trailing exports (const and function)`, async () => {
     `,
   });
   expect(artifacts[0].source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      console.log('keep', (0, _$$_REQUIRE(_dependencyMap[0]).add)(1, 2));
+      console.log('keep', (0, require(_dependencyMap[0]).add)(1, 2));
     },"/app/index.js",["/app/lib.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1049,12 +1049,12 @@ export { Worm as default };
   expect(artifacts[0].source).not.toMatch('icons');
   expect(artifacts[0].source).not.toMatch('Worm');
   expect(artifacts[0].source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      console.log('keep', _$$_REQUIRE(_dependencyMap[0]).AArrowDown);
+      console.log('keep', require(_dependencyMap[0]).AArrowDown);
     },"/app/index.js",["/app/lucide.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1071,9 +1071,9 @@ export { Worm as default };
           return _aArrowDownJs2.default;
         }
       });
-      var _aArrowDownJs2 = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
+      var _aArrowDownJs2 = _interopDefault(require(_dependencyMap[0]));
     },"/app/lucide.js",["/app/a-arrow-down.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1090,10 +1090,10 @@ export { Worm as default };
           return AArrowDown;
         }
       });
-      var createLucideIcon = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
+      var createLucideIcon = _interopDefault(require(_dependencyMap[0]));
       const AArrowDown = (0, createLucideIcon.default)();
     },"/app/a-arrow-down.js",["/app/createLucideIcon.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1170,7 +1170,7 @@ it(`removes unused exports`, async () => {
   expect(artifacts).toMatchInlineSnapshot(`
     [
       {
-        "filename": "_expo/static/js/web/index-d1e560ce32dfe033241094be8aa906e6.js",
+        "filename": "_expo/static/js/web/index-8abca6d5d425c00e018d01046c13c550.js",
         "metadata": {
           "expoDomComponentReferences": [],
           "isAsync": false,
@@ -1185,12 +1185,12 @@ it(`removes unused exports`, async () => {
           "requires": [],
         },
         "originFilename": "index.js",
-        "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      console.log('keep', (0, _$$_REQUIRE(_dependencyMap[0]).add)(1, 2));
+      console.log('keep', (0, require(_dependencyMap[0]).add)(1, 2));
     },"/app/index.js",["/app/math.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1371,12 +1371,12 @@ it(`preserves remapped imports when an import with the same name is removed`, as
   });
 
   expect(artifact.source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      console.log(_$$_REQUIRE(_dependencyMap[0]).Platform.KIOSK);
+      console.log(require(_dependencyMap[0]).Platform.KIOSK);
     },"/app/index.js",["/app/x0.ts"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1395,7 +1395,7 @@ it(`preserves remapped imports when an import with the same name is removed`, as
     },"/app/x0.ts",[]);
     TEST_RUN_MODULE("/app/index.js");"
   `);
-  expect(artifact.source).toMatch('_$$_REQUIRE(_dependencyMap[0]).Platform');
+  expect(artifact.source).toMatch('require(_dependencyMap[0]).Platform');
 });
 
 it(`recursively expands export all statements (shallow)`, async () => {
@@ -1416,12 +1416,12 @@ it(`recursively expands export all statements (shallow)`, async () => {
   );
   expect(artifact.source).toMatch('z1');
   expect(artifact.source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      console.log(_$$_REQUIRE(_dependencyMap[0]).z1, _$$_REQUIRE(_dependencyMap[0]).DDD);
+      console.log(require(_dependencyMap[0]).z1, require(_dependencyMap[0]).DDD);
     },"/app/index.js",["/app/x0.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1430,11 +1430,11 @@ it(`recursively expands export all statements (shallow)`, async () => {
       Object.defineProperty(exports, "z1", {
         enumerable: true,
         get: function () {
-          return _$$_REQUIRE(_dependencyMap[0]).z1;
+          return require(_dependencyMap[0]).z1;
         }
       });
     },"/app/x0.js",["/app/x1.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1470,7 +1470,7 @@ it(`recursively expands unused with overlapping exports`, async () => {
 
   expect(artifact.source).toMatch('z1');
   expect(artifact.source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       function _interopDefault(e) {
@@ -1478,10 +1478,10 @@ it(`recursively expands unused with overlapping exports`, async () => {
           default: e
         };
       }
-      var m = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
+      var m = _interopDefault(require(_dependencyMap[0]));
       console.log(m.default.z1, DDD);
     },"/app/index.js",["/app/x0.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1498,10 +1498,10 @@ it(`recursively expands unused with overlapping exports`, async () => {
           return _default;
         }
       });
-      var X = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
+      var X = _interopDefault(require(_dependencyMap[0]));
       var _default = X.default;
     },"/app/x0.js",["/app/x1.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1538,7 +1538,7 @@ it(`removes all overlapping exports (export-all and default)`, async () => {
 
   expect(artifact.source).not.toMatch('z1');
   expect(artifact.source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
     },"/app/index.js",[]);
     TEST_RUN_MODULE("/app/index.js");"
@@ -1565,12 +1565,12 @@ it(`TODO: removes default export with overlapping exports (export-all and defaul
 
   expect(artifact.source).toMatch('z1');
   expect(artifact.source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      consol.log(_$$_REQUIRE(_dependencyMap[0]).z1);
+      consol.log(require(_dependencyMap[0]).z1);
     },"/app/index.js",["/app/x0.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1584,7 +1584,7 @@ it(`TODO: removes default export with overlapping exports (export-all and defaul
       Object.defineProperty(exports, "z1", {
         enumerable: true,
         get: function () {
-          return _$$_REQUIRE(_dependencyMap[0]).z1;
+          return require(_dependencyMap[0]).z1;
         }
       });
       Object.defineProperty(exports, "default", {
@@ -1593,10 +1593,10 @@ it(`TODO: removes default export with overlapping exports (export-all and defaul
           return _default;
         }
       });
-      var X = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
+      var X = _interopDefault(require(_dependencyMap[0]));
       var _default = X.default;
     },"/app/x0.js",["/app/x1.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1664,12 +1664,12 @@ it(`recursively expands export all statements`, async () => {
   expect(artifact.source).not.toMatch('z3');
   expect(artifact.source).not.toMatch('z2');
   expect(artifact.source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      console.log(_$$_REQUIRE(_dependencyMap[0]).z1, _$$_REQUIRE(_dependencyMap[0]).DDD);
+      console.log(require(_dependencyMap[0]).z1, require(_dependencyMap[0]).DDD);
     },"/app/index.js",["/app/x0.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1678,11 +1678,11 @@ it(`recursively expands export all statements`, async () => {
       Object.defineProperty(exports, "z1", {
         enumerable: true,
         get: function () {
-          return _$$_REQUIRE(_dependencyMap[0]).z1;
+          return require(_dependencyMap[0]).z1;
         }
       });
     },"/app/x0.js",["/app/x1.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1691,11 +1691,11 @@ it(`recursively expands export all statements`, async () => {
       Object.defineProperty(exports, "z1", {
         enumerable: true,
         get: function () {
-          return _$$_REQUIRE(_dependencyMap[0]).z1;
+          return require(_dependencyMap[0]).z1;
         }
       });
     },"/app/x1.js",["/app/x2.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1739,12 +1739,12 @@ it(`recursively expands export all statements with nested statements`, async () 
   expect(artifact.source).not.toMatch('z3');
   expect(artifact.source).not.toMatch('z2');
   expect(artifact.source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      console.log(_$$_REQUIRE(_dependencyMap[0]).z1, _$$_REQUIRE(_dependencyMap[0]).DDD);
+      console.log(require(_dependencyMap[0]).z1, require(_dependencyMap[0]).DDD);
     },"/app/index.js",["/app/x0.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1753,11 +1753,11 @@ it(`recursively expands export all statements with nested statements`, async () 
       Object.defineProperty(exports, "z1", {
         enumerable: true,
         get: function () {
-          return _$$_REQUIRE(_dependencyMap[0]).z1;
+          return require(_dependencyMap[0]).z1;
         }
       });
     },"/app/x0.js",["/app/x1.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1854,7 +1854,7 @@ it(`recursively expands export all statements while omitting existing and defaul
   );
   expect(artifact.source).toMatch('z1');
   expect(artifact.source).toMatchInlineSnapshot(`
-    "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       function _interopNamespace(e) {
@@ -1873,10 +1873,10 @@ it(`recursively expands export all statements while omitting existing and defaul
         n.default = e;
         return n;
       }
-      var _all = _interopNamespace(_$$_REQUIRE(_dependencyMap[0]));
+      var _all = _interopNamespace(require(_dependencyMap[0]));
       console.log(_all);
     },"/app/index.js",["/app/x0.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1885,13 +1885,13 @@ it(`recursively expands export all statements while omitting existing and defaul
       Object.defineProperty(exports, "z2", {
         enumerable: true,
         get: function () {
-          return _$$_REQUIRE(_dependencyMap[0]).z2;
+          return require(_dependencyMap[0]).z2;
         }
       });
       Object.defineProperty(exports, "z3", {
         enumerable: true,
         get: function () {
-          return _$$_REQUIRE(_dependencyMap[0]).z3;
+          return require(_dependencyMap[0]).z3;
         }
       });
       Object.defineProperty(exports, "z1", {
@@ -1902,7 +1902,7 @@ it(`recursively expands export all statements while omitting existing and defaul
       });
       const z1 = 0;
     },"/app/x0.js",["/app/x1.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {
@@ -1911,13 +1911,13 @@ it(`recursively expands export all statements while omitting existing and defaul
       Object.defineProperty(exports, "z2", {
         enumerable: true,
         get: function () {
-          return _$$_REQUIRE(_dependencyMap[0]).z2;
+          return require(_dependencyMap[0]).z2;
         }
       });
       Object.defineProperty(exports, "z3", {
         enumerable: true,
         get: function () {
-          return _$$_REQUIRE(_dependencyMap[0]).z3;
+          return require(_dependencyMap[0]).z3;
         }
       });
       Object.defineProperty(exports, "default", {
@@ -1928,7 +1928,7 @@ it(`recursively expands export all statements while omitting existing and defaul
       });
       var _default = 0;
     },"/app/x1.js",["/app/x2.js"]);
-    __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+    __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {

--- a/packages/@expo/metro-config/src/serializer/__tests__/withExpoSerializers.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/withExpoSerializers.test.ts
@@ -275,7 +275,7 @@ describe('serializes', () => {
 
       // This will fail if the `module` -> `_module` transform doesn't work.
       expect(await serializer(...(await microBundle({ fs })))).toMatchInlineSnapshot(`
-        "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
           let _module = {};
           let _require = {};
           let _global = {};
@@ -308,10 +308,10 @@ describe('serializes', () => {
           /\/\/# sourceMappingURL=https:\/\/localhost:8081\/indedx\.bundle\?dev=false/
         );
         // Debug ID annotation is included at the end.
-        expect(artifacts.code).toMatch(/\/\/# debugId=d582bbf1-5fdf-4ce7-afea-e784a502f5bc/);
+        expect(artifacts.code).toMatch(/\/\/# debugId=abeba873-c91b-4b9f-b0b3-ecba23cbadfb/);
 
         // Test that the debugId is added to the source map and matches the annotation.
-        const debugId = 'd582bbf1-5fdf-4ce7-afea-e784a502f5bc';
+        const debugId = 'abeba873-c91b-4b9f-b0b3-ecba23cbadfb';
         expect(artifacts.code).toContain(debugId);
 
         expect(JSON.parse(artifacts.map)).toEqual(
@@ -367,10 +367,10 @@ describe('serializes', () => {
         /\/\/# sourceMappingURL=\/_expo\/static\/js\/web\/index-(?<md5>[0-9a-fA-F]{32})\.js\.map/
       );
       // Debug ID annotation is included at the end.
-      expect(artifacts[0].source).toMatch(/\/\/# debugId=295379f8-3d45-4ee7-8da9-c63d70ba75f3/);
+      expect(artifacts[0].source).toMatch(/\/\/# debugId=35adadee-cd42-451d-a8cf-aaf69dd92d97/);
 
       // Test that the debugId is added to the source map and matches the annotation.
-      const debugId = '295379f8-3d45-4ee7-8da9-c63d70ba75f3';
+      const debugId = '35adadee-cd42-451d-a8cf-aaf69dd92d97';
       expect(artifacts[0].source).toContain(debugId);
 
       const mapArtifact = artifacts.find(({ filename }: SerialAsset) =>
@@ -408,10 +408,10 @@ describe('serializes', () => {
         /\/\/# sourceMappingURL=https:\/\/localhost:8081\/_expo\/static\/js\/ios\/index-(?<md5>[0-9a-fA-F]{32})\.hbc\.map/
       );
       // Debug ID annotation is included at the end.
-      expect(artifacts[0].source).toMatch(/\/\/# debugId=295379f8-3d45-4ee7-8da9-c63d70ba75f3/);
+      expect(artifacts[0].source).toMatch(/\/\/# debugId=35adadee-cd42-451d-a8cf-aaf69dd92d97/);
 
       // Test that the debugId is added to the source map and matches the annotation.
-      const debugId = '295379f8-3d45-4ee7-8da9-c63d70ba75f3';
+      const debugId = '35adadee-cd42-451d-a8cf-aaf69dd92d97';
       expect(artifacts[0].source).toContain(debugId);
 
       const mapArtifact = artifacts.find(({ filename }: SerialAsset) =>
@@ -671,13 +671,13 @@ describe('serializes', () => {
     };
 
     expect(await serializer(...(await microBundle({ fs })))).toMatchInlineSnapshot(`
-      "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+      "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
-        var _foo = _$$_REQUIRE(_dependencyMap[0], "./foo");
+        var _foo = require(_dependencyMap[0], "./foo");
         console.log(_foo.foo);
       },"/app/index.js",["/app/foo.js"],"index.js");
-      __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+      __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -759,15 +759,15 @@ describe('serializes', () => {
 
     expect(artifacts.map((art: SerialAsset) => art.filename)).toMatchInlineSnapshot(`
       [
-        "_expo/static/js/web/index-94948be0883c5c5ec85126a6f3367b2c.js",
-        "_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js",
+        "_expo/static/js/web/index-7cf5bbda0f67ef0cdf5b051d24839059.js",
+        "_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js",
       ]
     `);
 
     expect(artifacts).toMatchInlineSnapshot(`
       [
         {
-          "filename": "_expo/static/js/web/index-94948be0883c5c5ec85126a6f3367b2c.js",
+          "filename": "_expo/static/js/web/index-7cf5bbda0f67ef0cdf5b051d24839059.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": false,
@@ -777,7 +777,7 @@ describe('serializes', () => {
             ],
             "paths": {
               "/app/index.js": {
-                "/app/foo.js": "/_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js",
+                "/app/foo.js": "/_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js",
               },
             },
             "reactClientReferences": [],
@@ -785,14 +785,14 @@ describe('serializes', () => {
             "requires": [],
           },
           "originFilename": "index.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         _dependencyMap[0];
-      },"/app/index.js",{"0":"/app/foo.js","paths":{"/app/foo.js":"/_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js"}});
+      },"/app/index.js",{"0":"/app/foo.js","paths":{"/app/foo.js":"/_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js"}});
       TEST_RUN_MODULE("/app/index.js");",
           "type": "js",
         },
         {
-          "filename": "_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js",
+          "filename": "_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": true,
@@ -806,7 +806,7 @@ describe('serializes', () => {
             "requires": [],
           },
           "originFilename": "foo.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -851,15 +851,15 @@ describe('serializes', () => {
 
     expect(artifacts.map((art: SerialAsset) => art.filename)).toMatchInlineSnapshot(`
       [
-        "_expo/static/js/web/index-1207f92ecd83de62d121a586b7d1a023.js",
-        "_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js",
+        "_expo/static/js/web/index-37d09d8a8e233810d0ae346a931f271e.js",
+        "_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js",
       ]
     `);
 
     expect(artifacts).toMatchInlineSnapshot(`
       [
         {
-          "filename": "_expo/static/js/web/index-1207f92ecd83de62d121a586b7d1a023.js",
+          "filename": "_expo/static/js/web/index-37d09d8a8e233810d0ae346a931f271e.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": false,
@@ -870,7 +870,7 @@ describe('serializes', () => {
             ],
             "paths": {
               "/app/index.js": {
-                "/app/foo.js": "/_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js",
+                "/app/foo.js": "/_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js",
               },
             },
             "reactClientReferences": [],
@@ -878,17 +878,17 @@ describe('serializes', () => {
             "requires": [],
           },
           "originFilename": "index.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-        _$$_REQUIRE(_dependencyMap[1])(_dependencyMap[0], _dependencyMap.paths);
-      },"/app/index.js",{"0":"/app/foo.js","1":"/app/expo-mock/async-require","paths":{"/app/foo.js":"/_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js"}});
-      __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        require(_dependencyMap[1])(_dependencyMap[0], _dependencyMap.paths);
+      },"/app/index.js",{"0":"/app/foo.js","1":"/app/expo-mock/async-require","paths":{"/app/foo.js":"/_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js"}});
+      __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         module.exports = () => 'MOCK';
       },"/app/expo-mock/async-require",[]);
       TEST_RUN_MODULE("/app/index.js");",
           "type": "js",
         },
         {
-          "filename": "_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js",
+          "filename": "_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": true,
@@ -902,7 +902,7 @@ describe('serializes', () => {
             "requires": [],
           },
           "originFilename": "foo.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -952,11 +952,11 @@ describe('serializes', () => {
     });
 
     expect(artifacts.map((art: SerialAsset) => art.filename)).toEqual([
-      '_expo/static/js/web/index-bdef585f35abb73ade9d9bf09663cd76.js',
-      '_expo/static/js/web/index-25b349d9df4cf37e2ce96f19a911e4eb.js',
-      '_expo/static/js/web/[foo]-b99e2a64404cca4d65e32984620b7bf1.js',
-      '_expo/static/js/web/{foo}-d032e4cf31d79b9563f18fce5c4d4da8.js',
-      '_expo/static/js/web/+foo-2b47c1ed90cec08c1514324d9ade788c.js',
+      '_expo/static/js/web/index-46b289da7e31e98725166090f17b807b.js',
+      '_expo/static/js/web/index-1e9b37b7a0c3033d8b3385bd9a556dae.js',
+      '_expo/static/js/web/[foo]-1a2cc21e93a511f706afa2c3afea0a7f.js',
+      '_expo/static/js/web/{foo}-c42fc7ce5bc02ecac6a19badaeaf106d.js',
+      '_expo/static/js/web/+foo-844771169e7b021c9c9b7fc0c1eda77d.js',
     ]);
 
     // Split bundle
@@ -1015,15 +1015,15 @@ describe('serializes', () => {
 
     expect(artifacts.map((art: SerialAsset) => art.filename)).toMatchInlineSnapshot(`
       [
-        "_expo/static/js/web/index-e1fb337e6686dcaff5b891611f2351c2.js",
-        "_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js",
+        "_expo/static/js/web/index-6d33b8d5aa388d29c911f1ea070dd843.js",
+        "_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js",
       ]
     `);
 
     expect(artifacts).toMatchInlineSnapshot(`
       [
         {
-          "filename": "_expo/static/js/web/index-e1fb337e6686dcaff5b891611f2351c2.js",
+          "filename": "_expo/static/js/web/index-6d33b8d5aa388d29c911f1ea070dd843.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": false,
@@ -1035,7 +1035,7 @@ describe('serializes', () => {
             ],
             "paths": {
               "/app/two.js": {
-                "/app/foo.js": "/_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js",
+                "/app/foo.js": "/_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js",
               },
             },
             "reactClientReferences": [],
@@ -1043,22 +1043,22 @@ describe('serializes', () => {
             "requires": [],
           },
           "originFilename": "index.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
-        _$$_REQUIRE(_dependencyMap[0]);
+        require(_dependencyMap[0]);
       },"/app/index.js",["/app/two.js"]);
-      __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-        _$$_REQUIRE(_dependencyMap[1])(_dependencyMap[0], _dependencyMap.paths);
-      },"/app/two.js",{"0":"/app/foo.js","1":"/app/expo-mock/async-require","paths":{"/app/foo.js":"/_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js"}});
-      __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+      __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        require(_dependencyMap[1])(_dependencyMap[0], _dependencyMap.paths);
+      },"/app/two.js",{"0":"/app/foo.js","1":"/app/expo-mock/async-require","paths":{"/app/foo.js":"/_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js"}});
+      __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         module.exports = () => 'MOCK';
       },"/app/expo-mock/async-require",[]);
       TEST_RUN_MODULE("/app/index.js");",
           "type": "js",
         },
         {
-          "filename": "_expo/static/js/web/foo-b41558b4adb6e8abc10fcd96d05def7b.js",
+          "filename": "_expo/static/js/web/foo-309ed73104dd28f5ce09af0d7b6b1521.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": true,
@@ -1072,7 +1072,7 @@ describe('serializes', () => {
             "requires": [],
           },
           "originFilename": "foo.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -1145,19 +1145,19 @@ describe('serializes', () => {
 
     expect(artifacts.map((art: SerialAsset) => art.filename)).toMatchInlineSnapshot(`
       [
-        "_expo/static/js/web/index-1a945ad9d39624147643462e65d5c9a5.js",
-        "_expo/static/js/web/a-70528b7a0a1910d872803a9f7d408bcb.js",
-        "_expo/static/js/web/b-fd5ce6f7800ab69b4ffe8359d27d268f.js",
-        "_expo/static/js/web/c-c1ea5faaf03846340d18f64eb7fd10a5.js",
-        "_expo/static/js/web/__common-e8c8ebf41a34c79ec57f339049e2ea36.js",
-        "_expo/static/js/web/__expo-metro-runtime-9766bff2257e805459e3ab4532b77d32.js",
+        "_expo/static/js/web/index-4925080761c211aba74fbfd054336f49.js",
+        "_expo/static/js/web/a-12c7a49f9bd14cd5825ead8b8b20af16.js",
+        "_expo/static/js/web/b-530ae3505b2e7d48992cf467aa3b51b5.js",
+        "_expo/static/js/web/c-56e8e09d8263e0e34c2784569336ac37.js",
+        "_expo/static/js/web/__common-39fcae1c62a6d2e698c18534fd82e6c6.js",
+        "_expo/static/js/web/__expo-metro-runtime-49146aac8fa3540454ba583868edfc36.js",
       ]
     `);
 
     expect(artifacts).toMatchInlineSnapshot(`
       [
         {
-          "filename": "_expo/static/js/web/index-1a945ad9d39624147643462e65d5c9a5.js",
+          "filename": "_expo/static/js/web/index-4925080761c211aba74fbfd054336f49.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": false,
@@ -1168,32 +1168,32 @@ describe('serializes', () => {
             ],
             "paths": {
               "/app/index.js": {
-                "/app/a.js": "/_expo/static/js/web/a-70528b7a0a1910d872803a9f7d408bcb.js",
-                "/app/b.js": "/_expo/static/js/web/b-fd5ce6f7800ab69b4ffe8359d27d268f.js",
-                "/app/c.js": "/_expo/static/js/web/c-c1ea5faaf03846340d18f64eb7fd10a5.js",
+                "/app/a.js": "/_expo/static/js/web/a-12c7a49f9bd14cd5825ead8b8b20af16.js",
+                "/app/b.js": "/_expo/static/js/web/b-530ae3505b2e7d48992cf467aa3b51b5.js",
+                "/app/c.js": "/_expo/static/js/web/c-56e8e09d8263e0e34c2784569336ac37.js",
               },
             },
             "reactClientReferences": [],
             "reactServerReferences": [],
             "requires": [
-              "_expo/static/js/web/__common-e8c8ebf41a34c79ec57f339049e2ea36.js",
-              "_expo/static/js/web/__expo-metro-runtime-9766bff2257e805459e3ab4532b77d32.js",
+              "_expo/static/js/web/__common-39fcae1c62a6d2e698c18534fd82e6c6.js",
+              "_expo/static/js/web/__expo-metro-runtime-49146aac8fa3540454ba583868edfc36.js",
             ],
           },
           "originFilename": "index.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-        _$$_REQUIRE(_dependencyMap[1])(_dependencyMap[0], _dependencyMap.paths);
-        _$$_REQUIRE(_dependencyMap[1])(_dependencyMap[2], _dependencyMap.paths);
-        _$$_REQUIRE(_dependencyMap[1])(_dependencyMap[3], _dependencyMap.paths);
-      },"/app/index.js",{"0":"/app/a.js","1":"/app/expo-mock/async-require","2":"/app/b.js","3":"/app/c.js","paths":{"/app/a.js":"/_expo/static/js/web/a-70528b7a0a1910d872803a9f7d408bcb.js","/app/b.js":"/_expo/static/js/web/b-fd5ce6f7800ab69b4ffe8359d27d268f.js","/app/c.js":"/_expo/static/js/web/c-c1ea5faaf03846340d18f64eb7fd10a5.js"}});
-      __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        require(_dependencyMap[1])(_dependencyMap[0], _dependencyMap.paths);
+        require(_dependencyMap[1])(_dependencyMap[2], _dependencyMap.paths);
+        require(_dependencyMap[1])(_dependencyMap[3], _dependencyMap.paths);
+      },"/app/index.js",{"0":"/app/a.js","1":"/app/expo-mock/async-require","2":"/app/b.js","3":"/app/c.js","paths":{"/app/a.js":"/_expo/static/js/web/a-12c7a49f9bd14cd5825ead8b8b20af16.js","/app/b.js":"/_expo/static/js/web/b-530ae3505b2e7d48992cf467aa3b51b5.js","/app/c.js":"/_expo/static/js/web/c-56e8e09d8263e0e34c2784569336ac37.js"}});
+      __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         module.exports = () => 'MOCK';
       },"/app/expo-mock/async-require",[]);
       TEST_RUN_MODULE("/app/index.js");",
           "type": "js",
         },
         {
-          "filename": "_expo/static/js/web/a-70528b7a0a1910d872803a9f7d408bcb.js",
+          "filename": "_expo/static/js/web/a-12c7a49f9bd14cd5825ead8b8b20af16.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": true,
@@ -1205,11 +1205,11 @@ describe('serializes', () => {
             "reactClientReferences": [],
             "reactServerReferences": [],
             "requires": [
-              "_expo/static/js/web/__expo-metro-runtime-9766bff2257e805459e3ab4532b77d32.js",
+              "_expo/static/js/web/__expo-metro-runtime-49146aac8fa3540454ba583868edfc36.js",
             ],
           },
           "originFilename": "a.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -1221,14 +1221,14 @@ describe('serializes', () => {
             return a;
           }
         });
-        _$$_REQUIRE(_dependencyMap[0]);
-        _$$_REQUIRE(_dependencyMap[1]);
+        require(_dependencyMap[0]);
+        require(_dependencyMap[1]);
         const a = 'a';
       },"/app/a.js",["/app/d.js","/app/e.js"]);",
           "type": "js",
         },
         {
-          "filename": "_expo/static/js/web/b-fd5ce6f7800ab69b4ffe8359d27d268f.js",
+          "filename": "_expo/static/js/web/b-530ae3505b2e7d48992cf467aa3b51b5.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": true,
@@ -1240,11 +1240,11 @@ describe('serializes', () => {
             "reactClientReferences": [],
             "reactServerReferences": [],
             "requires": [
-              "_expo/static/js/web/__expo-metro-runtime-9766bff2257e805459e3ab4532b77d32.js",
+              "_expo/static/js/web/__expo-metro-runtime-49146aac8fa3540454ba583868edfc36.js",
             ],
           },
           "originFilename": "b.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -1256,13 +1256,13 @@ describe('serializes', () => {
             return b;
           }
         });
-        _$$_REQUIRE(_dependencyMap[0]);
+        require(_dependencyMap[0]);
         const b = 'b';
       },"/app/b.js",["/app/d.js"]);",
           "type": "js",
         },
         {
-          "filename": "_expo/static/js/web/c-c1ea5faaf03846340d18f64eb7fd10a5.js",
+          "filename": "_expo/static/js/web/c-56e8e09d8263e0e34c2784569336ac37.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": true,
@@ -1274,11 +1274,11 @@ describe('serializes', () => {
             "reactClientReferences": [],
             "reactServerReferences": [],
             "requires": [
-              "_expo/static/js/web/__expo-metro-runtime-9766bff2257e805459e3ab4532b77d32.js",
+              "_expo/static/js/web/__expo-metro-runtime-49146aac8fa3540454ba583868edfc36.js",
             ],
           },
           "originFilename": "c.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -1290,13 +1290,13 @@ describe('serializes', () => {
             return c;
           }
         });
-        _$$_REQUIRE(_dependencyMap[0]);
+        require(_dependencyMap[0]);
         const c = 'c';
       },"/app/c.js",["/app/e.js"]);",
           "type": "js",
         },
         {
-          "filename": "_expo/static/js/web/__common-e8c8ebf41a34c79ec57f339049e2ea36.js",
+          "filename": "_expo/static/js/web/__common-39fcae1c62a6d2e698c18534fd82e6c6.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": false,
@@ -1309,11 +1309,11 @@ describe('serializes', () => {
             "reactClientReferences": [],
             "reactServerReferences": [],
             "requires": [
-              "_expo/static/js/web/__expo-metro-runtime-9766bff2257e805459e3ab4532b77d32.js",
+              "_expo/static/js/web/__expo-metro-runtime-49146aac8fa3540454ba583868edfc36.js",
             ],
           },
           "originFilename": "../__common.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -1327,7 +1327,7 @@ describe('serializes', () => {
         });
         const d = 'd';
       },"/app/d.js",[]);
-      __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+      __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         "use strict";
 
         Object.defineProperty(exports, '__esModule', {
@@ -1344,7 +1344,7 @@ describe('serializes', () => {
           "type": "js",
         },
         {
-          "filename": "_expo/static/js/web/__expo-metro-runtime-9766bff2257e805459e3ab4532b77d32.js",
+          "filename": "_expo/static/js/web/__expo-metro-runtime-49146aac8fa3540454ba583868edfc36.js",
           "metadata": {
             "expoDomComponentReferences": [],
             "isAsync": false,
@@ -1356,7 +1356,7 @@ describe('serializes', () => {
             "requires": [],
           },
           "originFilename": "../__expo-metro-runtime.js",
-          "source": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          "source": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
         console.log('PRE_MODULE_TEST');
       },"/app/__premodule__",[]);",
           "type": "js",
@@ -1613,12 +1613,12 @@ describe('serializes', () => {
       });
 
       expect(artifacts[0].source).toMatchInlineSnapshot(`
-        "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
           "use strict";
 
-          _$$_REQUIRE(_dependencyMap[0]);
+          require(_dependencyMap[0]);
         },"/app/index.js",["/app/other.js"]);
-        __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
           "use strict";
 
           Object.defineProperty(exports, '__esModule', {
@@ -1630,13 +1630,13 @@ describe('serializes', () => {
               return foo;
             }
           });
-          const proxy = _$$_REQUIRE(_dependencyMap[0]).createClientModuleProxy("./other.js");
+          const proxy = require(_dependencyMap[0]).createClientModuleProxy("./other.js");
           module.exports = proxy;
-          const foo = _$$_REQUIRE(_dependencyMap[0]).registerClientReference(function () {
+          const foo = require(_dependencyMap[0]).registerClientReference(function () {
             throw new Error("Attempted to call foo() of /app/other.js from the server but foo is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.");
           }, "./other.js", "foo");
         },"/app/other.js",["/app/react-server-dom-webpack/server"]);
-        __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {},"/app/react-server-dom-webpack/server",[]);
+        __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {},"/app/react-server-dom-webpack/server",[]);
         TEST_RUN_MODULE("/app/index.js");"
       `);
     });

--- a/packages/@expo/metro-config/src/serializer/fork/__tests__/js.test.ts
+++ b/packages/@expo/metro-config/src/serializer/fork/__tests__/js.test.ts
@@ -40,9 +40,9 @@ describe(wrapModule, () => {
       );
       expect(res.paths).toEqual({});
       expect(res.src).toMatchInlineSnapshot(`
-        "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-          var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/interopRequireDefault").default;
-          var _View = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], "react-native-web/dist/exports/View"));
+        "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          var _interopRequireDefault = require(_dependencyMap[0], "@babel/runtime/helpers/interopRequireDefault").default;
+          var _View = _interopRequireDefault(require(_dependencyMap[1], "react-native-web/dist/exports/View"));
           console.log("Hello World");
         },"/app/index.js",["/app/node_modules/@babel/runtime/helpers/interopRequireDefault/index.js","/app/node_modules/react-native-web/dist/exports/View/index.js"],"index.js");"
       `);
@@ -54,8 +54,8 @@ describe(wrapModule, () => {
       });
       expect(res.paths).toEqual({});
       expect(res.src).toMatchInlineSnapshot(`
-        "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-          const evan = _$$_REQUIRE(_dependencyMap[1], "expo-mock/async-require")(_dependencyMap[0], _dependencyMap.paths, "bacon");
+        "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+          const evan = require(_dependencyMap[1], "expo-mock/async-require")(_dependencyMap[0], _dependencyMap.paths, "bacon");
         },"/app/index.js",["/app/node_modules/bacon/index.js","/app/node_modules/expo-mock/async-require/index.js"],"index.js");"
       `);
     });
@@ -75,8 +75,8 @@ describe(wrapModule, () => {
       /node_modules\/bacon\/index\.bundle\?platform=web&dev=true&minify=false&modulesOnly=true&runModule=false/
     );
     expect(res.src).toMatchInlineSnapshot(`
-      "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-        const evan = _$$_REQUIRE(_dependencyMap[1], "expo-mock/async-require")(_dependencyMap[0], _dependencyMap.paths, "bacon");
+      "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        const evan = require(_dependencyMap[1], "expo-mock/async-require")(_dependencyMap[0], _dependencyMap.paths, "bacon");
       },"/app/index.js",{"0":"/app/node_modules/bacon/index.js","1":"/app/node_modules/expo-mock/async-require/index.js","paths":{"/app/node_modules/bacon/index.js":"/node_modules/bacon/index.bundle?platform=web&dev=true&minify=false&modulesOnly=true&runModule=false"}},"index.js");"
     `);
   });
@@ -99,8 +99,8 @@ describe(wrapModule, () => {
       /\?platform=web&dev=true&minify=false&modulesOnly=true&runModule=false/
     );
     expect(res.src).toMatchInlineSnapshot(`
-      "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-        const evan = _$$_REQUIRE(_dependencyMap[1], "expo-mock/async-require")(_dependencyMap[0], _dependencyMap.paths, "bacon");
+      "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        const evan = require(_dependencyMap[1], "expo-mock/async-require")(_dependencyMap[0], _dependencyMap.paths, "bacon");
       },"/app/index.js",{"0":"/app/node_modules/bacon/index.js","1":"/app/node_modules/expo-mock/async-require/index.js","paths":{"/app/node_modules/bacon/index.js":"/_expo/static/js/web/0.chunk.js"}});"
     `);
   });
@@ -117,8 +117,8 @@ describe(wrapModule, () => {
         '/node_modules/bacon/index.bundle?platform=web&dev=true&minify=false&modulesOnly=true&runModule=false',
     });
     expect(res.src).toMatchInlineSnapshot(`
-      "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-        const evan = _$$_REQUIRE(_dependencyMap[1], "expo-mock/async-require")(_dependencyMap[0], _dependencyMap.paths, "bacon");
+      "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        const evan = require(_dependencyMap[1], "expo-mock/async-require")(_dependencyMap[0], _dependencyMap.paths, "bacon");
       },"/app/index.js",{"0":"/app/node_modules/bacon/index.js","1":"/app/node_modules/expo-mock/async-require/index.js","paths":{"/app/node_modules/bacon/index.js":"/node_modules/bacon/index.bundle?platform=web&dev=true&minify=false&modulesOnly=true&runModule=false"}});"
     `);
   });
@@ -136,8 +136,8 @@ describe(wrapModule, () => {
       '/app/node_modules/bacon/index.js': '/_expo/static/js/web/0.chunk.js',
     });
     expect(res.src).toMatchInlineSnapshot(`
-      "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-        const evan = _$$_REQUIRE(_dependencyMap[1], "expo-mock/async-require")(_dependencyMap[0], _dependencyMap.paths, "bacon");
+      "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+        const evan = require(_dependencyMap[1], "expo-mock/async-require")(_dependencyMap[0], _dependencyMap.paths, "bacon");
       },"/app/index.js",{"0":"/app/node_modules/bacon/index.js","1":"/app/node_modules/expo-mock/async-require/index.js","paths":{"/app/node_modules/bacon/index.js":"/_expo/static/js/web/0.chunk.js"}});"
     `);
   });

--- a/packages/@expo/metro-config/src/serializer/fork/__tests__/mini-metro.test.ts
+++ b/packages/@expo/metro-config/src/serializer/fork/__tests__/mini-metro.test.ts
@@ -56,10 +56,10 @@ it(`can create a micro Metro graph fixture`, async () => {
             "output": [
               {
                 "data": {
-                  "code": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+                  "code": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      var _foo = _$$_REQUIRE(_dependencyMap[0], "./foo");
+      var _foo = require(_dependencyMap[0], "./foo");
       console.log(_foo.foo);
     });",
                   "expoDomComponentReference": undefined,
@@ -76,7 +76,7 @@ it(`can create a micro Metro graph fixture`, async () => {
                     "__count": 18,
                     "__names": [
                       "_foo",
-                      "_$$_REQUIRE",
+                      "require",
                       "_dependencyMap",
                       "console",
                       "log",
@@ -104,17 +104,17 @@ it(`can create a micro Metro graph fixture`, async () => {
                       4,
                       1,
                       4,
-                      24,
+                      20,
                       2,
                       4,
                       -1,
                       4,
-                      25,
+                      21,
                       2,
                       4,
                       2,
                       4,
-                      39,
+                      35,
                       2,
                       4,
                       -1,
@@ -193,7 +193,7 @@ it(`can create a micro Metro graph fixture`, async () => {
             "output": [
               {
                 "data": {
-                  "code": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+                  "code": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
       Object.defineProperty(exports, '__esModule', {

--- a/packages/@expo/metro-config/src/serializer/fork/__tests__/mini-metro.ts
+++ b/packages/@expo/metro-config/src/serializer/fork/__tests__/mini-metro.ts
@@ -324,6 +324,9 @@ export async function parseModule(
       // TODO: Maybe just pull from expo/metro-config to ensure correctness over time.
       {
         ...METRO_CONFIG_DEFAULTS.transformer,
+        // Matches `ExpoMetroConfig`, and the upcoming Metro default. The option goes away once
+        // Metro flips it, so fixtures shouldn't bake in the renamed `require`.
+        unstable_renameRequire: false,
         asyncRequireModulePath: 'expo-mock/async-require',
         unstable_allowRequireContext: true,
         allowOptionalDependencies: true,


### PR DESCRIPTION
# Why

By default, Expo's current Metro 0.84 renames `require` calls in transformed source to `_$$_REQUIRE`, historically to help some naive static analysis. The rename was always implemented inefficiently.

Evan contributed the `unstable_renameRequire` config allowing it to be disabled for performance, and the renaming **is already disabled** in `@expo/metro-config` since https://github.com/expo/expo/pull/29619 / SDK 51.

The remnants of `_$$_REQUIRE` in Expo are just test snapshots. The upcoming Metro 0.87.1 never renames require and removes the option, so this PR reduces some snapshot churn ahead of that update. There's no user-observable change.

# How

Specified `unstable_renameRequire: false` wherever we construct Metro config for tests, and regenerated snapshots.

# Test Plan

Test only change: CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
