### PR TITLE
[ios][modules-core] Add JavaScriptCodable conformance for Either

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 💡 Others
 
 - [iOS] Bumped `@expo/expo-modules-macros-plugin` to `0.10.0`. ([#50037](https://github.com/expo/expo/pull/50037) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Made `Either`, `EitherOfThree` and `EitherOfFour` conform to `JavaScriptDecodable` and `JavaScriptEncodable`, so they can be used with the new module API. ([#50053](https://github.com/expo/expo/pull/50053) by [@tsapeta](https://github.com/tsapeta))
 
 ## 58.0.0 — 2026-09-10
 

--- a/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Either.swift
+++ b/packages/expo-modules-core/ios/Core/Coding/JavaScriptCodable+Either.swift
@@ -1,0 +1,42 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+// `Either` is `JavaScriptCodable`. Its value is stored as `Any?`, so instead of recursing statically
+// into the generic parameters, the conversion walks the `AnyDynamicType` converters that
+// `dynamicTypes()` returns and takes the first one that accepts the value. Those converters need the
+// app context, recovered from the runtime like `Record` does.
+//
+// The conformance is declared on `Either` alone. `EitherOfThree` and `EitherOfFour` inherit it and
+// override `dynamicTypes()`, so an inherited conversion still sees their extra types.
+
+extension Either: JavaScriptDecodable, JavaScriptEncodable {
+  @JavaScriptActor
+  public static func decode(_ value: borrowing JavaScriptValue, in runtime: borrowing JavaScriptRuntime) throws -> Self {
+    guard let appContext = AppContext.from(runtime: runtime) else {
+      throw Exceptions.AppContextNotFound()
+    }
+    let types = Self.dynamicTypes()
+
+    for type in types {
+      if let converted = try? type.cast(jsValue: value, appContext: appContext) {
+        return Self(converted)
+      }
+    }
+    throw NeitherTypeException(types)
+  }
+
+  // The parameter is `Either<FirstType, SecondType>` rather than `Self` because a non-final class
+  // can't take a covariant `Self`. A subclass instance passes as its superclass.
+  @JavaScriptActor
+  public static func encode(
+    _ value: Either<FirstType, SecondType>,
+    in runtime: borrowing JavaScriptRuntime
+  ) throws -> JavaScriptValue {
+    guard let appContext = AppContext.from(runtime: runtime) else {
+      throw Exceptions.AppContextNotFound()
+    }
+    // `Either` adds no representation in JavaScript, so the wrapped value converts on its own.
+    return try Conversions.anyToJavaScriptValue(value.value, appContext: appContext, in: runtime)
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/JavaScriptCodableEitherTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptCodableEitherTests.swift
@@ -1,0 +1,138 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+@Suite("JavaScriptCodable+Either")
+@JavaScriptActor
+struct JavaScriptCodableEitherTests {
+  let appContext = AppContext.create()
+
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  // MARK: - Decoding
+
+  @Test
+  func `decodes the first type`() throws {
+    let runtime = try runtime
+    let decoded = try Either<String, Int>.decode(runtime.eval("'expo'"), in: runtime)
+
+    #expect(decoded.is(String.self) == true)
+    #expect(try decoded.as(String.self) == "expo")
+  }
+
+  @Test
+  func `decodes the second type`() throws {
+    let runtime = try runtime
+    let decoded = try Either<String, Int>.decode(runtime.eval("123"), in: runtime)
+
+    #expect(decoded.is(Int.self) == true)
+    #expect(try decoded.as(Int.self) == 123)
+  }
+
+  @Test
+  func `decodes an array type`() throws {
+    let runtime = try runtime
+    let decoded = try Either<String, [Int]>.decode(runtime.eval("[1, 2, 3]"), in: runtime)
+    let value: [Int]? = decoded.get()
+
+    #expect(value == [1, 2, 3])
+  }
+
+  // Convertibles have no `JavaScriptCodable` conformance of their own, so this covers the types that
+  // only the dynamic converters can handle.
+  @Test
+  func `decodes a convertible`() throws {
+    let runtime = try runtime
+    let decoded = try Either<Int, UIColor>.decode(runtime.eval("'blue'"), in: runtime)
+    let color: UIColor? = decoded.get()
+
+    #expect(decoded.is(UIColor.self) == true)
+    #expect(color?.cgColor.components == CGColor(red: 0, green: 0, blue: 1, alpha: 1).components)
+  }
+
+  @Test
+  func `throws when the value is of neither type`() throws {
+    let runtime = try runtime
+
+    #expect(throws: NeitherTypeException.self) {
+      try Either<String, Int>.decode(runtime.eval("true"), in: runtime)
+    }
+  }
+
+  // MARK: - Decoding in subclasses
+
+  // `EitherOfThree` and `EitherOfFour` inherit the conformance from `Either`, so these cover that an
+  // inherited decode dispatches to the subclass's `dynamicTypes()` and creates the subclass.
+
+  @Test
+  func `decodes the third type of EitherOfThree`() throws {
+    let runtime = try runtime
+    let decoded = try EitherOfThree<String, Int, Bool>.decode(runtime.eval("true"), in: runtime)
+
+    #expect(decoded.is(Bool.self) == true)
+    #expect(try decoded.as(Bool.self) == true)
+  }
+
+  @Test
+  func `decodes the fourth type of EitherOfFour`() throws {
+    let runtime = try runtime
+    let decoded = try EitherOfFour<String, Int, Bool, [String]>.decode(runtime.eval("['a', 'b']"), in: runtime)
+    let value: [String]? = decoded.get()
+
+    #expect(value == ["a", "b"])
+  }
+
+  @Test
+  func `throws when the value is of neither of four types`() throws {
+    let runtime = try runtime
+
+    #expect(throws: NeitherTypeException.self) {
+      try EitherOfFour<String, Int, Bool, [String]>.decode(runtime.eval("({ foo: 'bar' })"), in: runtime)
+    }
+  }
+
+  // MARK: - Encoding
+
+  @Test
+  func `encodes the wrapped value`() throws {
+    let runtime = try runtime
+
+    #expect(try Either<String, Int>.encode(Either("expo"), in: runtime).getString() == "expo")
+    #expect(try Either<String, Int>.encode(Either(123), in: runtime).getInt() == 123)
+  }
+
+  @Test
+  func `encodes the third type of EitherOfThree`() throws {
+    let runtime = try runtime
+    let encoded = try EitherOfThree<String, Int, Bool>.encode(EitherOfThree<String, Int, Bool>(true), in: runtime)
+
+    #expect(encoded.getBool() == true)
+  }
+
+  @Test
+  func `encodes an empty either as null`() throws {
+    let runtime = try runtime
+    let encoded = try Either<String, Int>.encode(Either(nil), in: runtime)
+
+    #expect(encoded.isNull() == true)
+  }
+
+  // MARK: - Round-trips
+
+  @Test
+  func `round-trips both types`() throws {
+    let runtime = try runtime
+
+    for either in [Either<String, Int>("expo"), Either<String, Int>(123)] {
+      let roundTripped = try Either<String, Int>.decode(Either<String, Int>.encode(either, in: runtime), in: runtime)
+      #expect(roundTripped == either)
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/Macros/MacroModuleTests.swift
+++ b/packages/expo-modules-core/ios/Tests/Macros/MacroModuleTests.swift
@@ -41,6 +41,16 @@ private final class MacroGreeter: Module, @unchecked Sendable {
     return MacroOptions(label: options.label, count: options.count + 1)
   }
 
+  // An `Either` argument and return. The return is an `EitherOfThree`, which conforms through the
+  // conformance inherited from `Either`.
+  @JS
+  func describe(value: Either<String, Int>) -> EitherOfThree<String, Int, Bool> {
+    if let string: String = value.get() {
+      return EitherOfThree(string.uppercased())
+    }
+    return EitherOfThree(value.is(Int.self))
+  }
+
   // A throwing function, whose coded error surfaces to JS.
   @JS
   func fail() throws {
@@ -185,6 +195,13 @@ private struct MacroModuleTests {
     let result = try runtime.eval("expo.modules.MacroGreeter.repeated({ label: 'a', count: 2 })").asObject()
     #expect(try result.getProperty("label").asString() == "a")
     #expect(try result.getProperty("count").asInt() == 3)
+  }
+
+  @Test
+  func `decodes and encodes an Either across a @JS function`() throws {
+    register(MacroGreeter(appContext: appContext))
+    #expect(try runtime.eval("expo.modules.MacroGreeter.describe('expo')").asString() == "EXPO")
+    #expect(try runtime.eval("expo.modules.MacroGreeter.describe(42)").asBool() == true)
   }
 
   // MARK: - Error propagation


### PR DESCRIPTION
# Why

`Either`, `EitherOfThree` and `EitherOfFour` don't conform to `JavaScriptDecodable`/`JavaScriptEncodable`, so the new module API rejects them as `@JS` arguments, return values and `@Record` fields. Union types will replace them eventually, but the existing types should keep working until then.

# How

Adds `JavaScriptCodable+Either.swift`. The value is stored as `Any?`, so instead of recursing statically into the generic parameters, the conversion walks the `AnyDynamicType` converters from `dynamicTypes()` and takes the first one that accepts the value, like `DynamicEitherType` does. Those need the app context, recovered from the runtime like `Record` does.

Two Swift constraints shaped it:

- A subclass can't restate a superclass conformance, so it's declared on `Either` alone and the other two inherit it. `decode` goes through `Self.dynamicTypes()`, which the subclasses override, and builds the result with the `required init`, so an inherited decode sees all three or four types and returns the concrete subclass.
- A non-final class can't take a covariant `Self` as a parameter, so `encode` takes `Either<FirstType, SecondType>`, same as `SharedObject`.

# Test Plan

`ExpoModulesCore-Unit-Tests` passes, 800 tests in 107 suites.

The new `JavaScriptCodable+Either` suite covers both directions for each generic parameter (including the third and fourth through the inherited conformance), arrays, a convertible, an empty either encoding as `null`, round-trips and the `NeitherTypeException` cases. `MacroModuleTests` gains a `@JS` function taking an `Either<String, Int>` and returning an `EitherOfThree<String, Int, Bool>`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
