### PR TITLE
[observe] Keep a rejected metric write from surfacing as an unhandled rejection

### DIFF
--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Keep a rejected navigation metric write from surfacing as an unhandled promise rejection in the host app. ([#50054](https://github.com/expo/expo/pull/50054) by [@bjjeong](https://github.com/bjjeong))
+
 ### 💡 Others
 
 ## 58.0.0 — 2026-09-10

--- a/packages/expo-observe/src/integrations/__tests__/recordMetric.test.ts
+++ b/packages/expo-observe/src/integrations/__tests__/recordMetric.test.ts
@@ -1,0 +1,61 @@
+import { recordMetric } from '../recordMetric';
+
+const metric = {
+  timestamp: '2026-01-01T00:00:00.000Z',
+  category: 'navigation',
+  name: 'warm_ttr',
+  routeName: '/a',
+  value: 0.1,
+  params: {},
+} as const;
+
+let warnSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+it('forwards the metric to the session', async () => {
+  const addMetric = jest.fn().mockResolvedValue(undefined);
+
+  await recordMetric({ addMetric }, metric);
+
+  expect(addMetric).toHaveBeenCalledWith(metric);
+  expect(warnSpy).not.toHaveBeenCalled();
+});
+
+it('resolves and warns when the write rejects', async () => {
+  const error = new Error('Cannot use shared object that was already released');
+  const addMetric = jest.fn().mockRejectedValue(error);
+
+  await expect(recordMetric({ addMetric }, metric)).resolves.toBeUndefined();
+
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[expo-observe]'), error);
+});
+
+it('resolves and warns when the write throws synchronously', async () => {
+  const error = new Error('boom');
+  const addMetric = jest.fn(() => {
+    throw error;
+  });
+
+  await expect(recordMetric({ addMetric }, metric)).resolves.toBeUndefined();
+
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[expo-observe]'), error);
+});
+
+it('stays silent outside development', async () => {
+  const dev = __DEV__;
+  (globalThis as any).__DEV__ = false;
+  try {
+    await recordMetric({ addMetric: jest.fn().mockRejectedValue(new Error('boom')) }, metric);
+  } finally {
+    (globalThis as any).__DEV__ = dev;
+  }
+
+  expect(warnSpy).not.toHaveBeenCalled();
+});

--- a/packages/expo-observe/src/integrations/expo-router/__tests__/init.test.native.ts
+++ b/packages/expo-observe/src/integrations/expo-router/__tests__/init.test.native.ts
@@ -144,6 +144,21 @@ describe('initListeners', () => {
     });
   });
 
