### PR TITLE
[app-metrics] Keep the main session's JS wrapper alive

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Hold on to the main session's JS wrapper so `getMainSession()` always returns the same object and `addMetric` on it can no longer fail with "Cannot use shared object that was already released" on Android. ([#50055](https://github.com/expo/expo/pull/50055) by [@bjjeong](https://github.com/bjjeong))
+
 ### 💡 Others
 
 ## 58.0.0 — 2026-09-10

--- a/packages/expo-app-metrics/src/__tests__/mainSession.test.native.ts
+++ b/packages/expo-app-metrics/src/__tests__/mainSession.test.native.ts
@@ -1,0 +1,33 @@
+export {};
+
+const mockGetMainSession = jest.fn();
+
+jest.mock('expo', () => ({
+  requireNativeModule: () => ({ getMainSession: mockGetMainSession }),
+}));
+
+beforeEach(() => {
+  jest.resetModules();
+  mockGetMainSession.mockReset().mockImplementation(() => ({ id: 'main', addMetric: jest.fn() }));
+});
+
+function loadModule() {
+  return (require('../module') as typeof import('../module')).default;
+}
+
+it('resolves the main session lazily, on the first call', () => {
+  const AppMetrics = loadModule();
+  expect(mockGetMainSession).not.toHaveBeenCalled();
+
+  AppMetrics.getMainSession();
+  expect(mockGetMainSession).toHaveBeenCalledTimes(1);
+});
+
+it('returns the same session on every call', () => {
+  const AppMetrics = loadModule();
+
+  const session = AppMetrics.getMainSession();
+
+  expect(AppMetrics.getMainSession()).toBe(session);
+  expect(mockGetMainSession).toHaveBeenCalledTimes(1);
+});

--- a/packages/expo-app-metrics/src/module.ts
+++ b/packages/expo-app-metrics/src/module.ts
@@ -1,5 +1,15 @@
 import { requireNativeModule } from 'expo';
 
+import type { Session } from './Session';
 import type { ExpoAppMetricsModuleType } from './types';
 
-export default requireNativeModule<ExpoAppMetricsModuleType>('ExpoAppMetrics');
+const AppMetrics = requireNativeModule<ExpoAppMetricsModuleType>('ExpoAppMetrics');
+
+// The native main session lives for the whole process, but its JS wrapper is a regular shared
+// object whose registry pairing is dropped once nothing references it. Hold one wrapper so repeated
+// calls return the same object and an un-awaited `addMetric` on it can't race the collector.
+let mainSession: Session | undefined;
+const getMainSession = AppMetrics.getMainSession.bind(AppMetrics);
+AppMetrics.getMainSession = () => (mainSession ??= getMainSession());
+
+export default AppMetrics;

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -582,8 +582,7 @@ export interface ExpoAppMetricsModuleType {
    * is synchronous and never returns `null`. Metrics and logs are fetched
    * lazily via the returned object.
    *
-   * The returned object is a static reference: repeated calls return the same
-   * object while it stays referenced, so `getMainSession() === getMainSession()`.
+   * The returned object is a static reference, so `getMainSession() === getMainSession()`.
    *
    * @private This API is unstable and may change without notice.
    */


### PR DESCRIPTION
# Why

`getMainSession()` hands out a process-lifetime native singleton as an ordinary shared object. The registry holds its JS wrapper weakly, so once nothing references the wrapper the pairing is dropped and the next call pairs a fresh one. The docs already carry the caveat ("the same object *while it stays referenced*"), and it is what lets a fire-and-forget `session.addMetric(...)` — the shape both `expo-observe` integrations use — race the collector on Android and reject with `Cannot use shared object that was already released` (#49799; ~83 users/day for us). The same release/re-pair churn is behind the `convertSharedObject` null-deref in #47787.

# How

Hold the wrapper in module scope and hand it back on every call, resolving it lazily on first use. `getMainSession() === getMainSession()` now holds unconditionally and the main session's wrapper is never released or re-paired. Complementary to #49807, which retains arguments per call: a singleton fetched on every navigation has no reason to be re-paired at all. Overlaps textually with #49841 (whose shim already caches its session) — happy to rebase either way.

# Test Plan

- New `mainSession.test.native.ts`: the session is resolved lazily on first call, and every call returns the same object with a single native lookup. The second test fails on `main`.
- `pnpm run test`, `typecheck`, `lint`, `format --check` in `packages/expo-app-metrics`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

