### PR TITLE
[android][expo] Request local network permission before loading the app

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Request the `ACCESS_LOCAL_NETWORK` permission in debug builds on Android 17 before loading the app, so the dev server can be reached without `expo-dev-client`.
+
 ### 💡 Others
 
 ## 58.0.0-preview.0 — 2026-09-10

--- a/packages/expo/android/src/main/java/expo/modules/LocalNetworkPermission.kt
+++ b/packages/expo/android/src/main/java/expo/modules/LocalNetworkPermission.kt
@@ -1,0 +1,19 @@
+package expo.modules
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.os.Build
+import com.facebook.react.common.build.ReactBuildConfig
+
+// Android 17 blocks dev server traffic until the app holds the permission React Native's debug manifest declares.
+internal object LocalNetworkPermission {
+  const val PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK"
+  const val REQUEST_CODE = 0x4c4e
+
+  private const val FIRST_ENFORCED_SDK = 37
+
+  fun shouldRequest(activity: Activity): Boolean =
+    ReactBuildConfig.DEBUG &&
+      Build.VERSION.SDK_INT >= FIRST_ENFORCED_SDK &&
+      activity.checkSelfPermission(PERMISSION) != PackageManager.PERMISSION_GRANTED
+}

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -30,13 +30,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 class ReactActivityDelegateWrapper(
   private val activity: ReactActivity,
@@ -64,6 +64,7 @@ class ReactActivityDelegateWrapper(
    * A deferred that indicates when the app loading is ready
    */
   private val loadAppReady = CompletableDeferred<Unit>()
+  private var localNetworkPermissionResult: CompletableDeferred<Unit>? = null
 
   /**
    * A mutex to ensure all coroutines in a scope are running in atomic way.
@@ -161,6 +162,7 @@ class ReactActivityDelegateWrapper(
         mReactDelegate.isAccessible = true
         mReactDelegate.set(delegate, reactDelegate)
         if (mainComponentName != null) {
+          awaitLocalNetworkPermission()
           loadAppImpl(mainComponentName, supportsDelayLoad = false)
         }
       }
@@ -329,6 +331,10 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+    if (requestCode == LocalNetworkPermission.REQUEST_CODE) {
+      localNetworkPermissionResult?.complete(Unit)
+      return
+    }
     launchLifecycleScopeWithLock {
       loadAppReady.await()
       delegate.onRequestPermissionsResult(requestCode, permissions, grantResults)
@@ -431,11 +437,22 @@ class ReactActivityDelegateWrapper(
     }
   }
 
+  private suspend fun awaitLocalNetworkPermission() {
+    if (!LocalNetworkPermission.shouldRequest(activity)) {
+      return
+    }
+    val result = CompletableDeferred<Unit>()
+    localNetworkPermissionResult = result
+    activity.requestPermissions(arrayOf(LocalNetworkPermission.PERMISSION), LocalNetworkPermission.REQUEST_CODE)
+    result.await()
+    localNetworkPermissionResult = null
+  }
+
   private suspend fun awaitDelayLoadAppWhenReady(delayLoadAppHandler: DelayLoadAppHandler?) {
     if (delayLoadAppHandler == null) {
       return
     }
-    suspendCoroutine { continuation ->
+    suspendCancellableCoroutine { continuation ->
       delayLoadAppHandler.whenReady {
         Utils.assertMainThread()
         continuation.resume(Unit)

--- a/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperLocalNetworkPermissionTest.kt
+++ b/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperLocalNetworkPermissionTest.kt
@@ -1,0 +1,99 @@
+package expo.modules
+
+import android.content.pm.PackageManager
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
+import com.facebook.soloader.SoLoader
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = MockApplication::class)
+internal class ReactActivityDelegateWrapperLocalNetworkPermissionTest {
+  private lateinit var activityController: ActivityController<MockActivity>
+  private val activity: MockActivity
+    get() = activityController.get()
+  private val wrapper: ReactActivityDelegateWrapper
+    get() = activity.reactActivityDelegate as ReactActivityDelegateWrapper
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Before
+  fun setUp() {
+    SoLoader.setInTestMode()
+    mockkObject(ExpoModulesPackage.Companion)
+    every { ExpoModulesPackage.Companion.packageList } returns listOf(MockPackageWithoutDelayHandler())
+    ReactNativeFeatureFlagsForTests.setUp()
+    mockkStatic(ReactNativeFeatureFlags::class)
+    every { ReactNativeFeatureFlags.enableBridgelessArchitecture() } returns true
+    Dispatchers.setMain(UnconfinedTestDispatcher())
+    mockkObject(LocalNetworkPermission)
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  private fun launchActivity() {
+    activityController = Robolectric.buildActivity(MockActivity::class.java)
+      .also { (it.get().application as MockApplication).bindCurrentActivity(it.get()) }
+      .setup()
+  }
+
+  private fun verifyLoadApp(times: Int) {
+    verify(exactly = times) { wrapper.invokeDelegateMethod("loadApp", arrayOf(String::class.java), arrayOf("main")) }
+  }
+
+  @Test
+  fun `requests the local network permission before loading the app`() {
+    every { LocalNetworkPermission.shouldRequest(any()) } returns true
+
+    launchActivity()
+
+    verifyLoadApp(0)
+    val request = shadowOf(activity).lastRequestedPermission
+    assertThat(request.requestedPermissions.toList()).containsExactly(LocalNetworkPermission.PERMISSION)
+
+    activity.onRequestPermissionsResult(request.requestCode, request.requestedPermissions, intArrayOf(PackageManager.PERMISSION_GRANTED))
+
+    verifyLoadApp(1)
+  }
+
+  @Test
+  fun `loads the app when the local network permission is denied`() {
+    every { LocalNetworkPermission.shouldRequest(any()) } returns true
+
+    launchActivity()
+    val request = shadowOf(activity).lastRequestedPermission
+    activity.onRequestPermissionsResult(request.requestCode, request.requestedPermissions, intArrayOf(PackageManager.PERMISSION_DENIED))
+
+    verifyLoadApp(1)
+  }
+
+  @Test
+  fun `loads the app immediately when the permission is not required`() {
+    every { LocalNetworkPermission.shouldRequest(any()) } returns false
+
+    launchActivity()
+
+    assertThat(shadowOf(activity).lastRequestedPermission).isNull()
+    verifyLoadApp(1)
+  }
+}


### PR DESCRIPTION
# Why
A bare SDK 58 project without dev client cannot reach the dev server on an Android 17 emulator. The app shows the "Unable to load script" red box.

React Native 0.87's debug manifest declares `ACCESS_LOCAL_NETWORK`. On Android 17 that removes the implicit grant, so the app has to request the permission at runtime before it can open a connection to a local network address. React Native does this in `ReactActivityDelegate.onCreate`. `ReactActivityDelegateWrapper` re-implements that method by reflection and skipped the request, so the prompt never appeared and the connection to `10.0.2.2:8081` timed out.

Installing `expo-dev-client` hides the problem on an emulator, but not because dev-launcher requests the permission. It does not. The CLI hands dev-client the host's LAN IP, which is not on the emulator's own subnet, and Android 17 did not block that traffic. A plain debug build uses React Native's default emulator host `10.0.2.2`, which is on the emulator's subnet and is blocked. The same dev-client build with the permission denied loads from the LAN IP and hangs on `10.0.2.2`.

This is the same root cause as the Expo Go fix in #49813.

# How
- Added `LocalNetworkPermission`, a small object with the same gate React Native uses: `ReactBuildConfig.DEBUG`, API 37 or newer, permission not granted. React Native's `LocalNetworkPermissionUtil` is `internal`, so it cannot be reused directly.
- `ReactActivityDelegateWrapper.onCreate` now awaits the permission before `loadAppImpl` in the branch that re-implements React Native's `onCreate`. It requests the permission through the plain Activity API and suspends on a `CompletableDeferred`.
- The app loads whether the permission is granted or denied, matching React Native's behavior. A denied permission leaves the dev server unreachable, and the existing red box explains the connection failure.
- Dev-client debug builds take the same branch after dev-launcher hands control back to `MainActivity`, so they now prompt before the app loads as well. The launcher screen itself still does not request the permission. 
- The delay-load wait now uses `suspendCancellableCoroutine` so the continuation is released if the activity is destroyed before the handler reports ready.

# Test Plan
Added tests
Manual check on an API 37 emulator with a bare SDK 58 debug build and no `expo-dev-client`:
Dev-client comparison on the same emulator, permission denied: opening `http://192.168.1.1:8081` loads the project, opening `http://10.0.2.2:8081` hangs with the WebSocket unable to connect.