### PR TITLE
[tools] Skip cutting off changelogs for prerelease versions

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -4,16 +4,6 @@
 
 ### 🛠 Breaking changes
 
-### 🎉 New features
-
-### 🐛 Bug fixes
-
-### 💡 Others
-
-## 58.0.0-preview.0 — 2026-09-10
-
-### 🛠 Breaking changes
-
 - Raise minimum Node.js version to `^22.13.0` ([#47202](https://github.com/expo/expo/pull/47202) by [@kitten](https://github.com/kitten))
 
 ### 🎉 New features

--- a/tools/src/publish-packages/tasks/cutOffChangelogs.test.ts
+++ b/tools/src/publish-packages/tasks/cutOffChangelogs.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { getCutOffSkipReason } from './cutOffChangelogs';
+
+describe('getCutOffSkipReason', () => {
+  it('cuts off a stable version', () => {
+    assert.equal(getCutOffSkipReason('58.0.0', true, ['57.0.9']), null);
+  });
+
+  it('skips a prerelease version', () => {
+    assert.equal(getCutOffSkipReason('58.0.0-preview.0', true, ['57.0.9']), 'prerelease version');
+  });
+
+  it('skips a canary version', () => {
+    assert.equal(
+      getCutOffSkipReason('58.0.0-canary-20260909-ea7a89a', true, ['57.0.9']),
+      'prerelease version'
+    );
+  });
+
+  it('skips a package without a changelog', () => {
+    assert.equal(getCutOffSkipReason('58.0.0', false, []), 'no changelog file');
+  });
+
+  it('skips a version that has already been cut off', () => {
+    assert.equal(
+      getCutOffSkipReason('58.0.0', true, ['58.0.0', '57.0.9']),
+      'version already exists'
+    );
+  });
+});

--- a/tools/src/publish-packages/tasks/cutOffChangelogs.ts
+++ b/tools/src/publish-packages/tasks/cutOffChangelogs.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import semver from 'semver';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
 import logger from '../../Logger';
@@ -6,6 +7,29 @@ import { Task } from '../../TasksRunner';
 import { Parcel, TaskArgs } from '../types';
 
 const { green, gray } = chalk;
+
+/**
+ * Returns the reason to skip cutting off the changelog, or `null` when it should be cut off.
+ * Prerelease versions are skipped so their entries stay under "Unpublished" and end up
+ * in the section of the stable version that follows.
+ */
+export function getCutOffSkipReason(
+  releaseVersion: string,
+  changelogExists: boolean,
+  changelogVersions: string[]
+): string | null {
+  if (semver.prerelease(releaseVersion)) {
+    return 'prerelease version';
+  }
+  if (!changelogExists) {
+    return 'no changelog file';
+  }
+  // Prevents another cut-off when that version has already been cut off.
+  if (changelogVersions.includes(releaseVersion)) {
+    return 'version already exists';
+  }
+  return null;
+}
 
 /**
  * Cuts off changelogs - renames unpublished section header
@@ -26,24 +50,21 @@ export const cutOffChangelogs = new Task<TaskArgs>(
           return;
         }
 
-        let skipReason = '';
+        const changelogExists = await changelog.fileExistsAsync();
+        const skipReason = getCutOffSkipReason(
+          state.releaseVersion,
+          changelogExists,
+          changelogExists ? await changelog.getVersionsAsync() : []
+        );
 
-        if (await changelog.fileExistsAsync()) {
-          const versions = await changelog.getVersionsAsync();
-
-          // This prevents unnecessary cut-offs when that version was already cutted off.
-          // Maybe we should move "unpublished" entries to this version? It's probably too rare to worry about it.
-          if (!versions.includes(state.releaseVersion)) {
-            logger.log('  ', green(pkg.packageName) + '...');
-            await changelog.cutOffAsync(state.releaseVersion);
-            await changelog.saveAsync();
-            return;
-          }
-          skipReason = 'version already exists';
-        } else {
-          skipReason = 'no changelog file';
+        if (skipReason) {
+          logger.log('  ', green(pkg.packageName), gray(`- skipped, ${skipReason}`));
+          return;
         }
-        logger.log('  ', green(pkg.packageName), gray(`- skipped, ${skipReason}`));
+
+        logger.log('  ', green(pkg.packageName) + '...');
+        await changelog.cutOffAsync(state.releaseVersion);
+        await changelog.saveAsync();
       })
     );
   }


### PR DESCRIPTION
## Why

`cutOffChangelogs` cut changelogs on `state.releaseVersion` without checking for a prerelease identifier. Publishing `expo@58.0.0-preview.0` therefore filed every SDK 58 entry of the `expo` package under a `## 58.0.0-preview.0` heading. When `58.0.0` ships, its cut creates an empty section. SDK 57 shows the result: `## 57.0.0` says "_This version does not introduce any user-facing changes._" while the entries sit under `## 57.0.0-preview.0`.

## How

Skip the cut when the release version has a prerelease identifier. Entries stay under `Unpublished` through the prerelease cycle and land in the section of the stable version that follows. The skip decision moved into `getCutOffSkipReason`, a pure function with tests.

Also moves the `58.0.0-preview.0` section of `packages/expo/CHANGELOG.md` back into `Unpublished`, so the SDK 58 entry is complete when `58.0.0` is cut.

## Test Plan

`cd tools && pnpm test` (3 pre-existing failures in `prebuilds/Utils.test.js` and the Hermes V1 test, both unrelated).
