### PR TITLE
[ios][app-intents] Drop macOS from podspec platforms

### DIFF
--- a/packages/expo-app-intents/CHANGELOG.md
+++ b/packages/expo-app-intents/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Drop macOS from the podspec platforms to fix `pod install` failing with "Unable to find a specification for `ExpoUI`". ([#50065](https://github.com/expo/expo/pull/50065) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 0.2.0 — 2026-09-10

--- a/packages/expo-app-intents/ios/ExpoAppIntents.podspec
+++ b/packages/expo-app-intents/ios/ExpoAppIntents.podspec
@@ -12,7 +12,10 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '16.4',
-    :osx => '13.4',
+    # This module depends on ExpoUI, which is iOS/tvOS only. CocoaPods' resolver walks
+    # `all_dependencies` and ignores the `.ios`/`.tvos` scoping below, so linking fails on macOS
+    # Restore :osx once ExpoUI supports macOS
+    # :osx => '13.4',
     :tvos => '16.4'
   }
   s.swift_version  = '6.0'


### PR DESCRIPTION
# Why

[#47592](https://github.com/expo/expo/pull/47592) added a dependency on `@expo/ui` to `expo-app-intents` using `s.ios.dependency 'ExpoUI'` / `s.tvos.dependency 'ExpoUI'` in the podspec.

Although we are using `s.[platform].dependency` pod install targeting macOS still fails with:

```
[!] [Expo] @expo/ui was not linked: supports iOS, tvOS but target is macOS
[!] Unable to find a specification for `ExpoUI` depended upon by `ExpoAppIntents`
```

E.g. https://github.com/expo/expo/actions/runs/34648731813/job/103425650081

# How

The surprising part is that the `.ios` / `.tvos` scoping does not prevent this. Platform-scoped dependencies scope linking, but not resolution:

- `spec.dependencies(Platform osx)` correctly returns `[]`, so `ExpoUI` would never be linked into the macOS binary.
- Molinillo builds its dependency graph earlier, from `specification.all_dependencies` ([resolver.rb#L178](https://github.com/CocoaPods/CocoaPods/blob/1.16.2/lib/cocoapods/resolver.rb#L178)), which is platform-blind.

So a platform-scoped dependency still has to be resolvable on every platform the pod is linked into. Since `ExpoUI` is not, `ExpoAppIntents` cannot claim macOS today. This PR comments out `:osx` and records why, so the constraint is not rediscovered the hard way.

# Test Plan

CI should be green
  