### PR TITLE
[haptics][iOS] Migrate to the Expo Modules API 2.0

### DIFF
--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Migrate to the Expo Modules API 2.0 macros. ([#50047](https://github.com/expo/expo/pull/50047) by [@tsapeta](https://github.com/tsapeta))
+
 ## 58.0.0 — 2026-09-10
 
 ### 🐛 Bug fixes

--- a/packages/expo-haptics/ios/HapticsModule.swift
+++ b/packages/expo-haptics/ios/HapticsModule.swift
@@ -1,29 +1,31 @@
 import ExpoModulesCore
 
+@ExpoModule("ExpoHaptics")
 public class HapticsModule: Module {
-  public func definition() -> ModuleDefinition {
-    Name("ExpoHaptics")
+  // Feedback generators must be used on the main thread, so these members are isolated to the main
+  // actor instead of the JS thread the macro would pick for them.
+  @JS
+  @MainActor
+  func notificationAsync(notificationType: NotificationType) async {
+    let generator = UINotificationFeedbackGenerator()
+    generator.prepare()
+    generator.notificationOccurred(notificationType.toFeedbackType())
+  }
 
-    AsyncFunction("notificationAsync") { (notificationType: NotificationType) in
-      let generator = UINotificationFeedbackGenerator()
-      generator.prepare()
-      generator.notificationOccurred(notificationType.toFeedbackType())
-    }
-    .runOnQueue(.main)
+  @JS
+  @MainActor
+  func impactAsync(style: ImpactStyle) async {
+    let generator = UIImpactFeedbackGenerator(style: style.toFeedbackStyle())
+    generator.prepare()
+    generator.impactOccurred()
+  }
 
-    AsyncFunction("impactAsync") { (style: ImpactStyle) in
-      let generator = UIImpactFeedbackGenerator(style: style.toFeedbackStyle())
-      generator.prepare()
-      generator.impactOccurred()
-    }
-    .runOnQueue(.main)
-
-    AsyncFunction("selectionAsync") {
-      let generator = UISelectionFeedbackGenerator()
-      generator.prepare()
-      generator.selectionChanged()
-    }
-    .runOnQueue(.main)
+  @JS
+  @MainActor
+  func selectionAsync() async {
+    let generator = UISelectionFeedbackGenerator()
+    generator.prepare()
+    generator.selectionChanged()
   }
 
   enum NotificationType: String, Enumerable {


### PR DESCRIPTION
# Why

Follow-up to #49894. `expo-haptics` is another small SDK module whose whole surface the 2.0 macros cover today: one module, three async functions and two string enums, with no views, events, static members or `Either` types.

# How

`HapticsModule` drops `definition()` and exposes its three functions as `@JS` members under `@ExpoModule("ExpoHaptics")`. The enums are unchanged, since `Enumerable` with a `String` raw value already conforms to `JavaScriptCodable`.

The feedback generators must be used on the main thread. The 1.0 definition did that with `.runOnQueue(.main)`. Under the macros, an async `@JS` member gets `@JavaScriptActor` unless it declares its own isolation, so each function is marked `@MainActor`. The generated binding decodes the arguments on the JS thread, awaits the call (which hops to the main actor) and resolves the promise with `undefined`.

One thing to be aware of: the macro emits `try await` for every async call, and these functions don't throw, so the build reports `no calls to throwing functions occur within 'try' expression` once per function in the expanded code. The `try` comes from `callExpression` in the plugin's `DecorateModuleBuilder`, which adds it whenever the member is async, not only when it throws. I kept the functions non-throwing rather than adding `throws` to silence the warning; the fix belongs in the plugin.

# Test Plan

`xcodebuild -scheme ExpoHaptics` against bare-expo succeeds. The only new warnings are the three `try` warnings described above. `et check-packages expo-haptics` passes (build, typecheck, lint, format). There are no native tests for this package, so the bindings haven't been exercised at runtime yet.
