### PR TITLE
[ios][precompile] Fix skia prebuild after 2.11.2 moved its binaries out of the package

### DIFF
--- a/packages/expo-modules-autolinking/external-configs/ios/@shopify/react-native-skia/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/@shopify/react-native-skia/spm.config.json
@@ -11,42 +11,50 @@
         {
           "type": "framework",
           "name": "libskia",
-          "path": "libs/ios/libskia.xcframework"
+          "package": "react-native-skia-apple-ios",
+          "path": "libs/libskia.xcframework"
         },
         {
           "type": "framework",
           "name": "libsvg",
-          "path": "libs/ios/libsvg.xcframework"
+          "package": "react-native-skia-apple-ios",
+          "path": "libs/libsvg.xcframework"
         },
         {
           "type": "framework",
           "name": "libskshaper",
-          "path": "libs/ios/libskshaper.xcframework"
+          "package": "react-native-skia-apple-ios",
+          "path": "libs/libskshaper.xcframework"
         },
         {
           "type": "framework",
           "name": "libskparagraph",
-          "path": "libs/ios/libskparagraph.xcframework"
+          "package": "react-native-skia-apple-ios",
+          "path": "libs/libskparagraph.xcframework"
         },
         {
           "type": "framework",
           "name": "libskunicode_core",
-          "path": "libs/ios/libskunicode_core.xcframework"
+          "package": "react-native-skia-apple-ios",
+          "path": "libs/libskunicode_core.xcframework"
         },
         {
           "type": "framework",
           "name": "libskunicode_libgrapheme",
-          "path": "libs/ios/libskunicode_libgrapheme.xcframework"
+          "package": "react-native-skia-apple-ios",
+          "path": "libs/libskunicode_libgrapheme.xcframework"
         },
         {
           "type": "framework",
           "name": "libskottie",
-          "path": "libs/ios/libskottie.xcframework"
+          "package": "react-native-skia-apple-ios",
+          "path": "libs/libskottie.xcframework"
         },
         {
           "type": "framework",
           "name": "libsksg",
-          "path": "libs/ios/libsksg.xcframework"
+          "package": "react-native-skia-apple-ios",
+          "path": "libs/libsksg.xcframework"
         },
         {
           "type": "objc",

--- a/tools/src/prebuilds/SPMConfig.types.ts
+++ b/tools/src/prebuilds/SPMConfig.types.ts
@@ -11,8 +11,10 @@ export interface FrameworkTarget {
   type: 'framework';
   /** The name of the target */
   name: string;
-  /** Path to the xcframework relative to package root */
+  /** Path to the xcframework relative to package root, or to `package`'s root when it is set */
   path: string;
+  /** npm package shipping the xcframework, when it is not the package being built (resolved from it) */
+  package?: string;
   /** Header locations within the framework bundle */
   includeDirectories?: string[];
   /** System frameworks to link */

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -33,7 +33,7 @@ import {
   ResolvedTargetDependency,
   SPMPackageVersion,
 } from './SPMPackage.types';
-import { createAsyncSpinner, SpinnerError } from './Utils';
+import { createAsyncSpinner, resolveFrameworkTargetPath, SpinnerError } from './Utils';
 import { resolvePackagePath } from './resolvePackage';
 
 /**
@@ -1539,7 +1539,7 @@ async function buildPackageSwiftContext(
   // These are binary targets that other source targets can depend on
   for (const target of product.targets) {
     if (target.type === 'framework') {
-      const frameworkPath = path.join(pkg.path, target.path);
+      const frameworkPath = resolveFrameworkTargetPath(pkg.path, target);
       const relativePath = path.relative(packageSwiftDir, frameworkPath);
       spinner.info(`Adding vendored framework target: ${target.name} at ${relativePath}`);
       resolvedTargets.push({

--- a/tools/src/prebuilds/Utils.test.ts
+++ b/tools/src/prebuilds/Utils.test.ts
@@ -3,12 +3,14 @@
  */
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { before, describe, it, afterEach } from 'node:test';
+import { after, before, describe, it, afterEach } from 'node:test';
 
 import {
   getVersionsInfoAsync,
   isNonInteractive,
+  resolveFrameworkTargetPath,
   resolveHermesVersion,
   selectDistributedPackages,
   setForceNonInteractive,
@@ -239,5 +241,62 @@ describe('getVersionsInfoAsync — Hermes V1 polarity', () => {
     delete process.env.RCT_HERMES_V1_ENABLED;
     const { hermesVersion } = await getVersionsInfoAsync({});
     assert.equal(hermesVersion, classicVersion);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFrameworkTargetPath
+// ---------------------------------------------------------------------------
+
+describe('resolveFrameworkTargetPath', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'spm-framework-target-'));
+  const packagePath = path.join(fs.realpathSync(tmpDir), 'node_modules', 'some-package');
+  const binaryPackagePath = path.join(packagePath, 'node_modules', 'binary-package');
+
+  before(() => {
+    fs.mkdirSync(binaryPackagePath, { recursive: true });
+    fs.writeFileSync(
+      path.join(binaryPackagePath, 'package.json'),
+      JSON.stringify({ name: 'binary-package', version: '1.0.0' })
+    );
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolves the xcframework inside the package by default', () => {
+    const target = {
+      type: 'framework',
+      name: 'libfoo',
+      path: 'libs/libfoo.xcframework',
+    } as const;
+    assert.equal(
+      resolveFrameworkTargetPath(packagePath, target),
+      path.join(packagePath, 'libs/libfoo.xcframework')
+    );
+  });
+
+  it('resolves the xcframework inside another npm package when `package` is set', () => {
+    const target = {
+      type: 'framework',
+      name: 'libfoo',
+      path: 'libs/libfoo.xcframework',
+      package: 'binary-package',
+    } as const;
+    assert.equal(
+      resolveFrameworkTargetPath(packagePath, target),
+      path.join(binaryPackagePath, 'libs/libfoo.xcframework')
+    );
+  });
+
+  it('throws a helpful error when the package shipping the xcframework is missing', () => {
+    const target = {
+      type: 'framework',
+      name: 'libfoo',
+      path: 'libs/libfoo.xcframework',
+      package: 'not-installed-package',
+    } as const;
+    assert.throws(() => resolveFrameworkTargetPath(packagePath, target), /not-installed-package/);
   });
 });

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -14,7 +14,7 @@ import {
   isExternalPackage,
   SPMPackageSource,
 } from './ExternalPackage';
-import { SPMProduct } from './SPMConfig.types';
+import { FrameworkTarget, SPMProduct } from './SPMConfig.types';
 import { resolvePackagePath } from './resolvePackage';
 
 /**
@@ -52,6 +52,32 @@ export function runWithLogPrefix<T>(prefix: string, fn: () => T): T {
 
 export function getActiveLogPrefix(): string | null {
   return _logPrefixStorage.getStore() ?? null;
+}
+
+/**
+ * Resolves the directory holding a framework target's xcframework.
+ *
+ * By default the xcframework ships inside the package being built. Some packages ship their
+ * binaries in a separate npm package instead (e.g. `@shopify/react-native-skia` publishes its
+ * Skia slices as `react-native-skia-apple-ios`); those targets name it in `package` and their
+ * `path` is then relative to that package's root.
+ */
+export function resolveFrameworkTargetPath(packagePath: string, target: FrameworkTarget): string {
+  if (!target.package) {
+    return path.join(packagePath, target.path);
+  }
+  let packageJsonPath: string;
+  try {
+    packageJsonPath = require.resolve(`${target.package}/package.json`, { paths: [packagePath] });
+  } catch {
+    throw new Error(
+      `Cannot find "${target.package}", the package that ships the "${target.name}" xcframework. ` +
+        `Its spm.config.json expects it next to "${packagePath}", so it is either not a dependency ` +
+        `of that package anymore or node_modules is out of date. Run \`pnpm install\` and, if it ` +
+        `still fails, update the framework targets in the package's spm.config.json.`
+    );
+  }
+  return path.join(path.dirname(packageJsonPath), target.path);
 }
 
 /**

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -29,6 +29,7 @@ import type { SPMPackageDependencyConfig, SPMProduct, SPMTarget } from '../SPMCo
 import { getTargetExcludePatterns } from '../SPMGenerator';
 import {
   getVersionsInfoAsync,
+  resolveFrameworkTargetPath,
   setForceNonInteractive,
   validateAllPodNamesAsync,
   verifyAllPackagesAsync,
@@ -280,7 +281,7 @@ function getFrameworkMtimeMs(frameworkPath: string): number {
 
 function getSourceTargetPath(pkg: SPMPackageSource, target: SPMTarget): string | null {
   if (target.type === 'framework') {
-    return path.resolve(pkg.path, target.path);
+    return resolveFrameworkTargetPath(pkg.path, target);
   }
 
   const isBuildArtifact = target.path.startsWith('.build/');

--- a/tools/src/prebuilds/schemas/spm.config.schema.json
+++ b/tools/src/prebuilds/schemas/spm.config.schema.json
@@ -277,7 +277,11 @@
                 },
                 "path": {
                     "type": "string",
-                    "description": "Path to the xcframework relative to package root"
+                    "description": "Path to the xcframework, relative to the package root or to the root of `package` when that is set"
+                },
+                "package": {
+                    "type": "string",
+                    "description": "npm package shipping the xcframework, when it is not the package being built (resolved from it with Node module resolution)"
                 },
                 "includeDirectories": {
                     "type": "array",


### PR DESCRIPTION
# Why

The `Prebuild External iOS XCFrameworks` workflow is [failing on `main`](https://github.com/expo/expo/actions/runs/34630781433) since we bumped `@shopify/react-native-skia` to 2.11.2

```
xcodebuild: error: Could not resolve package dependencies:
local binary target 'libskia' at '.../@shopify/react-native-skia/libs/ios/libskia.xcframework'
does not contain a binary artifact.
```

The problem is that Skia no longer ships `libs/ios/*.xcframework` in its own tarball. The slices now live in a separate npm package (`react-native-skia-apple-ios`), and skia's podspec copies them into `libs/ios/` at `pod install` time. 

# How

Framework targets in `spm.config.json` assume the xcframework lives inside the package being built. This adds an optional `package` field so a target can specify which npm package ships the binary. One other approach could be setting up something to run `pod install` when precompiling.

# Test Plan

New unit tests cover the default path, the cross-package path, and the missing-package error


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
