### PR TITLE
refactor: Wrap per package Android precompiling in cached Turbo tasks

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -55,9 +55,6 @@ jobs:
           java-version: '17'
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: expo
       - name: 📦 Publish canaries
         run: pnpm expotools publish-packages --canary ${{ github.event_name != 'workflow_dispatch' && '--dry' || '' }} ${{ inputs.skip-ios-prebuilds && '--skip-ios-prebuilds' || '' }}
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ bare-apps
 # Node
 node_modules
 .expo-prebuild
+.expo-prebuild-android
 npm-debug.log
 yarn-error.log
 
@@ -136,6 +137,7 @@ docs/pages/versions/*/react-native/*.diff
 
 # Prebuilds
 /packages/**/prebuilds/
+/packages/**/local-maven-repo/
 /packages/**/xcframeworks/
 /packages/**/*.spec.json
 /packages/**/Info-generated.plist

--- a/packages/expo-age-range/expo-module.config.json
+++ b/packages/expo-age-range/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["AgeRangeModule"]
   },
   "android": {
-    "modules": ["expo.modules.agerange.AgeRangeModule"]
+    "modules": ["expo.modules.agerange.AgeRangeModule"],
+    "publication": {
+      "groupId": "expo.modules.agerange",
+      "artifactId": "expo.modules.agerange",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-age-range/package.json
+++ b/packages/expo-age-range/package.json
@@ -24,6 +24,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -33,7 +34,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-app-integrity/expo-module.config.json
+++ b/packages/expo-app-integrity/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["IntegrityModule"]
   },
   "android": {
-    "modules": ["expo.modules.integrity.IntegrityModule"]
+    "modules": ["expo.modules.integrity.IntegrityModule"],
+    "publication": {
+      "groupId": "expo.modules.integrity",
+      "artifactId": "expo.modules.integrity",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-app-integrity/package.json
+++ b/packages/expo-app-integrity/package.json
@@ -25,6 +25,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -34,7 +35,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-app-metrics/expo-module.config.json
+++ b/packages/expo-app-metrics/expo-module.config.json
@@ -5,6 +5,11 @@
     "appDelegateSubscribers": ["AppMetricsAppDelegateSubscriber"]
   },
   "android": {
-    "modules": ["expo.modules.appmetrics.AppMetricsModule"]
+    "modules": ["expo.modules.appmetrics.AppMetricsModule"],
+    "publication": {
+      "groupId": "expo.modules.appmetrics",
+      "artifactId": "expo.modules.appmetrics",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-app-metrics/package.json
+++ b/packages/expo-app-metrics/package.json
@@ -32,6 +32,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -39,6 +40,7 @@
     "swift:format": "../../scripts/swift-format.sh",
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "test": "jest",
+    "prepack": "expo-module prepack",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -p tsconfig.json"

--- a/packages/expo-application/expo-module.config.json
+++ b/packages/expo-application/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["ApplicationModule"]
   },
   "android": {
-    "modules": ["expo.modules.application.ApplicationModule"]
+    "modules": ["expo.modules.application.ApplicationModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.application",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-application/package.json
+++ b/packages/expo-application/package.json
@@ -32,6 +32,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -40,7 +41,8 @@
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-asset/expo-module.config.json
+++ b/packages/expo-asset/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["AssetModule"]
   },
   "android": {
-    "modules": ["expo.modules.asset.AssetModule"]
+    "modules": ["expo.modules.asset.AssetModule"],
+    "publication": {
+      "groupId": "expo.modules.asset",
+      "artifactId": "expo.modules.asset",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -48,6 +48,7 @@
     }
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -57,6 +58,7 @@
     "swift:format": "../../scripts/swift-format.sh",
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "test": "jest",
+    "prepack": "expo-module prepack",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -b tsconfig.all.json"

--- a/packages/expo-audio/expo-module.config.json
+++ b/packages/expo-audio/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["AudioModule"]
   },
   "android": {
-    "modules": ["expo.modules.audio.AudioModule"]
+    "modules": ["expo.modules.audio.AudioModule"],
+    "publication": {
+      "groupId": "expo.modules.audio",
+      "artifactId": "expo.modules.audio",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-audio/package.json
+++ b/packages/expo-audio/package.json
@@ -22,6 +22,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -30,7 +31,8 @@
     "format": "expo-module format",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/packages/expo-background-fetch/expo-module.config.json
+++ b/packages/expo-background-fetch/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["BackgroundFetchModule"]
   },
   "android": {
-    "modules": ["expo.modules.backgroundfetch.BackgroundFetchModule"]
+    "modules": ["expo.modules.backgroundfetch.BackgroundFetchModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.backgroundfetch",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-background-fetch/package.json
+++ b/packages/expo-background-fetch/package.json
@@ -24,6 +24,7 @@
   "main": "build/BackgroundFetch.js",
   "types": "build/BackgroundFetch.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -34,7 +35,8 @@
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "expo-task-manager": "workspace:~"

--- a/packages/expo-background-task/expo-module.config.json
+++ b/packages/expo-background-task/expo-module.config.json
@@ -5,6 +5,11 @@
     "modules": ["BackgroundTaskModule"]
   },
   "android": {
-    "modules": ["expo.modules.backgroundtask.BackgroundTaskModule"]
+    "modules": ["expo.modules.backgroundtask.BackgroundTaskModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.backgroundtask",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-background-task/package.json
+++ b/packages/expo-background-task/package.json
@@ -23,6 +23,7 @@
   "main": "build/BackgroundTask.js",
   "types": "build/BackgroundTask.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -31,7 +32,8 @@
     "format": "expo-module format",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "expo-task-manager": "workspace:~"

--- a/packages/expo-battery/expo-module.config.json
+++ b/packages/expo-battery/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["BatteryModule"]
   },
   "android": {
-    "modules": ["expo.modules.battery.BatteryModule"]
+    "modules": ["expo.modules.battery.BatteryModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.battery",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-battery/package.json
+++ b/packages/expo-battery/package.json
@@ -21,6 +21,7 @@
   "main": "build/Battery.js",
   "types": "build/Battery.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -29,7 +30,8 @@
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-blob/expo-module.config.json
+++ b/packages/expo-blob/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["ExpoBlob"]
   },
   "android": {
-    "modules": ["expo.modules.blob.BlobModule"]
+    "modules": ["expo.modules.blob.BlobModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.blob",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-blob/package.json
+++ b/packages/expo-blob/package.json
@@ -21,6 +21,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -29,7 +30,8 @@
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-blur/expo-module.config.json
+++ b/packages/expo-blur/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["BlurViewModule"]
   },
   "android": {
-    "modules": ["expo.modules.blur.BlurModule"]
+    "modules": ["expo.modules.blur.BlurModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.blur",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-blur/package.json
+++ b/packages/expo-blur/package.json
@@ -22,6 +22,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -29,7 +30,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-brightness/expo-module.config.json
+++ b/packages/expo-brightness/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["BrightnessModule"]
   },
   "android": {
-    "modules": ["expo.modules.brightness.BrightnessModule"]
+    "modules": ["expo.modules.brightness.BrightnessModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.brightness",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-brightness/package.json
+++ b/packages/expo-brightness/package.json
@@ -23,6 +23,7 @@
   "main": "build/Brightness.js",
   "types": "build/Brightness.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -35,7 +36,8 @@
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/packages/expo-calendar/expo-module.config.json
+++ b/packages/expo-calendar/expo-module.config.json
@@ -7,6 +7,11 @@
     "modules": [
       "expo.modules.calendar.CalendarModule",
       "expo.modules.calendar.next.CalendarNextModule"
-    ]
+    ],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.calendar",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-calendar/package.json
+++ b/packages/expo-calendar/package.json
@@ -53,6 +53,7 @@
     }
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -62,7 +63,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/packages/expo-camera/expo-module.config.json
+++ b/packages/expo-camera/expo-module.config.json
@@ -5,6 +5,11 @@
     "podspecPath": ["ios/ExpoCamera.podspec"]
   },
   "android": {
-    "modules": ["expo.modules.camera.CameraViewModule"]
+    "modules": ["expo.modules.camera.CameraViewModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.camera",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
     "clean": "expo-module clean",

--- a/packages/expo-cellular/expo-module.config.json
+++ b/packages/expo-cellular/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["CellularModule"]
   },
   "android": {
-    "modules": ["expo.modules.cellular.CellularModule"]
+    "modules": ["expo.modules.cellular.CellularModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.cellular",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-cellular/package.json
+++ b/packages/expo-cellular/package.json
@@ -21,6 +21,7 @@
   "main": "build/Cellular.js",
   "types": "build/Cellular.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -31,7 +32,8 @@
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/packages/expo-clipboard/expo-module.config.json
+++ b/packages/expo-clipboard/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["ClipboardModule"]
   },
   "android": {
-    "modules": ["expo.modules.clipboard.ClipboardModule"]
+    "modules": ["expo.modules.clipboard.ClipboardModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.clipboard",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-clipboard/package.json
+++ b/packages/expo-clipboard/package.json
@@ -21,6 +21,7 @@
   "main": "build/Clipboard.js",
   "types": "build/Clipboard.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -28,7 +29,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-contacts/expo-module.config.json
+++ b/packages/expo-contacts/expo-module.config.json
@@ -1,12 +1,21 @@
 {
   "platforms": ["apple", "android"],
   "apple": {
-    "modules": ["ContactsModule", "ContactAccessButtonModule", "ContactsNextModule"]
+    "modules": [
+      "ContactsModule",
+      "ContactAccessButtonModule",
+      "ContactsNextModule"
+    ]
   },
   "android": {
     "modules": [
       "expo.modules.contacts.ContactsModule",
       "expo.modules.contacts.next.ContactsNextModule"
-    ]
+    ],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.contacts",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-contacts/expo-module.config.json
+++ b/packages/expo-contacts/expo-module.config.json
@@ -1,11 +1,7 @@
 {
   "platforms": ["apple", "android"],
   "apple": {
-    "modules": [
-      "ContactsModule",
-      "ContactAccessButtonModule",
-      "ContactsNextModule"
-    ]
+    "modules": ["ContactsModule", "ContactAccessButtonModule", "ContactsNextModule"]
   },
   "android": {
     "modules": [

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -53,6 +53,7 @@
   },
   "scripts": {
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",

--- a/packages/expo-crypto/expo-module.config.json
+++ b/packages/expo-crypto/expo-module.config.json
@@ -4,10 +4,7 @@
     "modules": ["CryptoModule", "AesCryptoModule"]
   },
   "android": {
-    "modules": [
-      "expo.modules.crypto.CryptoModule",
-      "expo.modules.crypto.aes.AesCryptoModule"
-    ],
+    "modules": ["expo.modules.crypto.CryptoModule", "expo.modules.crypto.aes.AesCryptoModule"],
     "publication": {
       "groupId": "host.exp.exponent",
       "artifactId": "expo.modules.crypto",

--- a/packages/expo-crypto/expo-module.config.json
+++ b/packages/expo-crypto/expo-module.config.json
@@ -4,6 +4,14 @@
     "modules": ["CryptoModule", "AesCryptoModule"]
   },
   "android": {
-    "modules": ["expo.modules.crypto.CryptoModule", "expo.modules.crypto.aes.AesCryptoModule"]
+    "modules": [
+      "expo.modules.crypto.CryptoModule",
+      "expo.modules.crypto.aes.AesCryptoModule"
+    ],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.crypto",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-crypto/package.json
+++ b/packages/expo-crypto/package.json
@@ -38,6 +38,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -45,7 +46,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-device/expo-module.config.json
+++ b/packages/expo-device/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["DeviceModule"]
   },
   "android": {
-    "modules": ["expo.modules.device.DeviceModule"]
+    "modules": ["expo.modules.device.DeviceModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.device",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-device/package.json
+++ b/packages/expo-device/package.json
@@ -21,6 +21,7 @@
   "main": "build/Device.js",
   "types": "build/Device.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -28,7 +29,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "ua-parser-js": "^0.7.33"

--- a/packages/expo-document-picker/expo-module.config.json
+++ b/packages/expo-document-picker/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["DocumentPickerModule"]
   },
   "android": {
-    "modules": ["expo.modules.documentpicker.DocumentPickerModule"]
+    "modules": ["expo.modules.documentpicker.DocumentPickerModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.documentpicker",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-document-picker/package.json
+++ b/packages/expo-document-picker/package.json
@@ -23,6 +23,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -34,7 +35,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/packages/expo-file-system/expo-module.config.json
+++ b/packages/expo-file-system/expo-module.config.json
@@ -8,6 +8,11 @@
     "modules": [
       "expo.modules.filesystem.FileSystemModule",
       "expo.modules.filesystem.legacy.FileSystemLegacyModule"
-    ]
+    ],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.filesystem",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -54,6 +54,7 @@
   },
   "scripts": {
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",

--- a/packages/expo-font/expo-module.config.json
+++ b/packages/expo-font/expo-module.config.json
@@ -4,10 +4,7 @@
     "modules": ["FontLoaderModule", "FontUtilsModule"]
   },
   "android": {
-    "modules": [
-      "expo.modules.font.FontLoaderModule",
-      "expo.modules.font.FontUtilsModule"
-    ],
+    "modules": ["expo.modules.font.FontLoaderModule", "expo.modules.font.FontUtilsModule"],
     "publication": {
       "groupId": "host.exp.exponent",
       "artifactId": "expo.modules.font",

--- a/packages/expo-font/expo-module.config.json
+++ b/packages/expo-font/expo-module.config.json
@@ -4,6 +4,14 @@
     "modules": ["FontLoaderModule", "FontUtilsModule"]
   },
   "android": {
-    "modules": ["expo.modules.font.FontLoaderModule", "expo.modules.font.FontUtilsModule"]
+    "modules": [
+      "expo.modules.font.FontLoaderModule",
+      "expo.modules.font.FontUtilsModule"
+    ],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.font",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-font/package.json
+++ b/packages/expo-font/package.json
@@ -53,6 +53,7 @@
   "scripts": {
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
     "clean": "expo-module clean",

--- a/packages/expo-gl/expo-module.config.json
+++ b/packages/expo-gl/expo-module.config.json
@@ -5,6 +5,11 @@
     "modules": ["ExpoGLModule"]
   },
   "android": {
-    "modules": ["expo.modules.gl.GLModule"]
+    "modules": ["expo.modules.gl.GLModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.gl",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-gl/package.json
+++ b/packages/expo-gl/package.json
@@ -24,6 +24,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -32,7 +33,8 @@
     "test:snapshots": "jest --updateSnapshot",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "invariant": "^2.2.4"

--- a/packages/expo-haptics/expo-module.config.json
+++ b/packages/expo-haptics/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["HapticsModule"]
   },
   "android": {
-    "modules": ["expo.modules.haptics.HapticsModule"]
+    "modules": ["expo.modules.haptics.HapticsModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.haptics",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-haptics/package.json
+++ b/packages/expo-haptics/package.json
@@ -34,6 +34,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -42,7 +43,8 @@
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-image-loader/expo-module.config.json
+++ b/packages/expo-image-loader/expo-module.config.json
@@ -1,6 +1,11 @@
 {
   "platforms": ["android"],
   "android": {
-    "services": ["expo.modules.imageloader.ImageLoaderService"]
+    "services": ["expo.modules.imageloader.ImageLoaderService"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.imageloader",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-image-loader/package.json
+++ b/packages/expo-image-loader/package.json
@@ -25,5 +25,9 @@
   },
   "peerDependencies": {
     "expo": "*"
+  },
+  "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
+    "prepack": "expo-module prepack"
   }
 }

--- a/packages/expo-image-manipulator/expo-module.config.json
+++ b/packages/expo-image-manipulator/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["ImageManipulatorModule"]
   },
   "android": {
-    "modules": ["expo.modules.imagemanipulator.ImageManipulatorModule"]
+    "modules": ["expo.modules.imagemanipulator.ImageManipulatorModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.imagemanipulator",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-image-manipulator/package.json
+++ b/packages/expo-image-manipulator/package.json
@@ -34,6 +34,7 @@
   },
   "scripts": {
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",

--- a/packages/expo-image-picker/expo-module.config.json
+++ b/packages/expo-image-picker/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["ImagePickerModule"]
   },
   "android": {
-    "modules": ["expo.modules.imagepicker.ImagePickerModule"]
+    "modules": ["expo.modules.imagepicker.ImagePickerModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.imagepicker",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-image-picker/package.json
+++ b/packages/expo-image-picker/package.json
@@ -24,6 +24,7 @@
   "main": "src/ImagePicker.ts",
   "types": "build/ImagePicker.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -33,7 +34,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "expo-image-loader": "workspace:~"

--- a/packages/expo-image/expo-module.config.json
+++ b/packages/expo-image/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["ImageModule"]
   },
   "android": {
-    "modules": ["expo.modules.image.ExpoImageModule"]
+    "modules": ["expo.modules.image.ExpoImageModule"],
+    "publication": {
+      "groupId": "expo.modules.image",
+      "artifactId": "expo.modules.image",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-image/package.json
+++ b/packages/expo-image/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",

--- a/packages/expo-insights/expo-module.config.json
+++ b/packages/expo-insights/expo-module.config.json
@@ -5,6 +5,11 @@
     "appDelegateSubscribers": ["InsightsAppDelegateSubscriber"]
   },
   "android": {
-    "modules": ["expo.modules.insights.ExpoInsightsModule"]
+    "modules": ["expo.modules.insights.ExpoInsightsModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.insights",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-insights/package.json
+++ b/packages/expo-insights/package.json
@@ -22,13 +22,15 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
     "format": "expo-module format",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "expo-eas-client": "workspace:~"

--- a/packages/expo-intent-launcher/expo-module.config.json
+++ b/packages/expo-intent-launcher/expo-module.config.json
@@ -1,6 +1,11 @@
 {
   "platforms": ["android"],
   "android": {
-    "modules": ["expo.modules.intentlauncher.IntentLauncherModule"]
+    "modules": ["expo.modules.intentlauncher.IntentLauncherModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.intentlauncher",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-intent-launcher/package.json
+++ b/packages/expo-intent-launcher/package.json
@@ -24,13 +24,15 @@
   "main": "build/IntentLauncher.js",
   "types": "build/IntentLauncher.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
     "format": "expo-module format",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-keep-awake/expo-module.config.json
+++ b/packages/expo-keep-awake/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["KeepAwakeModule"]
   },
   "android": {
-    "modules": ["expo.modules.keepawake.KeepAwakeModule"]
+    "modules": ["expo.modules.keepawake.KeepAwakeModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.keepawake",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-keep-awake/package.json
+++ b/packages/expo-keep-awake/package.json
@@ -42,6 +42,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -49,6 +50,7 @@
     "swift:format": "../../scripts/swift-format.sh",
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "test": "jest",
+    "prepack": "expo-module prepack",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "depscheck": "expo-module depscheck",

--- a/packages/expo-linear-gradient/expo-module.config.json
+++ b/packages/expo-linear-gradient/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["LinearGradientModule"]
   },
   "android": {
-    "modules": ["expo.modules.lineargradient.LinearGradientModule"]
+    "modules": ["expo.modules.lineargradient.LinearGradientModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.lineargradient",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-linear-gradient/package.json
+++ b/packages/expo-linear-gradient/package.json
@@ -22,6 +22,7 @@
   "main": "build/LinearGradient.js",
   "types": "build/LinearGradient.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -29,7 +30,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/packages/expo-linking/expo-module.config.json
+++ b/packages/expo-linking/expo-module.config.json
@@ -5,6 +5,11 @@
     "appDelegateSubscribers": ["LinkingAppDelegateSubscriber"]
   },
   "android": {
-    "modules": ["expo.modules.linking.ExpoLinkingModule"]
+    "modules": ["expo.modules.linking.ExpoLinkingModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.linking",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-linking/package.json
+++ b/packages/expo-linking/package.json
@@ -40,6 +40,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -49,7 +50,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "expo-constants": "workspace:~",

--- a/packages/expo-local-authentication/expo-module.config.json
+++ b/packages/expo-local-authentication/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["LocalAuthenticationModule"]
   },
   "android": {
-    "modules": ["expo.modules.localauthentication.LocalAuthenticationModule"]
+    "modules": ["expo.modules.localauthentication.LocalAuthenticationModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.localauthentication",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-local-authentication/package.json
+++ b/packages/expo-local-authentication/package.json
@@ -26,6 +26,7 @@
   "main": "build/LocalAuthentication.js",
   "types": "build/LocalAuthentication.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -35,7 +36,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "invariant": "^2.2.4"

--- a/packages/expo-localization/expo-module.config.json
+++ b/packages/expo-localization/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["LocalizationModule"]
   },
   "android": {
-    "modules": ["expo.modules.localization.LocalizationModule"]
+    "modules": ["expo.modules.localization.LocalizationModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.localization",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-localization/package.json
+++ b/packages/expo-localization/package.json
@@ -27,6 +27,7 @@
   "main": "build/Localization.js",
   "types": "build/Localization.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -36,7 +37,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "rtl-detect": "^1.0.2"

--- a/packages/expo-location/expo-module.config.json
+++ b/packages/expo-location/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["LocationModule"]
   },
   "android": {
-    "modules": ["expo.modules.location.LocationModule"]
+    "modules": ["expo.modules.location.LocationModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.location",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -28,6 +28,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",

--- a/packages/expo-mail-composer/expo-module.config.json
+++ b/packages/expo-mail-composer/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["MailComposerModule"]
   },
   "android": {
-    "modules": ["expo.modules.mailcomposer.MailComposerModule"]
+    "modules": ["expo.modules.mailcomposer.MailComposerModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.mailcomposer",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-mail-composer/package.json
+++ b/packages/expo-mail-composer/package.json
@@ -23,6 +23,7 @@
   "main": "build/MailComposer.js",
   "types": "build/MailComposer.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -32,7 +33,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/packages/expo-maps/expo-module.config.json
+++ b/packages/expo-maps/expo-module.config.json
@@ -9,6 +9,11 @@
       "expo.modules.maps.MapsModule",
       "expo.modules.maps.GoogleMapsModule",
       "expo.modules.maps.StreetViewModule"
-    ]
+    ],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.maps",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-maps/package.json
+++ b/packages/expo-maps/package.json
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",

--- a/packages/expo-media-library/expo-module.config.json
+++ b/packages/expo-media-library/expo-module.config.json
@@ -7,6 +7,11 @@
     "modules": [
       "expo.modules.medialibrary.MediaLibraryModule",
       "expo.modules.medialibrary.next.MediaLibraryNextModule"
-    ]
+    ],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.medialibrary",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -57,6 +57,7 @@
   },
   "scripts": {
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",

--- a/packages/expo-mesh-gradient/expo-module.config.json
+++ b/packages/expo-mesh-gradient/expo-module.config.json
@@ -5,6 +5,11 @@
     "modules": ["MeshGradientModule"]
   },
   "android": {
-    "modules": ["expo.modules.meshgradient.MeshGradientModule"]
+    "modules": ["expo.modules.meshgradient.MeshGradientModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.meshgradient",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-mesh-gradient/package.json
+++ b/packages/expo-mesh-gradient/package.json
@@ -31,13 +31,15 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
     "format": "expo-module format",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-module-scripts/bin/expo-module-prepack
+++ b/packages/expo-module-scripts/bin/expo-module-prepack
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 
 import { stageIosPrebuilds } from '../utils/iosPrebuilds.js';
+import { stageAndroidPrebuilds } from '../utils/androidPrebuilds.js';
 
 try {
   if (stageIosPrebuilds()) console.log('Staged iOS prebuilds for publishing');
+  if (stageAndroidPrebuilds()) console.log('Staged Android prebuilds for publishing');
 } catch (error) {
   console.error(error);
   process.exit(error.status || error.code || 1);

--- a/packages/expo-module-scripts/bin/expo-module-prepublishOnly
+++ b/packages/expo-module-scripts/bin/expo-module-prepublishOnly
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { commandRunner, packageManagerRunAsync } from '../utils/commandUtils.js';
 import { validateRawIosPrebuilds } from '../utils/iosPrebuilds.js';
+import { validateRawAndroidPrebuilds } from '../utils/androidPrebuilds.js';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -15,6 +16,7 @@ async function runAsync() {
   // Run the package's own `build` script so `expo-build` modules still emit output before publishing.
   await packageManagerRunAsync(['build']);
   validateRawIosPrebuilds();
+  validateRawAndroidPrebuilds();
 }
 
 (async () => {

--- a/packages/expo-module-scripts/utils/androidPrebuilds.js
+++ b/packages/expo-module-scripts/utils/androidPrebuilds.js
@@ -1,0 +1,93 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const OUTPUT = '.expo-prebuild-android';
+
+function readManifest(packageRoot) {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
+  if (!packageJson.scripts?.['precompile-android']) {
+    return null;
+  }
+  const manifestPath = path.join(packageRoot, OUTPUT, 'publication.json');
+  if (!fs.statSync(manifestPath, { throwIfNoEntry: false })?.isFile()) {
+    throw new Error(`Android publication manifest is missing: ${manifestPath}`);
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  if (
+    manifest.schemaVersion !== 1 ||
+    manifest.packageName !== packageJson.name ||
+    manifest.packageVersion !== packageJson.version ||
+    !Array.isArray(manifest.publications) ||
+    manifest.publications.length === 0
+  ) {
+    throw new Error(
+      `Android publication manifest does not match ${packageJson.name}@${packageJson.version}`
+    );
+  }
+  return manifest;
+}
+
+export function validateRawAndroidPrebuilds(packageRoot = process.cwd()) {
+  const manifest = readManifest(packageRoot);
+  if (!manifest) return false;
+  const config = JSON.parse(
+    fs.readFileSync(path.join(packageRoot, 'expo-module.config.json'), 'utf8')
+  );
+  const repositoryRoot = path.resolve(packageRoot, OUTPUT, 'local-maven-repo');
+  const coordinates = new Set();
+  for (const publication of manifest.publications) {
+    const coordinate = `${publication.groupId}:${publication.artifactId}:${publication.version}`;
+    if (coordinates.has(coordinate))
+      throw new Error(`Duplicate Android publication: ${coordinate}`);
+    coordinates.add(coordinate);
+    if (
+      publication.version !== manifest.packageVersion ||
+      publication.repository !== 'local-maven-repo'
+    ) {
+      throw new Error(`Invalid Android publication: ${coordinate}`);
+    }
+    const configuredProject = config.android?.projects?.find(
+      (project) => project.name === publication.projectName
+    );
+    const configuredPublication = configuredProject?.publication ?? config.android?.publication;
+    if (
+      configuredPublication?.groupId !== publication.groupId ||
+      configuredPublication?.artifactId !== publication.artifactId ||
+      (configuredPublication?.version != null &&
+        configuredPublication.version !== publication.version) ||
+      configuredPublication?.repository !== publication.repository
+    ) {
+      throw new Error(`Committed Android publication configuration does not match ${coordinate}`);
+    }
+    const directory = path.resolve(
+      repositoryRoot,
+      ...publication.groupId.split('.'),
+      publication.artifactId,
+      publication.version
+    );
+    if (!directory.startsWith(repositoryRoot + path.sep)) {
+      throw new Error(`Unsafe Android publication path: ${coordinate}`);
+    }
+    const basename = `${publication.artifactId}-${publication.version}`;
+    for (const extension of ['aar', 'pom', 'module']) {
+      const artifact = path.join(directory, `${basename}.${extension}`);
+      if (!fs.statSync(artifact, { throwIfNoEntry: false })?.isFile()) {
+        throw new Error(`Android publication artifact is missing: ${artifact}`);
+      }
+    }
+  }
+  return true;
+}
+
+export function stageAndroidPrebuilds(packageRoot = process.cwd()) {
+  const manifest = readManifest(packageRoot);
+  if (!manifest) return false;
+  validateRawAndroidPrebuilds(packageRoot);
+
+  const repositoryDestination = path.join(packageRoot, 'local-maven-repo');
+  fs.rmSync(repositoryDestination, { recursive: true, force: true });
+  fs.cpSync(path.join(packageRoot, OUTPUT, 'local-maven-repo'), repositoryDestination, {
+    recursive: true,
+  });
+  return true;
+}

--- a/packages/expo-module-scripts/utils/androidPrebuilds.test.js
+++ b/packages/expo-module-scripts/utils/androidPrebuilds.test.js
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { stageAndroidPrebuilds, validateRawAndroidPrebuilds } from './androidPrebuilds.js';
+
+function fixture(version = '1.0.0') {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'android-prebuilds-'));
+  const publication = {
+    projectName: 'expo-fixture',
+    groupId: 'expo.modules',
+    artifactId: 'fixture',
+    version,
+    repository: 'local-maven-repo',
+  };
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'expo-fixture',
+      version,
+      scripts: { 'precompile-android': 'precompile fixture' },
+    })
+  );
+  fs.writeFileSync(
+    path.join(root, 'expo-module.config.json'),
+    `${JSON.stringify(
+      {
+        platforms: ['android'],
+        android: {
+          publication: {
+            groupId: publication.groupId,
+            artifactId: publication.artifactId,
+            repository: publication.repository,
+          },
+        },
+      },
+      null,
+      2
+    )}\n`
+  );
+  const output = path.join(root, '.expo-prebuild-android');
+  fs.mkdirSync(output, { recursive: true });
+  fs.writeFileSync(
+    path.join(output, 'publication.json'),
+    JSON.stringify({
+      schemaVersion: 1,
+      packageName: 'expo-fixture',
+      packageVersion: version,
+      publications: [publication],
+    })
+  );
+  const coordinate = path.join(output, `local-maven-repo/expo/modules/fixture/${version}`);
+  fs.mkdirSync(coordinate, { recursive: true });
+  for (const extension of ['aar', 'pom', 'module']) {
+    fs.writeFileSync(path.join(coordinate, `fixture-${version}.${extension}`), extension);
+  }
+  return root;
+}
+
+test('stages an embedded Maven repository without modifying committed config', () => {
+  const root = fixture();
+  const configPath = path.join(root, 'expo-module.config.json');
+  const original = fs.readFileSync(configPath, 'utf8');
+  assert.equal(validateRawAndroidPrebuilds(root), true);
+  assert.equal(stageAndroidPrebuilds(root), true);
+  assert.equal(fs.readFileSync(configPath, 'utf8'), original);
+  assert.equal(
+    fs.readFileSync(
+      path.join(root, 'local-maven-repo/expo/modules/fixture/1.0.0/fixture-1.0.0.aar'),
+      'utf8'
+    ),
+    'aar'
+  );
+  assert.equal(fs.readFileSync(configPath, 'utf8'), original);
+});
+
+test('rejects stale versions and missing artifacts before staging', () => {
+  const root = fixture();
+  const manifestPath = path.join(root, '.expo-prebuild-android/publication.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  manifest.packageVersion = '2.0.0';
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+  assert.throws(() => stageAndroidPrebuilds(root), /does not match expo-fixture@1\.0\.0/);
+  manifest.packageVersion = '1.0.0';
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+  fs.rmSync(
+    path.join(
+      root,
+      '.expo-prebuild-android/local-maven-repo/expo/modules/fixture/1.0.0/fixture-1.0.0.aar'
+    )
+  );
+  assert.throws(() => stageAndroidPrebuilds(root), /artifact is missing/);
+});
+
+test('stages canary publication versions while config remains versionless', () => {
+  const version = '59.0.0-canary-20260911-deadbee';
+  const root = fixture(version);
+  assert.equal(stageAndroidPrebuilds(root), true);
+  assert.equal(
+    fs.existsSync(
+      path.join(root, `local-maven-repo/expo/modules/fixture/${version}/fixture-${version}.aar`)
+    ),
+    true
+  );
+});
+
+test('packages without the Android precompile marker are lifecycle no-ops', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'android-prebuilds-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: 'fixture', scripts: {} })
+  );
+  assert.equal(validateRawAndroidPrebuilds(root), false);
+  assert.equal(stageAndroidPrebuilds(root), false);
+});

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsPlugin.kt
@@ -48,6 +48,10 @@ open class ExpoAutolinkingSettingsPlugin : Plugin<Settings> {
   }
 
   private fun getExpoGradlePluginsFile(settings: Settings): File {
+    settings.providers.gradleProperty("expo.precompileAndroid.expoPlugin")
+      .orNull
+      ?.let { return File(it).absoluteFile }
+
     val expoModulesAutolinkingPath =
       settings.providers.exec { env ->
         env.workingDir(settings.rootDir)

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -72,7 +72,10 @@ class SettingsManager(
           it.matches(project.name)
         }
 
-        project.configuration.shouldUsePublication = !forceBuildFromSource && evaluateShouldUsePublicationScript(project)
+        project.configuration.shouldUsePublication =
+          !forceBuildFromSource &&
+          hasPublicationRepository(project) &&
+          evaluateShouldUsePublicationScript(project)
       }
     }
   }
@@ -169,4 +172,12 @@ class SettingsManager(
     allPlugins.forEach(settings::linkPlugin)
     allAarProjects.forEach(settings::linkAarProject)
   }
+}
+
+internal fun hasPublicationRepository(project: GradleProject): Boolean {
+  val repository = project.publication?.repository ?: return false
+  if (repository == "mavenLocal") {
+    return true
+  }
+  return File(project.sourceDir).resolve("../$repository").isDirectory
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/test/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsPluginTest.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/test/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsPluginTest.kt
@@ -2,6 +2,8 @@ package expo.modules.plugin
 
 import com.google.common.truth.Truth
 import expo.modules.plugin.configuration.ExpoAutolinkingConfig
+import expo.modules.plugin.configuration.GradleProject
+import expo.modules.plugin.configuration.Publication
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Before
@@ -52,6 +54,25 @@ class ExpoAutolinkingSettingsPluginTest {
     val configFromAutolinking = ExpoAutolinkingConfig.decodeFromString(configStringFromAutolinking)
 
     Truth.assertThat(configFromPlugin).isEqualTo(configFromAutolinking)
+  }
+
+  @Test
+  fun `uses a package-local publication only when its repository exists`() {
+    val androidDirectory = testProjectDir.newFolder("module", "android")
+    val project = GradleProject(
+      name = "expo-module",
+      sourceDir = androidDirectory.absolutePath,
+      publication = Publication(
+        groupId = "expo.modules",
+        artifactId = "module",
+        version = "1.0.0",
+        repository = "local-maven-repo"
+      )
+    )
+
+    Truth.assertThat(hasPublicationRepository(project)).isFalse()
+    File(androidDirectory.parentFile, "local-maven-repo").mkdirs()
+    Truth.assertThat(hasPublicationRepository(project)).isTrue()
   }
 
   private fun executeGradleRun(task: String? = null): BuildResult =

--- a/packages/expo-modules-autolinking/src/platforms/__tests__/android-test.ts
+++ b/packages/expo-modules-autolinking/src/platforms/__tests__/android-test.ts
@@ -56,6 +56,34 @@ describe(resolveModuleAsync, () => {
     });
   });
 
+  it('should default an Android publication to the package version', async () => {
+    const name = 'react-native-third-party';
+    const pkgDir = path.join('node_modules', name);
+    const result = await resolveModuleAsync(name, {
+      name,
+      path: pkgDir,
+      version: '1.2.3',
+      config: new ExpoModuleConfig({
+        platforms: ['android'],
+        android: {
+          path: 'android',
+          publication: {
+            groupId: 'example.modules',
+            artifactId: 'third-party',
+            repository: 'local-maven-repo',
+          },
+        },
+      }),
+    });
+
+    expect(result?.projects?.[0]?.publication).toEqual({
+      groupId: 'example.modules',
+      artifactId: 'third-party',
+      version: '1.2.3',
+      repository: 'local-maven-repo',
+    });
+  });
+
   it('should contain coreFeature field', async () => {
     const name = 'react-native-third-party';
     const pkgDir = path.join('node_modules', name);

--- a/packages/expo-modules-autolinking/src/platforms/android/android.ts
+++ b/packages/expo-modules-autolinking/src/platforms/android/android.ts
@@ -89,7 +89,12 @@ export async function resolveModuleAsync(
       };
     });
 
-    const { publication } = project;
+    const publication = project.publication
+      ? {
+          ...project.publication,
+          version: project.publication.version ?? revision.version,
+        }
+      : undefined;
     const shouldUsePublicationScriptPath = project.shouldUsePublicationScriptPath
       ? path.join(revision.path, project.shouldUsePublicationScriptPath)
       : undefined;

--- a/packages/expo-modules-autolinking/src/types.ts
+++ b/packages/expo-modules-autolinking/src/types.ts
@@ -34,7 +34,7 @@ export interface ModuleAndroidProjectInfo {
   modulesV2: string[];
   services: string[];
   packages: string[];
-  publication?: AndroidPublication;
+  publication?: WithRequired<AndroidPublication, 'version'>;
   aarProjects?: AndroidGradleAarProjectDescriptor[];
   shouldUsePublicationScriptPath?: string;
 }
@@ -165,15 +165,15 @@ export interface AndroidPublication {
   /**
    * The Maven artifact ID.
    */
-  id: string;
+  artifactId: string;
   /**
    * The Maven group ID.
    */
-  group: string;
+  groupId: string;
   /**
-   * The Maven version.
+   * The Maven version. Defaults to the package version when omitted from module config.
    */
-  version: string;
+  version?: string;
   /**
    * The Maven repository.
    */

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -13,6 +13,7 @@ import expo.modules.plugin.android.createEmptyExpoPublishToMavenLocalTask
 import expo.modules.plugin.android.createExpoPublishTask
 import expo.modules.plugin.android.createExpoPublishToMavenLocalTask
 import expo.modules.plugin.android.createReleasePublication
+import expo.modules.plugin.android.validateProjectConfiguration
 import expo.modules.plugin.gradle.ExpoModuleExtension
 import io.github.expo.pika.PikaGradleExtension
 import org.gradle.api.Project
@@ -121,10 +122,18 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
       project.createExpoPublishToMavenLocalTask(publicationInfo, expoModulesExtension)
 
       val npmLocalRepositoryRelativePath = "local-maven-repo"
-      val npmLocalRepository = File("${project.projectDir.parentFile}/${npmLocalRepositoryRelativePath}").toURI()
+      val precompileRepository = project.providers.gradleProperty("expo.precompileAndroid.repository")
+        .orNull
+        ?.let(::File)
+        ?.absoluteFile
+      if (precompileRepository != null) {
+        project.validateProjectConfiguration(expoModulesExtension)
+      }
+      val npmLocalRepository = precompileRepository
+        ?: File("${project.projectDir.parentFile}/${npmLocalRepositoryRelativePath}")
       project.publishingExtension().repositories.mavenLocal { mavenRepo ->
         mavenRepo.name = "NPMPackage"
-        mavenRepo.url = npmLocalRepository
+        mavenRepo.url = npmLocalRepository.toURI()
       }
 
       project.createExpoPublishTask(publicationInfo, expoModulesExtension, npmLocalRepositoryRelativePath)

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
@@ -119,7 +119,7 @@ internal fun Project.createExpoPublishTask(publicationInfo: PublicationInfo, exp
     val publishTask = tasks.getByName("publish")
 
     task.group = "publishing"
-    task.description = "Publishes the library to the GitHub Packages repository"
+    task.description = "Publishes the library to the embedded npm Maven repository"
     task.dependsOn(publishTask)
   }
 
@@ -134,7 +134,7 @@ internal fun Project.createEmptyExpoPublishTask(): TaskProvider<Task> {
   }
   taskProvider.configure { task ->
     task.group = "publishing"
-    task.description = "Publishes the library to the GitHub Packages repository"
+    task.description = "Publishes the library to the embedded npm Maven repository"
   }
 
   return taskProvider
@@ -208,7 +208,7 @@ private fun Project.expoPublishBody(publicationInfo: PublicationInfo, expoModule
   }.result.get()
 }
 
-private fun Project.validateProjectConfiguration(expoModulesExtension: ExpoModuleExtension) {
+internal fun Project.validateProjectConfiguration(expoModulesExtension: ExpoModuleExtension) {
   val shouldUsePublicationScript = expoModulesExtension.autolinking.getShouldUsePublicationScriptPath(this)
     ?: return // If the path to the script is not defined, we assume that we can publish the module.
 

--- a/packages/expo-navigation-bar/expo-module.config.json
+++ b/packages/expo-navigation-bar/expo-module.config.json
@@ -1,6 +1,11 @@
 {
   "platforms": ["android"],
   "android": {
-    "modules": ["expo.modules.navigationbar.NavigationBarModule"]
+    "modules": ["expo.modules.navigationbar.NavigationBarModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.navigationbar",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -35,6 +35,7 @@
     "./app.plugin.js": "./app.plugin.js"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -44,7 +45,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "debug": "^4.3.2"

--- a/packages/expo-network-addons/expo-module.config.json
+++ b/packages/expo-network-addons/expo-module.config.json
@@ -7,6 +7,11 @@
         "group": "expo.modules",
         "sourceDir": "expo-network-addons-gradle-plugin"
       }
-    ]
+    ],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.networkaddons",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-network-addons/package.json
+++ b/packages/expo-network-addons/package.json
@@ -23,13 +23,15 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
     "format": "expo-module format",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-network/expo-module.config.json
+++ b/packages/expo-network/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["NetworkModule"]
   },
   "android": {
-    "modules": ["expo.modules.network.NetworkModule"]
+    "modules": ["expo.modules.network.NetworkModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.network",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-network/package.json
+++ b/packages/expo-network/package.json
@@ -21,6 +21,7 @@
   "main": "build/Network.js",
   "types": "build/Network.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -29,7 +30,8 @@
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-notifications/expo-module.config.json
+++ b/packages/expo-notifications/expo-module.config.json
@@ -31,6 +31,11 @@
       "expo.modules.notifications.tokens.PushTokenModule",
       "expo.modules.notifications.topics.TopicSubscriptionModule",
       "expo.modules.notifications.notifications.channels.AndroidXNotificationsChannelsProvider"
-    ]
+    ],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.notifications",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -26,6 +26,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -35,7 +36,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "@expo/image-utils": "workspace:^",

--- a/packages/expo-observe/expo-module.config.json
+++ b/packages/expo-observe/expo-module.config.json
@@ -5,6 +5,11 @@
     "appDelegateSubscribers": ["ObserveAppDelegateSubscriber"]
   },
   "android": {
-    "modules": ["expo.modules.observe.ObserveModule"]
+    "modules": ["expo.modules.observe.ObserveModule"],
+    "publication": {
+      "groupId": "expo.modules.observe",
+      "artifactId": "expo.modules.observe",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-observe/package.json
+++ b/packages/expo-observe/package.json
@@ -42,6 +42,7 @@
     }
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -51,7 +52,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "expo-app-metrics": "workspace:~",

--- a/packages/expo-print/expo-module.config.json
+++ b/packages/expo-print/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["ExpoPrintModule"]
   },
   "android": {
-    "modules": ["expo.modules.print.PrintModule"]
+    "modules": ["expo.modules.print.PrintModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.print",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-print/package.json
+++ b/packages/expo-print/package.json
@@ -26,6 +26,7 @@
   "types": "build/Print.d.ts",
   "scripts": {
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",

--- a/packages/expo-router/expo-module.config.json
+++ b/packages/expo-router/expo-module.config.json
@@ -1,10 +1,19 @@
 {
   "platforms": ["apple", "android", "web"],
   "apple": {
-    "modules": ["ExpoHeadModule", "LinkPreviewNativeModule", "RouterToolbarModule"],
+    "modules": [
+      "ExpoHeadModule",
+      "LinkPreviewNativeModule",
+      "RouterToolbarModule"
+    ],
     "appDelegateSubscribers": ["ExpoHeadAppDelegateSubscriber"]
   },
   "android": {
-    "modules": ["expo.modules.router.ExpoRouterModule"]
+    "modules": ["expo.modules.router.ExpoRouterModule"],
+    "publication": {
+      "groupId": "expo.modules.router",
+      "artifactId": "expo.modules.router",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-router/expo-module.config.json
+++ b/packages/expo-router/expo-module.config.json
@@ -1,11 +1,7 @@
 {
   "platforms": ["apple", "android", "web"],
   "apple": {
-    "modules": [
-      "ExpoHeadModule",
-      "LinkPreviewNativeModule",
-      "RouterToolbarModule"
-    ],
+    "modules": ["ExpoHeadModule", "LinkPreviewNativeModule", "RouterToolbarModule"],
     "appDelegateSubscribers": ["ExpoHeadAppDelegateSubscriber"]
   },
   "android": {

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -265,6 +265,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build cjs:src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -277,7 +278,8 @@
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "@expo/log-box": "workspace:^",

--- a/packages/expo-screen-capture/expo-module.config.json
+++ b/packages/expo-screen-capture/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["ScreenCaptureModule"]
   },
   "android": {
-    "modules": ["expo.modules.screencapture.ScreenCaptureModule"]
+    "modules": ["expo.modules.screencapture.ScreenCaptureModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.screencapture",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-screen-capture/package.json
+++ b/packages/expo-screen-capture/package.json
@@ -21,6 +21,7 @@
   "main": "build/ScreenCapture.js",
   "types": "build/ScreenCapture.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -28,7 +29,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-screen-orientation/expo-module.config.json
+++ b/packages/expo-screen-orientation/expo-module.config.json
@@ -6,6 +6,11 @@
     "modules": ["ScreenOrientationModule"]
   },
   "android": {
-    "modules": ["expo.modules.screenorientation.ScreenOrientationModule"]
+    "modules": ["expo.modules.screenorientation.ScreenOrientationModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.screenorientation",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-screen-orientation/package.json
+++ b/packages/expo-screen-orientation/package.json
@@ -24,6 +24,7 @@
   "main": "build/ScreenOrientation.js",
   "types": "build/ScreenOrientation.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -33,7 +34,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/packages/expo-secure-store/expo-module.config.json
+++ b/packages/expo-secure-store/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["SecureStoreModule"]
   },
   "android": {
-    "modules": ["expo.modules.securestore.SecureStoreModule"]
+    "modules": ["expo.modules.securestore.SecureStoreModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.securestore",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-secure-store/package.json
+++ b/packages/expo-secure-store/package.json
@@ -24,6 +24,7 @@
   "main": "build/SecureStore.js",
   "types": "build/SecureStore.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -33,7 +34,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/packages/expo-sensors/expo-module.config.json
+++ b/packages/expo-sensors/expo-module.config.json
@@ -21,6 +21,11 @@
       "expo.modules.sensors.modules.MagnetometerModule",
       "expo.modules.sensors.modules.MagnetometerUncalibratedModule",
       "expo.modules.sensors.modules.PedometerModule"
-    ]
+    ],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.sensors",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-sensors/package.json
+++ b/packages/expo-sensors/package.json
@@ -29,6 +29,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -38,7 +39,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "invariant": "^2.2.4"

--- a/packages/expo-sharing/expo-module.config.json
+++ b/packages/expo-sharing/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["SharingModule"]
   },
   "android": {
-    "modules": ["expo.modules.sharing.SharingModule"]
+    "modules": ["expo.modules.sharing.SharingModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.sharing",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-sharing/package.json
+++ b/packages/expo-sharing/package.json
@@ -22,6 +22,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -31,7 +32,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "@expo/config-plugins": "workspace:^",

--- a/packages/expo-sms/expo-module.config.json
+++ b/packages/expo-sms/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["ExpoSMSModule"]
   },
   "android": {
-    "modules": ["expo.modules.sms.SMSModule"]
+    "modules": ["expo.modules.sms.SMSModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.sms",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-sms/package.json
+++ b/packages/expo-sms/package.json
@@ -22,6 +22,7 @@
   "main": "build/SMS.js",
   "types": "build/SMS.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -31,7 +32,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-speech/expo-module.config.json
+++ b/packages/expo-speech/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["SpeechModule"]
   },
   "android": {
-    "modules": ["expo.modules.speech.SpeechModule"]
+    "modules": ["expo.modules.speech.SpeechModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.speech",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-speech/package.json
+++ b/packages/expo-speech/package.json
@@ -24,6 +24,7 @@
   "main": "build/Speech.js",
   "types": "build/Speech.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -31,7 +32,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-splash-screen/expo-module.config.json
+++ b/packages/expo-splash-screen/expo-module.config.json
@@ -5,6 +5,11 @@
     "appDelegateSubscribers": ["SplashScreenAppDelegateSubscriber"]
   },
   "android": {
-    "modules": ["expo.modules.splashscreen.SplashScreenModule"]
+    "modules": ["expo.modules.splashscreen.SplashScreenModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.splashscreen",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-splash-screen/package.json
+++ b/packages/expo-splash-screen/package.json
@@ -34,6 +34,7 @@
     "./app.plugin.js": "./app.plugin.js"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -45,7 +46,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "@expo/config-plugins": "workspace:~",

--- a/packages/expo-sqlite/expo-module.config.json
+++ b/packages/expo-sqlite/expo-module.config.json
@@ -5,7 +5,12 @@
   },
   "android": {
     "modules": ["expo.modules.sqlite.SQLiteModule"],
-    "shouldUsePublicationScriptPath": "android/shouldUsePublication.groovy"
+    "shouldUsePublicationScriptPath": "android/shouldUsePublication.groovy",
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.sqlite",
+      "repository": "local-maven-repo"
+    }
   },
   "devtools": {
     "webpageRoot": "dev-plugin-dist"

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -47,6 +47,7 @@
     "./plugin": "./plugin/build/index.js"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -55,6 +56,7 @@
     "lint": "oxlint --config oxlint.config.mjs .",
     "format": "expo-module format",
     "test": "jest",
+    "prepack": "expo-module prepack",
     "prepublishOnly": "expo-module prepublishOnly && pnpm run build:webui",
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -b tsconfig.all.json"

--- a/packages/expo-status-bar/expo-module.config.json
+++ b/packages/expo-status-bar/expo-module.config.json
@@ -1,3 +1,10 @@
 {
-  "platforms": ["android"]
+  "platforms": ["android"],
+  "android": {
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.statusbar",
+      "repository": "local-maven-repo"
+    }
+  }
 }

--- a/packages/expo-status-bar/package.json
+++ b/packages/expo-status-bar/package.json
@@ -34,6 +34,7 @@
     "./app.plugin.js": "./app.plugin.js"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -43,7 +44,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/packages/expo-store-review/expo-module.config.json
+++ b/packages/expo-store-review/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["StoreReviewModule"]
   },
   "android": {
-    "modules": ["expo.modules.storereview.StoreReviewModule"]
+    "modules": ["expo.modules.storereview.StoreReviewModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.storereview",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-store-review/package.json
+++ b/packages/expo-store-review/package.json
@@ -24,6 +24,7 @@
   "main": "build/StoreReview.js",
   "types": "build/StoreReview.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
@@ -32,7 +33,8 @@
     "swift:lint": "../../scripts/swift-format.sh --lint",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-system-ui/expo-module.config.json
+++ b/packages/expo-system-ui/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["ExpoSystemUIModule"]
   },
   "android": {
-    "modules": ["expo.modules.systemui.SystemUIModule"]
+    "modules": ["expo.modules.systemui.SystemUIModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.systemui",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -23,6 +23,7 @@
   "main": "build/SystemUI.js",
   "types": "build/SystemUI.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -34,7 +35,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "@react-native/normalize-colors": "0.87.1",

--- a/packages/expo-task-manager/expo-module.config.json
+++ b/packages/expo-task-manager/expo-module.config.json
@@ -5,6 +5,11 @@
     "appDelegateSubscribers": ["TaskManagerAppDelegateSubscriber"]
   },
   "android": {
-    "modules": ["expo.modules.taskManager.TaskManagerModule"]
+    "modules": ["expo.modules.taskManager.TaskManagerModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.taskmanager",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-task-manager/package.json
+++ b/packages/expo-task-manager/package.json
@@ -24,6 +24,7 @@
   "main": "build/TaskManager.js",
   "types": "build/TaskManager.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -32,7 +33,8 @@
     "format": "expo-module format",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {
     "unimodules-app-loader": "workspace:~"

--- a/packages/expo-tracking-transparency/expo-module.config.json
+++ b/packages/expo-tracking-transparency/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["TrackingTransparencyModule"]
   },
   "android": {
-    "modules": ["expo.modules.trackingtransparency.TrackingTransparencyModule"]
+    "modules": ["expo.modules.trackingtransparency.TrackingTransparencyModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.trackingtransparency",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-tracking-transparency/package.json
+++ b/packages/expo-tracking-transparency/package.json
@@ -21,6 +21,7 @@
   "main": "build/TrackingTransparency.js",
   "types": "build/TrackingTransparency.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -32,7 +33,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/packages/expo-ui/expo-module.config.json
+++ b/packages/expo-ui/expo-module.config.json
@@ -6,6 +6,11 @@
     "modules": ["ExpoUIModule"]
   },
   "android": {
-    "modules": ["expo.modules.ui.ExpoUIModule"]
+    "modules": ["expo.modules.ui.ExpoUIModule"],
+    "publication": {
+      "groupId": "expo.modules.ui",
+      "artifactId": "expo.modules.ui",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-ui/package.json
+++ b/packages/expo-ui/package.json
@@ -138,6 +138,7 @@
   },
   "scripts": {
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",

--- a/packages/expo-video-thumbnails/expo-module.config.json
+++ b/packages/expo-video-thumbnails/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["VideoThumbnailsModule"]
   },
   "android": {
-    "modules": ["expo.modules.videothumbnails.VideoThumbnailsModule"]
+    "modules": ["expo.modules.videothumbnails.VideoThumbnailsModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.videothumbnails",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-video-thumbnails/package.json
+++ b/packages/expo-video-thumbnails/package.json
@@ -24,13 +24,15 @@
   "main": "build/VideoThumbnails.js",
   "types": "build/VideoThumbnails.d.ts",
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "expo-build src",
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
     "format": "expo-module format",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "prepack": "expo-module prepack"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/expo-video/expo-module.config.json
+++ b/packages/expo-video/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["VideoModule"]
   },
   "android": {
-    "modules": ["expo.modules.video.VideoModule"]
+    "modules": ["expo.modules.video.VideoModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.video",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-video/package.json
+++ b/packages/expo-video/package.json
@@ -21,6 +21,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "precompile-ios": "et prebuild-package-for-publish",
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",

--- a/packages/expo-web-browser/expo-module.config.json
+++ b/packages/expo-web-browser/expo-module.config.json
@@ -4,6 +4,11 @@
     "modules": ["WebBrowserModule"]
   },
   "android": {
-    "modules": ["expo.modules.webbrowser.WebBrowserModule"]
+    "modules": ["expo.modules.webbrowser.WebBrowserModule"],
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "expo.modules.webbrowser",
+      "repository": "local-maven-repo"
+    }
   }
 }

--- a/packages/expo-web-browser/package.json
+++ b/packages/expo-web-browser/package.json
@@ -35,6 +35,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
     "build": "pnpm run build:lib && pnpm run build:plugin",
     "build:lib": "expo-build src",
     "build:plugin": "expo-build --base plugin cjs:src",
@@ -44,7 +45,8 @@
     "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
-    "typecheck": "tsc -b tsconfig.all.json"
+    "typecheck": "tsc -b tsconfig.all.json",
+    "prepack": "expo-module prepack"
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",

--- a/packages/unimodules-app-loader/expo-module.config.json
+++ b/packages/unimodules-app-loader/expo-module.config.json
@@ -1,3 +1,10 @@
 {
-  "platforms": ["apple", "android"]
+  "platforms": ["apple", "android"],
+  "android": {
+    "publication": {
+      "groupId": "host.exp.exponent",
+      "artifactId": "org.unimodules.apploader",
+      "repository": "local-maven-repo"
+    }
+  }
 }

--- a/packages/unimodules-app-loader/package.json
+++ b/packages/unimodules-app-loader/package.json
@@ -20,5 +20,9 @@
   "homepage": "https://github.com/expo/expo/tree/main/packages/unimodules-app-loader",
   "devDependencies": {
     "expo-module-scripts": "workspace:*"
+  },
+  "scripts": {
+    "precompile-android": "et prebuild-android-package-for-publish",
+    "prepack": "expo-module prepack"
   }
 }

--- a/tools/android-precompile/build.gradle
+++ b/tools/android-precompile/build.gradle
@@ -1,0 +1,37 @@
+buildscript {
+  repositories {
+    google()
+    mavenCentral()
+  }
+  dependencies {
+    classpath("com.android.tools.build:gradle")
+    classpath("com.facebook.react:react-native-gradle-plugin")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+  }
+}
+
+allprojects {
+  repositories {
+    google()
+    mavenCentral()
+    maven { url "https://jitpack.io" }
+  }
+  configurations.configureEach {
+    resolutionStrategy.force("com.facebook.react:react-android:${providers.gradleProperty('expo.precompileAndroid.reactNativeVersion').get()}")
+  }
+}
+
+subprojects { project ->
+  project.pluginManager.withPlugin("com.android.library") {
+    project.afterEvaluate {
+      project.android {
+        compileOptions {
+          sourceCompatibility JavaVersion.VERSION_17
+          targetCompatibility JavaVersion.VERSION_17
+        }
+      }
+    }
+  }
+}
+
+apply plugin: "expo-root-project"

--- a/tools/android-precompile/gradle.properties
+++ b/tools/android-precompile/gradle.properties
@@ -1,0 +1,7 @@
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+android.useAndroidX=true
+android.builtInKotlin=false
+android.newDsl=false
+newArchEnabled=true
+hermesEnabled=true

--- a/tools/android-precompile/package.json
+++ b/tools/android-precompile/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/tools/android-precompile/settings.gradle
+++ b/tools/android-precompile/settings.gradle
@@ -1,0 +1,20 @@
+pluginManagement {
+  repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+  }
+  includeBuild(providers.gradleProperty("expo.precompileAndroid.reactNativePlugin").get())
+  includeBuild(providers.gradleProperty("expo.precompileAndroid.expoPlugin").get())
+}
+
+plugins {
+  id("expo-autolinking-settings")
+}
+
+expoAutolinking.searchPaths = [providers.gradleProperty("expo.precompileAndroid.modulesDirectory").get()]
+expoAutolinking.useExpoModules()
+expoAutolinking.useExpoVersionCatalog()
+includeBuild(providers.gradleProperty("expo.precompileAndroid.reactNativePlugin").get())
+
+rootProject.name = "expo-android-precompile"

--- a/tools/src/commands/PrebuildAndroidPackageForPublish.ts
+++ b/tools/src/commands/PrebuildAndroidPackageForPublish.ts
@@ -1,0 +1,171 @@
+import { Command } from '@expo/commander';
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+
+import { EXPO_DIR, EXPOTOOLS_DIR } from '../Constants';
+import { getListOfPackagesAsync, Package } from '../Packages';
+import {
+  createAndroidPublicationManifest,
+  removeNondeterministicMavenMetadataAsync,
+  validateAndroidPublicationRepositoryAsync,
+} from '../prebuilds/AndroidPrebuilds';
+
+const COPY_FILTER = (source: string): boolean => {
+  const basename = path.basename(source);
+  return ![
+    '.expo-prebuild',
+    '.expo-prebuild-android',
+    '.git',
+    '.gradle',
+    'build',
+    'local-maven-repo',
+    'node_modules',
+    'prebuilds',
+  ].includes(basename);
+};
+
+function androidProjects(pkg: Package) {
+  const config = pkg.expoModuleConfig;
+  if (!config?.platforms.includes('android')) {
+    throw new Error(`${pkg.packageName} is not an Android Expo module`);
+  }
+  const projects = [
+    {
+      projectName: config.android?.name ?? pkg.packageName.replace(/^@/, '').replace(/\W+/g, '-'),
+      publication: config.android?.publication,
+    },
+  ];
+  for (const project of config.android?.projects ?? []) {
+    if (project.name)
+      projects.push({ projectName: project.name, publication: project.publication });
+  }
+  return projects;
+}
+
+async function resolveNativeClosureAsync(target: Package): Promise<Package[]> {
+  const workspacePackages = await getListOfPackagesAsync();
+  const byName = new Map(workspacePackages.map((pkg) => [pkg.packageName, pkg]));
+  const result = new Map<string, Package>();
+  const pending = [target.packageName, 'expo-modules-core'];
+
+  while (pending.length > 0) {
+    const name = pending.pop()!;
+    if (result.has(name)) continue;
+    const pkg = byName.get(name);
+    if (!pkg?.expoModuleConfig?.platforms.includes('android')) continue;
+    result.set(name, pkg);
+    for (const dependency of Object.keys(pkg.packageJson.dependencies ?? {})) {
+      if (byName.has(dependency)) pending.push(dependency);
+    }
+  }
+  return [...result.values()].sort((a, b) => a.packageName.localeCompare(b.packageName));
+}
+
+async function resolveReactNativeAsync(projectRoot: string): Promise<{
+  pluginDirectory: string;
+  version: string;
+}> {
+  const packageJsonPath = require.resolve('react-native/package.json', { paths: [projectRoot] });
+  const packageJson = await fs.readJson(packageJsonPath);
+  const pluginPackageJsonPath = require.resolve('@react-native/gradle-plugin/package.json', {
+    paths: [packageJsonPath],
+  });
+  return {
+    pluginDirectory: path.dirname(pluginPackageJsonPath),
+    version: packageJson.version,
+  };
+}
+
+export async function prebuildAndroidPackageForPublishAsync(packageRoot = process.cwd()) {
+  const pkg = new Package(packageRoot);
+  if (!pkg.scripts['precompile-android']) {
+    throw new Error(`${pkg.packageName} does not declare a precompile-android script`);
+  }
+
+  const projects = androidProjects(pkg);
+  const manifest = createAndroidPublicationManifest(pkg.packageName, pkg.packageVersion, projects);
+  const closure = await resolveNativeClosureAsync(pkg);
+  const bareExpoRoot = path.join(EXPO_DIR, 'apps/bare-expo');
+  const reactNative = await resolveReactNativeAsync(bareExpoRoot);
+  const workRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), `expo-precompile-android-${pkg.packageName.replace(/\W/g, '-')}-`)
+  );
+  const hostRoot = path.join(workRoot, 'host');
+  const modulesRoot = path.join(workRoot, 'modules');
+  const pluginsRoot = path.join(workRoot, 'plugins');
+  const repositoryRoot = path.join(workRoot, 'repository');
+  const outputRoot = path.join(pkg.path, '.expo-prebuild-android');
+
+  try {
+    await Promise.all([
+      fs.copy(path.join(EXPOTOOLS_DIR, 'android-precompile'), hostRoot, { filter: COPY_FILTER }),
+      fs.copy(
+        path.join(EXPO_DIR, 'packages/expo-modules-autolinking/android/expo-gradle-plugin'),
+        path.join(pluginsRoot, 'expo-gradle-plugin'),
+        { filter: COPY_FILTER }
+      ),
+      fs.copy(reactNative.pluginDirectory, path.join(pluginsRoot, 'react-native-gradle-plugin'), {
+        filter: COPY_FILTER,
+      }),
+      ...closure.map(async (dependency) => {
+        const destination = path.join(
+          modulesRoot,
+          dependency.packageName.replace(/^@/, '').replace('/', '-')
+        );
+        await fs.copy(dependency.path, destination, { filter: COPY_FILTER });
+        const dependencyNodeModules = path.join(dependency.path, 'node_modules');
+        if (await fs.pathExists(dependencyNodeModules)) {
+          await fs.symlink(dependencyNodeModules, path.join(destination, 'node_modules'));
+        }
+      }),
+    ]);
+    await fs.symlink(path.join(bareExpoRoot, 'node_modules'), path.join(hostRoot, 'node_modules'));
+
+    const properties = [
+      `-Pexpo.precompileAndroid.reactNativePlugin=${path.join(pluginsRoot, 'react-native-gradle-plugin')}`,
+      `-Pexpo.precompileAndroid.expoPlugin=${path.join(pluginsRoot, 'expo-gradle-plugin')}`,
+      `-Pexpo.precompileAndroid.modulesDirectory=${modulesRoot}`,
+      `-Pexpo.precompileAndroid.reactNativeVersion=${reactNative.version}`,
+      `-Pexpo.precompileAndroid.repository=${repositoryRoot}`,
+    ];
+    const tasks = projects.map(
+      ({ projectName }) => `:${projectName}:publishReleasePublicationToNPMPackageRepository`
+    );
+    await spawnAsync(
+      path.join(EXPO_DIR, 'apps/bare-expo/android/gradlew'),
+      [
+        '-p',
+        hostRoot,
+        ...tasks,
+        '--no-daemon',
+        '--no-build-cache',
+        '--no-configuration-cache',
+        '--no-watch-fs',
+        '--project-cache-dir',
+        path.join(workRoot, 'project-cache'),
+        ...properties,
+      ],
+      { cwd: EXPO_DIR, stdio: 'inherit' }
+    );
+
+    await validateAndroidPublicationRepositoryAsync(repositoryRoot, manifest);
+    await removeNondeterministicMavenMetadataAsync(repositoryRoot);
+    await fs.remove(outputRoot);
+    await fs.ensureDir(outputRoot);
+    await Promise.all([
+      fs.copy(repositoryRoot, path.join(outputRoot, 'local-maven-repo')),
+      fs.writeJson(path.join(outputRoot, 'publication.json'), manifest, { spaces: 2 }),
+    ]);
+  } finally {
+    await fs.remove(workRoot);
+  }
+}
+
+export default (program: Command) => {
+  program
+    .command('prebuild-android-package-for-publish')
+    .description('Builds exactly the current package Android publication into its Turbo output.')
+    .asyncAction(() => prebuildAndroidPackageForPublishAsync());
+};

--- a/tools/src/prebuilds/AndroidPrebuilds.test.ts
+++ b/tools/src/prebuilds/AndroidPrebuilds.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  createAndroidPublicationManifest,
+  removeNondeterministicMavenMetadataAsync,
+  validateAndroidPublicationRepositoryAsync,
+} from './AndroidPrebuilds';
+
+describe('AndroidPrebuilds', () => {
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'android-prebuilds-test-'));
+  });
+
+  afterEach(() => fs.rmSync(temporaryDirectory, { recursive: true, force: true }));
+
+  it('creates a deterministic manifest and validates Maven artifacts', async () => {
+    const publication = {
+      projectName: 'expo-keep-awake',
+      groupId: 'host.exp.exponent',
+      artifactId: 'expo.modules.keepawake',
+      version: '58.0.0',
+      repository: 'local-maven-repo',
+    };
+    const manifest = createAndroidPublicationManifest('expo-keep-awake', '58.0.0', [
+      { projectName: publication.projectName, publication },
+    ]);
+    assert.deepEqual(manifest.publications, [publication]);
+
+    const coordinate = path.join(
+      temporaryDirectory,
+      'repository/host/exp/exponent/expo.modules.keepawake/58.0.0'
+    );
+    fs.mkdirSync(coordinate, { recursive: true });
+    for (const extension of ['aar', 'pom', 'module']) {
+      fs.writeFileSync(path.join(coordinate, `expo.modules.keepawake-58.0.0.${extension}`), '');
+    }
+    await validateAndroidPublicationRepositoryAsync(
+      path.join(temporaryDirectory, 'repository'),
+      manifest
+    );
+  });
+
+  it('rejects version mismatches, duplicate coordinates, and missing artifacts', async () => {
+    const publication = {
+      projectName: 'one',
+      groupId: 'expo.modules',
+      artifactId: 'one',
+      version: '1.0.0',
+      repository: 'local-maven-repo',
+    };
+    assert.throws(
+      () =>
+        createAndroidPublicationManifest('example', '2.0.0', [
+          { projectName: publication.projectName, publication },
+        ]),
+      /expected 2\.0\.0/
+    );
+
+    assert.throws(
+      () =>
+        createAndroidPublicationManifest('example', '1.0.0', [
+          { projectName: 'one', publication },
+          { projectName: 'two', publication },
+        ]),
+      /Duplicate Android publication coordinate/
+    );
+    const manifest = createAndroidPublicationManifest('example', '1.0.0', [
+      { projectName: publication.projectName, publication },
+    ]);
+    await assert.rejects(
+      validateAndroidPublicationRepositoryAsync(
+        path.join(temporaryDirectory, 'repository'),
+        manifest
+      ),
+      /Missing Android publication artifact/
+    );
+  });
+
+  it('removes timestamped Maven repository metadata and its checksums', async () => {
+    const repository = path.join(temporaryDirectory, 'repository');
+    const artifactDirectory = path.join(repository, 'expo/modules/example/1.0.0');
+    fs.mkdirSync(artifactDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(repository, 'expo/modules/example/maven-metadata.xml'),
+      'timestamped'
+    );
+    fs.writeFileSync(
+      path.join(repository, 'expo/modules/example/maven-metadata.xml.sha256'),
+      'digest'
+    );
+    fs.writeFileSync(path.join(artifactDirectory, 'example-1.0.0.module'), 'artifact');
+
+    await removeNondeterministicMavenMetadataAsync(repository);
+
+    assert.equal(
+      fs.existsSync(path.join(repository, 'expo/modules/example/maven-metadata.xml')),
+      false
+    );
+    assert.equal(
+      fs.existsSync(path.join(repository, 'expo/modules/example/maven-metadata.xml.sha256')),
+      false
+    );
+    assert.equal(fs.existsSync(path.join(artifactDirectory, 'example-1.0.0.module')), true);
+  });
+});

--- a/tools/src/prebuilds/AndroidPrebuilds.ts
+++ b/tools/src/prebuilds/AndroidPrebuilds.ts
@@ -1,0 +1,119 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+export type AndroidPublication = {
+  projectName: string;
+  groupId: string;
+  artifactId: string;
+  version: string;
+  repository: 'local-maven-repo';
+};
+
+export type AndroidPublicationManifest = {
+  schemaVersion: 1;
+  packageName: string;
+  packageVersion: string;
+  publications: AndroidPublication[];
+};
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Invalid Android publication metadata: ${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+export function createAndroidPublicationManifest(
+  packageName: string,
+  packageVersion: string,
+  projects: { projectName: string; publication: unknown }[]
+): AndroidPublicationManifest {
+  if (projects.length === 0) {
+    throw new Error(`No Android publications are configured for ${packageName}`);
+  }
+
+  const publications = projects
+    .map(({ projectName, publication: value }, index): AndroidPublication => {
+      const field = `android publication ${index}`;
+      if (!value || typeof value !== 'object') {
+        throw new Error(`Invalid Android publication metadata: ${field} must be an object`);
+      }
+      const config = value as Record<string, unknown>;
+      const publication: AndroidPublication = {
+        projectName,
+        groupId: requireString(config.groupId, `${field}.groupId`),
+        artifactId: requireString(config.artifactId, `${field}.artifactId`),
+        version: requireString(config.version ?? packageVersion, `${field}.version`),
+        repository: config.repository as AndroidPublication['repository'],
+      };
+      if (publication.repository !== 'local-maven-repo') {
+        throw new Error(
+          `Invalid Android publication metadata: ${field}.repository is not package-local`
+        );
+      }
+      if (publication.version !== packageVersion) {
+        throw new Error(
+          `Android publication ${publication.projectName} has version ${publication.version}, expected ${packageVersion}`
+        );
+      }
+      return publication;
+    })
+    .sort((a, b) => a.projectName.localeCompare(b.projectName));
+
+  const coordinates = new Set<string>();
+  for (const publication of publications) {
+    const coordinate = `${publication.groupId}:${publication.artifactId}:${publication.version}`;
+    if (coordinates.has(coordinate)) {
+      throw new Error(`Duplicate Android publication coordinate: ${coordinate}`);
+    }
+    coordinates.add(coordinate);
+  }
+
+  return { schemaVersion: 1, packageName, packageVersion, publications };
+}
+
+export async function validateAndroidPublicationRepositoryAsync(
+  repositoryDirectory: string,
+  manifest: AndroidPublicationManifest
+): Promise<void> {
+  const repositoryRoot = path.resolve(repositoryDirectory);
+  for (const publication of manifest.publications) {
+    const coordinateDirectory = path.resolve(
+      repositoryRoot,
+      ...publication.groupId.split('.'),
+      publication.artifactId,
+      publication.version
+    );
+    if (
+      coordinateDirectory !== repositoryRoot &&
+      !coordinateDirectory.startsWith(repositoryRoot + path.sep)
+    ) {
+      throw new Error(`Unsafe Android publication coordinate for ${publication.projectName}`);
+    }
+    const basename = `${publication.artifactId}-${publication.version}`;
+    for (const extension of ['aar', 'pom', 'module']) {
+      const artifact = path.join(coordinateDirectory, `${basename}.${extension}`);
+      if (!(await fs.pathExists(artifact))) {
+        throw new Error(
+          `Missing Android publication artifact: ${path.relative(repositoryRoot, artifact)}`
+        );
+      }
+    }
+  }
+}
+
+export async function removeNondeterministicMavenMetadataAsync(
+  repositoryDirectory: string
+): Promise<void> {
+  const entries = await fs.readdir(repositoryDirectory, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(repositoryDirectory, entry.name);
+      if (entry.isDirectory()) {
+        await removeNondeterministicMavenMetadataAsync(entryPath);
+      } else if (/^maven-metadata\.xml(?:\..+)?$/.test(entry.name)) {
+        await fs.remove(entryPath);
+      }
+    })
+  );
+}

--- a/tools/src/publish-packages/tasks/publishAndroidPackages.ts
+++ b/tools/src/publish-packages/tasks/publishAndroidPackages.ts
@@ -1,216 +1,40 @@
-import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
-import fs from 'fs-extra';
-import { glob } from 'glob';
-import inquirer from 'inquirer';
-import path from 'path';
-
-import { ensureBareExpoDependencies } from './ensureBareExpoDependencies';
-import { updateAndroidProjects } from './updateAndroidProjects';
-import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
-import { ExpoModuleConfig, Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
+import { runTurboTasksAsync } from '../../Turbo';
 import type { CommandOptions, Parcel, TaskArgs } from '../types';
-
-const EXCLUDE = ['expo-module-template'];
+import { updateAndroidProjects } from './updateAndroidProjects';
 
 /**
- * Finds and removes stale build directories (*.cxx and android/build) that can cause build issues.
- * Prompts the user for confirmation before deletion.
- *
- * This cleanup may slow down the publish process, but skipping it often leads to compile errors
- * during Android artifact publishing that make the whole process more tedious to recover from.
+ * Restores or builds package-owned Android Maven repositories through Turbo. Each package's
+ * prepack lifecycle stages the repository immediately before npm packs it; publication
+ * coordinates remain committed in expo-module.config.json.
  */
-async function cleanupStaleBuildDirectories(): Promise<void> {
-  const packagesDir = path.join(EXPO_DIR, 'packages');
-
-  // Find all *.cxx directories and android/build directories
-  // Use trailing slash to match only directories
-  const cxxDirs = await glob('**/*.cxx/', {
-    cwd: packagesDir,
-    absolute: true,
-  });
-
-  const androidBuildDirs = await glob('**/android/build/', {
-    cwd: packagesDir,
-    absolute: true,
-  });
-
-  // Remove trailing slashes from paths
-  const dirsToRemove = [...cxxDirs, ...androidBuildDirs].map((dir) => dir.replace(/\/$/, ''));
-
-  if (dirsToRemove.length === 0) {
-    return;
-  }
-
-  const promptForCleanup = async (): Promise<boolean> => {
-    const { action } = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'action',
-        prefix: '🧹',
-        message: chalk.cyan(
-          `Found ${dirsToRemove.length} stale build director${dirsToRemove.length === 1 ? 'y' : 'ies'} (*.cxx, android/build). Remove?`
-        ),
-        choices: [
-          { name: 'Yes', value: 'yes' },
-          { name: 'No', value: 'no' },
-          { name: 'List all', value: 'list' },
-        ],
-        default: 'yes',
-      },
-    ]);
-
-    if (action === 'list') {
-      logger.log();
-      for (const dir of dirsToRemove) {
-        logger.log('  ', chalk.gray(path.relative(EXPO_DIR, dir)));
-      }
-      logger.log();
-      return promptForCleanup();
-    }
-
-    return action === 'yes';
-  };
-
-  if (await promptForCleanup()) {
-    logger.log('  ', 'Removing stale build directories...');
-    await Promise.all(dirsToRemove.map((dir) => fs.remove(dir)));
-    logger.success('  ', 'Removed stale build directories.');
-  } else {
-    logger.log('  ', 'Skipping cleanup of stale build directories.');
-  }
-}
-
 export const publishAndroidArtifacts = new Task<TaskArgs>(
   {
     name: 'publishAndroidArtifacts',
-    dependsOn: [updateAndroidProjects, ensureBareExpoDependencies],
+    dependsOn: [updateAndroidProjects],
   },
   async (parcels: Parcel[], options: CommandOptions) => {
-    // If only templates are being published, skip Android artifacts step entirely
     if (options.templatesOnly) {
-      logger.log('\n🤖 Skipping publishing Android artifacts (templates-only).');
+      logger.log('\n🤖 Skipping Android precompiles (templates-only).');
       return;
     }
     if (options.skipAndroidArtifacts) {
-      logger.log('\n🤖 Skipping publishing Android artifacts.');
+      logger.log('\n🤖 Skipping Android precompiles.');
       return;
     }
 
-    // Clean up stale build directories before building
-    await cleanupStaleBuildDirectories();
-
-    const packages = parcels.map((parcels) => parcels.pkg);
-
-    // Collect all packages that have Android artifacts to publish.
-    const androidPackages = packages.filter((pkg) => {
-      const moduleConfig = pkg.expoModuleConfig;
-      if (!moduleConfig) {
-        return false;
-      }
-      if (!moduleConfig.platforms.includes('android')) {
-        return false;
-      }
-      if (EXCLUDE.includes(pkg.packageName)) {
-        return false;
-      }
-      return true;
-    });
-
-    if (androidPackages.length === 0) {
-      logger.log('\n🤖 No Android artifacts to publish.');
+    const packageNames = parcels
+      .filter(({ pkg, state }) => state.releaseVersion && pkg.scripts['precompile-android'])
+      .map(({ pkg }) => pkg.packageName);
+    if (packageNames.length === 0) {
+      logger.log('\n🤖 No Android precompile packages in publish set, skipping.');
       return;
     }
 
-    logger.info('\n🤖 Publishing Android artifacts...');
-
-    logger.log('  ', 'Removing existing publications...');
-    // Remove existing publications from expo-module.config.json
-    await Promise.all(androidPackages.map((pkg) => removeExistingPublications(pkg)));
-
-    const batch = logger.batch();
-    batch.log('  ', 'Collecting publication Gradle tasks...');
-    // Collect all Gradle tasks to publish Android artifacts.
-    const gradleTasks = androidPackages.flatMap((pkg) => {
-      const publicationCommands = getPublicationCommands(pkg.packageName, pkg.expoModuleConfig!);
-
-      if (publicationCommands.length === 1) {
-        const publicationCommand = publicationCommands[0];
-        batch.log('  ', '  ', `${chalk.green(pkg.packageName)}: ${publicationCommand}`);
-      } else {
-        batch.log('  ', '  ', `${chalk.green(pkg.packageName)}:`);
-        for (const command of publicationCommands) {
-          batch.log('  ', '  ', '  ', `${command}`);
-        }
-      }
-
-      return publicationCommands;
-    });
-    batch.flush();
-
-    logger.log('  ', 'Publishing Android artifacts...');
-    // Run Gradle tasks in one batch to speed up the process.
-    await spawnAsync(
-      './gradlew',
-      [...gradleTasks, '--no-build-cache', '--no-configuration-cache'],
-      {
-        cwd: path.join(EXPO_DIR, 'apps/bare-expo/android'),
-        stdio: 'inherit',
-      }
+    logger.log(
+      `\n🤖 Restoring Android precompiles for ${packageNames.length} package(s) with Turbo...`
     );
-    logger.success('  ', 'Done!');
+    await runTurboTasksAsync(['precompile-android'], { filters: packageNames });
   }
 );
-
-function getPublicationCommands(packageName: string, moduleConfig: ExpoModuleConfig): string[] {
-  const androidProjectsName = new Set<string>();
-  androidProjectsName.add(moduleConfig.android?.name ?? convertPackageToProjectName(packageName));
-
-  for (const subproject of moduleConfig.android?.projects ?? []) {
-    const subprojectName = subproject.name;
-    if (subprojectName) {
-      androidProjectsName.add(subprojectName);
-    }
-  }
-
-  return [...androidProjectsName].map((projectName) => `:${projectName}:expoPublish`);
-}
-
-async function removeExistingPublications(pkg: Package) {
-  let needToUpdate = false;
-
-  if (pkg.expoModuleConfig?.android?.publication) {
-    needToUpdate = true;
-    delete pkg.expoModuleConfig?.android?.publication;
-  }
-
-  pkg.expoModuleConfig?.android?.projects?.forEach((project) => {
-    if (project.publication) {
-      needToUpdate = true;
-      delete project.publication;
-    }
-  });
-
-  if (!needToUpdate) {
-    return;
-  }
-
-  const stringifyConfig = JSON.stringify(pkg.expoModuleConfig, null, 2);
-
-  await fs.writeFile(pkg.expoModulesConfigPath, stringifyConfig, 'utf-8');
-  return spawnAsync('pnpm', ['prettier', '--write', pkg.expoModulesConfigPath], {
-    cwd: pkg.path,
-  });
-}
-
-/**
- * Converts the package name to Android's project name.
- *   `/` path will transform as `-`
- *
- * Example: `@expo/example` + `android/build.gradle` → `expo-example`
- */
-function convertPackageToProjectName(packageName: string): string {
-  return packageName.replace(/^@/g, '').replace(/\W+/g, '-');
-}

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -1,4 +1,6 @@
 import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
 import semver from 'semver';
 
 import Git from '../../Git';
@@ -107,7 +109,7 @@ export const cleanWorkingTree = new Task<TaskArgs>(
     name: 'cleanWorkingTree',
     dependsOn: [],
   },
-  async () => {
+  async (parcels: Parcel[]) => {
     await runWithSpinner(
       'Cleaning up the working tree',
       async () => {
@@ -126,16 +128,19 @@ export const cleanWorkingTree = new Task<TaskArgs>(
           ],
         });
 
+        await Promise.all(
+          parcels.flatMap(({ pkg }) =>
+            ['prebuilds', 'local-maven-repo'].map((directory) =>
+              fs.remove(path.join(pkg.path, directory))
+            )
+          )
+        );
+
         // Remove tarballs created by `npm pack`.
         await Git.cleanAsync({
           recursive: true,
           force: true,
-          paths: [
-            'packages/**/*.tgz',
-            'packages/**/local-maven-repo/**',
-            'packages/**/prebuilds/**',
-            'templates/**/*.tgz',
-          ],
+          paths: ['packages/**/*.tgz', 'templates/**/*.tgz'],
         });
       },
       'Cleaned up the working tree'

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -1,5 +1,12 @@
 import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
 
+import Git from '../../Git';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { runWithSpinner } from '../../Utils';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { addPublishedLabelToPullRequests } from './addPublishedLabelToPullRequests';
 import { addTemplateTarball } from './addTemplateTarball';
 import { bundleIOSPrebuilds } from './bundleIOSPrebuilds';
@@ -25,11 +32,6 @@ import { updatePackageVersions } from './updatePackageVersions';
 import { updateProjectTemplates } from './updateProjectTemplates';
 import { updateVersionsEndpoint } from './updateVersionsEndpoint';
 import { updateWorkspaceProjects } from './updateWorkspaceProjects';
-import Git from '../../Git';
-import logger from '../../Logger';
-import { Task } from '../../TasksRunner';
-import { runWithSpinner } from '../../Utils';
-import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 const { cyan, yellow } = chalk;
 
@@ -41,7 +43,7 @@ const cleanWorkingTree = new Task<TaskArgs>(
     name: 'cleanWorkingTree',
     dependsOn: [],
   },
-  async () => {
+  async (parcels: Parcel[]) => {
     await runWithSpinner(
       'Cleaning up the working tree',
       async () => {
@@ -54,17 +56,19 @@ const cleanWorkingTree = new Task<TaskArgs>(
             'pnpm-lock.yaml',
           ],
         });
-        // Remove local repositories.
-        await Git.cleanAsync({
-          recursive: true,
-          force: true,
-          paths: ['packages/**/local-maven-repo/**'],
-        });
+        // Remove package-root staging directories while retaining their separate Turbo outputs.
+        await Promise.all(
+          parcels.flatMap(({ pkg }) =>
+            ['prebuilds', 'local-maven-repo'].map((directory) =>
+              fs.remove(path.join(pkg.path, directory))
+            )
+          )
+        );
         // Remove tarballs.
         await Git.cleanAsync({
           recursive: true,
           force: true,
-          paths: ['packages/**/*.tgz', 'packages/**/prebuilds/**', 'templates/**/*.tgz'],
+          paths: ['packages/**/*.tgz', 'templates/**/*.tgz'],
         });
       },
       'Cleaned up the working tree'

--- a/tools/src/publish-packages/tasks/updateAndroidProjects.ts
+++ b/tools/src/publish-packages/tasks/updateAndroidProjects.ts
@@ -2,12 +2,12 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { transformFileAsync } from '../../Transforms';
 import { Parcel, TaskArgs } from '../types';
+import { updatePackageVersions } from './updatePackageVersions';
 
 const { yellow, magenta } = chalk;
 
@@ -17,7 +17,7 @@ const { yellow, magenta } = chalk;
 export const updateAndroidProjects = new Task<TaskArgs>(
   {
     name: 'updateAndroidProjects',
-    dependsOn: [selectPackagesToPublish],
+    dependsOn: [updatePackageVersions],
     filesToStage: ['packages/**/android/build.gradle'],
   },
   async (parcels: Parcel[]) => {

--- a/turbo.json
+++ b/turbo.json
@@ -61,6 +61,41 @@
       "env": ["RCT_HERMES_V1_ENABLED"],
       "outputs": [".expo-prebuild/output/**"],
       "outputLogs": "new-only"
+    },
+    "precompile-android": {
+      "dependsOn": [
+        "expo-modules-core#precompile-android-inputs",
+        "expo-modules-autolinking#precompile-android-inputs",
+        "expo-modules-autolinking#build",
+        "^precompile-android-inputs"
+      ],
+      "inputs": [
+        "package.json",
+        "expo-module.config.json",
+        "common/**",
+        "android/**",
+        "!android/**/build/**",
+        "!android/**/.gradle/**",
+        "!android/**/.cxx/**",
+        "$TURBO_ROOT$/tools/android-precompile/**",
+        "$TURBO_ROOT$/tools/src/prebuilds/**"
+      ],
+      "passThroughEnv": ["JAVA_HOME", "GRADLE_USER_HOME", "ANDROID_HOME", "ANDROID_SDK_ROOT"],
+      "outputs": [".expo-prebuild-android/**"],
+      "outputLogs": "new-only"
+    },
+    "precompile-android-inputs": {
+      "inputs": [
+        "package.json",
+        "expo-module.config.json",
+        "android/**",
+        "!android/**/build/**",
+        "!android/**/.gradle/**",
+        "!android/**/.cxx/**",
+        "common/**",
+        "src/**"
+      ],
+      "outputLogs": "errors-only"
     }
   },
   "remoteCache": {

--- a/turbo.json
+++ b/turbo.json
@@ -77,6 +77,7 @@
         "!android/**/build/**",
         "!android/**/.gradle/**",
         "!android/**/.cxx/**",
+        "node_modules/react-native/package.json",
         "$TURBO_ROOT$/tools/android-precompile/**",
         "$TURBO_ROOT$/tools/src/prebuilds/**"
       ],


### PR DESCRIPTION
# Why

Related to #49744 but for Android.

For publishing, we'll want to restructure the publish-sensitive precompile Android tasks, like we have for iOS' precompiling of xcframeworks too. Currently, this is a monolithic Gradle task that reaches into BareExpo and across packages, instead of being isolated to individual packages at a time. Switching this to Turborepo with a `precompile-android` task (parallel to the `precompile-ios` task) makes sure that the task runner is dependency-graph-aware, but also allows us to specify inputs and outputs for caching, and isolate changes to packages as they're published more precisely.

# How

There's two prerequisites we need:

We need to make changes to `expo-modules-autolinking` to mark `expo-module.config.json`'s `android.publication.version` as optional. This property duplicates `package.json:version` and was written by the monolithic Gradle build. However, as far as I'm aware, otherwise the `publication` section is static, and can hence be owned more strongly by the CLI resolve command and be filled in, as needed.

We also need a change in `expo-modules-core` to alter where the publication output should be written to, so we can separate the `.expo-prebuild-android` intermediate and output from `local-maven-repo`, and separate the source inputs themselves to temporarily alter autolinking (There might be a better way to do this though, granted, but this minimises changes)

Many of the changes otherwise spiritually attempt to mirror the `precompile-ios` changes.

We add an `et prebuild-android-package-for-publish` command that builds the embedded Maven artifacts for one package in isolation. In the publishing flow this is modeled as:

- Turbo captures a `precompile-android` task for each eligible package
- Each `precompile-android` script runs `prebuild-android-package-for-publish`
- The command creates an invocation-local Gradle host and copies the necessary files into the intermediate folder
- Gradle writes the AAR, POM, Gradle module metadata, and checksums into a temporary Maven repository
- The `prepublishOnly` task separately verifies that the expected artifacts were produced for the package's current version
- The `prepack` task copies the Maven repository from `.expo-prebuild-android` to `local-maven-repo`, where it is included in the npm package

Android `publication` metadata are now committed in `expo-module.config.json` but without the `version`, so it remains stable.

The publication build uses a minimal Gradle host based on BareExpo's build conventions, but does not configure or mutate BareExpo itself. Each invocation receives its own copies of the host, Gradle plugins, package sources, native dependency closure, project cache, and Maven output. This allows package tasks to run concurrently without sharing writable Gradle project outputs.

The existing Android step in `publish-packages` now invokes the package-owned tasks through Turbo instead. Turbo captures the inputs and caches the `.expo-prebuild-android` outputs.

During publishing, `prebuilds` (iOS) and `local-maven-repo` (Android) are temporary package-root staging directories. They are removed after publishing, while `.expo-prebuild` and `.expo-prebuild-android` remain available as Turbo outputs.

# Test Plan

- [ ] Run a few `pnpm turbo run precompile-android` tests locally
- [ ] Run `publish-packages.yml` workflow in dry-run
- [ ] Re-run `publish-packages.yml` workflow in dry-run, validating caching

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
