### PR TITLE
[ios][autolinking] Fix missing CSSEvent.h in reanimated SPM prebuild

### DIFF
--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json
@@ -87,6 +87,7 @@
                         { "from": "CSS/core/*.h", "to": "reanimated/CSS/core/{filename}", "type": "header" },
                         { "from": "CSS/core/transition/*.h", "to": "reanimated/CSS/core/transition/{filename}", "type": "header" },
                         { "from": "CSS/easing/*.h", "to": "reanimated/CSS/easing/{filename}", "type": "header" },
+                        { "from": "CSS/events/*.h", "to": "reanimated/CSS/events/{filename}", "type": "header" },
                         { "from": "CSS/interpolation/*.h", "to": "reanimated/CSS/interpolation/{filename}", "type": "header" },
                         { "from": "CSS/interpolation/filters/*.h", "to": "reanimated/CSS/interpolation/filters/{filename}", "type": "header" },
                         { "from": "CSS/interpolation/filters/operations/*.h", "to": "reanimated/CSS/interpolation/filters/operations/{filename}", "type": "header" },


### PR DESCRIPTION
# Why

Prebuild External iOS XCFrameworks fails to build `react-native-reanimated` (https://github.com/expo/expo/actions/runs/34533375728/job/103059256238):

```
❌ (RNReanimated_cpp/include/reanimated/CSS/configs/CSSAnimationConfig.h:5:10)
  > 5 | #include <reanimated/CSS/events/CSSEvent.h>
      |          ^ 'reanimated/CSS/events/CSSEvent.h' file not found
```

Reanimated 4.6.0 added a `Common/cpp/reanimated/CSS/events/` directory that was not mapped in our SPM config

# How

Adds the missing `CSS/events/*.h` mapping entry to `packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json`

# Test Plan

Ran the generation step against reanimated 4.6.0:

```
et prebuild react-native-reanimated --external-only --platform iOS --flavor Release \
  --skip-build --skip-compose --skip-verify
```


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)