### PR TITLE
[docs] Fix decodeJsStringLiteral unescapes backslashes twice

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -218,14 +218,14 @@ export interface ResolvedMdxImport {
 
 type ResolveImportedMdx = (importPath: string, fromPath: string | null) => ResolvedMdxImport | null;
 
+const JS_STRING_ESCAPES: Record<string, string> = {
+  n: '\n',
+  r: '\r',
+  t: '\t',
+};
+
 function decodeJsStringLiteral(value: string): string {
-  return value
-    .replace(/\\n/g, '\n')
-    .replace(/\\r/g, '\r')
-    .replace(/\\t/g, '\t')
-    .replace(/\\\\/g, '\\')
-    .replace(/\\'/g, "'")
-    .replace(/\\"/g, '"');
+  return value.replace(/\\(.)/g, (_match, char: string) => JS_STRING_ESCAPES[char] ?? char);
 }
 
 function extractTerminalCommands(arrayLiteral: string): string[] {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26678


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2200" height="840" alt="eng-26678-before" src="https://github.com/user-attachments/assets/480ea709-fa69-4730-a5e8-fa72940a6d3d" />


<img width="2200" height="840" alt="eng-26678-after" src="https://github.com/user-attachments/assets/5f539497-d97e-48c0-b953-ae0de1efb1b5" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