+  it('warns instead of rejecting when a metric write fails', async () => {
+    const error = new Error('Cannot use shared object that was already released');
+    mockAddMetric.mockRejectedValueOnce(error).mockRejectedValueOnce(error);
+    // A pending interactive makes the listener take the awaited TTI path as well.
+    storage.screenTimes['a'] = { lastInteractiveCall: performance.now() };
+
+    focus(events, 'a');
+    await flushAsync();
+
+    expect(mockAddMetric).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[expo-observe]'), error);
+    warnSpy.mockClear();
+  });
+
   it('filters route params from cold_ttr, warm_ttr, and deferred tti metrics', async () => {
     setRouterConfig({ filteredParams: ['userId', 'token'] });
     const circular: Record<string, unknown> = {};

--- a/packages/expo-observe/src/integrations/expo-router/emitTTI.ts
+++ b/packages/expo-observe/src/integrations/expo-router/emitTTI.ts
@@ -2,6 +2,7 @@ import type { Session } from 'expo-app-metrics';
 
 import type { ObserveIntegrationsConfig } from '../../types';
 import { getNavigationMetricParams } from '../navigationConfig';
+import { recordMetric } from '../recordMetric';
 
 export function emitTTI(args: {
   session: Pick<Session, 'addMetric'>;
@@ -13,7 +14,7 @@ export function emitTTI(args: {
   url: string | undefined;
   config?: ObserveIntegrationsConfig['expo-router'];
 }): Promise<void> {
-  return args.session.addMetric({
+  return recordMetric(args.session, {
     timestamp: args.timestamp,
     category: 'navigation',
     name: 'tti',

--- a/packages/expo-observe/src/integrations/expo-router/init.ts
+++ b/packages/expo-observe/src/integrations/expo-router/init.ts
@@ -2,6 +2,7 @@ import AppMetrics from 'expo-app-metrics';
 
 import type { ObserveIntegrationsConfig } from '../../types';
 import { getNavigationMetricParams } from '../navigationConfig';
+import { recordMetric } from '../recordMetric';
 import { emitTTI } from './emitTTI';
 import { buildRoutePattern } from './routeName';
 import { optionalRouter } from './router';
@@ -112,7 +113,7 @@ export function initListeners(
       e.pathname
     );
 
-    mainSession.addMetric({
+    recordMetric(mainSession, {
       timestamp,
       category: 'navigation',
       name,

--- a/packages/expo-observe/src/integrations/react-navigation/__tests__/handleStateChange.test.native.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/__tests__/handleStateChange.test.native.ts
@@ -321,6 +321,21 @@ describe('createStateChangeHandler', () => {
     expect(entry!.dispatchTime!).toBeLessThan(entry!.lastInteractiveCall!);
   });
 
+  it('warns instead of rejecting when a metric write fails', async () => {
+    const error = new Error('Cannot use shared object that was already released');
+    mockAddMetric.mockRejectedValueOnce(error).mockRejectedValueOnce(error);
+    // A pending interactive makes the handler take the awaited TTI path as well.
+    storage.screenTimes['a'] = { lastInteractiveCall: performance.now() };
+
+    handle(stackState([{ key: 'a' }]));
+    await flushAsync();
+
+    expect(mockAddMetric).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[expo-observe]'), error);
+    warnSpy.mockClear();
+  });
+
   it('does not emit tti when no pending interactive is waiting', async () => {
     handle(stackState([{ key: 'a' }], 0));
     await flushAsync();

--- a/packages/expo-observe/src/integrations/react-navigation/emitTTI.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/emitTTI.ts
@@ -1,5 +1,7 @@
 import type { Session } from 'expo-app-metrics';
 
+import { recordMetric } from '../recordMetric';
+
 export function emitTTI(args: {
   session: Pick<Session, 'addMetric'>;
   timestamp: string;
@@ -8,7 +10,7 @@ export function emitTTI(args: {
   routeParams: object;
   urlHidden?: true;
 }): Promise<void> {
-  return args.session.addMetric({
+  return recordMetric(args.session, {
     timestamp: args.timestamp,
     category: 'navigation',
     name: 'tti',

--- a/packages/expo-observe/src/integrations/react-navigation/handleStateChange.ts
+++ b/packages/expo-observe/src/integrations/react-navigation/handleStateChange.ts
@@ -1,6 +1,7 @@
 import AppMetrics from 'expo-app-metrics';
 
 import { getNavigationRouteParams } from '../navigationConfig';
+import { recordMetric } from '../recordMetric';
 import { emitTTI } from './emitTTI';
 import { getPathname } from './getPathname';
 import { getReactNavigationIntegrationConfig } from './init';
@@ -70,7 +71,7 @@ export function createStateChangeHandler(
     const name = isInitial ? 'cold_ttr' : 'warm_ttr';
 
     // The main session is a static shared object, available synchronously and
-    // never null. Metrics are recorded against it directly via `addMetric`.
+    // never null. Metrics are recorded against it via `recordMetric`.
     const mainSession = AppMetrics.getMainSession();
 
     if (isColdAppLaunch) {
@@ -82,7 +83,7 @@ export function createStateChangeHandler(
           lastInteractiveCall: now,
         };
       }
-      mainSession.addMetric({
+      recordMetric(mainSession, {
         timestamp,
         category: 'navigation',
         name,
@@ -112,7 +113,7 @@ export function createStateChangeHandler(
       };
     }
 
-    mainSession.addMetric({
+    recordMetric(mainSession, {
       timestamp,
       category: 'navigation',
       name,

--- a/packages/expo-observe/src/integrations/recordMetric.ts
+++ b/packages/expo-observe/src/integrations/recordMetric.ts
@@ -1,0 +1,19 @@
+import type { MetricInput, Session } from 'expo-app-metrics';
+
+/**
+ * Records a metric on the session. A rejected write is logged in development instead of
+ * propagating: the integrations call this from navigation listeners where nothing awaits it, so a
+ * rejection would surface as an unhandled promise rejection in the host app.
+ */
+export async function recordMetric(
+  session: Pick<Session, 'addMetric'>,
+  metric: MetricInput
+): Promise<void> {
+  try {
+    await session.addMetric(metric);
+  } catch (error) {
+    if (__DEV__) {
+      console.warn('[expo-observe] Failed to record a navigation metric:', error);
+    }
+  }
+}


### PR DESCRIPTION
# Why

Both navigation integrations write TTR/TTI metrics with `session.addMetric(...)` from listeners that nothing awaits: `ObserveNavigationProvider` drops the async state handler's promise, and so does expo-router's `pageFocused` emitter. When native rejects the write, the rejection reaches the host app as an unhandled promise rejection — one per navigation.

We see this in production on Android (~83 users/day), where the write rejects with `Cannot use shared object that was already released` (#49799; core fix in #49807). Independently of that race, a failed telemetry write should never surface as an app-level error.

# How

Route every navigation metric write through `recordMetric`, which awaits `session.addMetric` and logs a rejection in development instead of propagating it — the same shape `reportCaughtError` already uses. Covers both integrations' TTR writes and `emitTTI`.

# Test Plan

- `recordMetric`: forwards the metric; resolves and warns on a rejection and on a synchronous throw; silent outside `__DEV__`.
- `handleStateChange` and `initListeners`: a rejected write on the TTR + deferred-TTI path warns twice and rejects nothing. Both new tests fail on `main`.
- `pnpm run test` (72 suites, 588 tests), `typecheck`, `lint`, `format --check` in `packages/expo-observe`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
