### PR TITLE
[macos][ui] Add macOS support to @expo/ui

### DIFF
--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -28,6 +28,7 @@ on:
       - packages/expo-sqlite/**
       - packages/expo-structured-headers/**
       - packages/expo-symbols/**
+      - packages/expo-ui/**
       - packages/expo-updates-interface/**
       - packages/expo-updates/**
       - packages/expo-web-browser/**

--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - EASClient (56.0.1):
+  - EASClient (57.0.1):
     - ExpoModulesCore
-  - EXConstants (56.0.16):
+  - EXConstants (57.0.8):
     - ExpoModulesCore
-  - EXManifests (56.0.4):
+  - EXManifests (57.0.1):
     - ExpoModulesCore
-  - Expo (56.0.5):
+  - Expo (57.0.9):
     - boost
     - DoubleConversion
     - ExpoModulesCore
@@ -39,87 +39,13 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-client (56.0.16):
+  - expo-dev-client (57.0.10):
     - EXManifests
     - expo-dev-launcher
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (56.0.16):
-    - boost
-    - DoubleConversion
-    - EXManifests
-    - expo-dev-launcher/Main (= 56.0.16)
-    - expo-dev-menu
-    - expo-dev-menu-interface
-    - ExpoModulesCore
-    - EXUpdatesInterface
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-jsinspector
-    - React-NativeModulesApple
-    - React-RCTAppDelegate
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactAppDependencyProvider
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - expo-dev-launcher/Main (56.0.16):
-    - boost
-    - DoubleConversion
-    - EXManifests
-    - expo-dev-launcher/Unsafe
-    - expo-dev-menu
-    - expo-dev-menu-interface
-    - ExpoModulesCore
-    - EXUpdatesInterface
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-jsinspector
-    - React-NativeModulesApple
-    - React-RCTAppDelegate
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactAppDependencyProvider
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - expo-dev-launcher/Unsafe (56.0.16):
+  - expo-dev-launcher (57.0.10):
     - boost
     - DoubleConversion
     - EXManifests
@@ -155,10 +81,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu (56.0.15):
+  - expo-dev-menu (57.0.10):
     - boost
     - DoubleConversion
-    - expo-dev-menu/Main (= 56.0.15)
+    - expo-dev-menu/Main (= 57.0.10)
     - fast_float
     - fmt
     - glog
@@ -184,8 +110,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu-interface (56.0.1)
-  - expo-dev-menu/Main (56.0.15):
+  - expo-dev-menu-interface (57.0.0)
+  - expo-dev-menu/Main (57.0.10):
     - boost
     - DoubleConversion
     - EXManifests
@@ -217,29 +143,29 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ExpoAsset (56.0.15):
+  - ExpoAsset (57.0.8):
     - ExpoModulesCore
-  - ExpoClipboard (56.0.3):
+  - ExpoClipboard (57.0.1):
     - ExpoModulesCore
-  - ExpoCrypto (56.0.4):
+  - ExpoCrypto (57.0.1):
     - ExpoModulesCore
-  - ExpoFileSystem (56.0.7):
+  - ExpoFileSystem (57.0.1):
     - ExpoModulesCore
-  - ExpoFont (56.0.5):
+  - ExpoFont (57.0.1):
     - ExpoModulesCore
-  - ExpoKeepAwake (56.0.3):
+  - ExpoKeepAwake (57.0.1):
     - ExpoModulesCore
-  - ExpoLinearGradient (56.0.4):
+  - ExpoLinearGradient (57.0.1):
     - ExpoModulesCore
-  - ExpoLinking (56.0.12):
+  - ExpoLinking (57.0.4):
     - ExpoModulesCore
-  - ExpoLocalAuthentication (56.0.4):
+  - ExpoLocalAuthentication (57.0.2):
     - ExpoModulesCore
-  - ExpoLogBox (56.0.12):
+  - ExpoLogBox (57.0.2):
     - React-Core
-  - ExpoMeshGradient (56.0.3):
+  - ExpoMeshGradient (57.0.1):
     - ExpoModulesCore
-  - ExpoModulesCore (56.0.13):
+  - ExpoModulesCore (57.0.8):
     - boost
     - DoubleConversion
     - ExpoModulesJSI
@@ -269,27 +195,31 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ExpoModulesJSI (56.0.7):
+  - ExpoModulesJSI (57.0.4):
     - React-Core
     - ReactCommon
-  - ExpoModulesWorklets (56.0.13):
+  - ExpoModulesWorklets (57.0.8):
     - ExpoModulesCore
     - ExpoModulesJSI
-  - ExpoModulesWorkletsAdapter (56.0.13):
+  - ExpoModulesWorkletsAdapter (57.0.8):
     - ExpoModulesCore
     - ExpoModulesJSI
     - ExpoModulesWorklets
     - RNWorklets
-  - ExpoNetwork (56.0.4):
+  - ExpoNetwork (57.0.1):
     - ExpoModulesCore
-  - ExpoSQLite (56.0.4):
+  - ExpoSQLite (57.0.1):
     - ExpoModulesCore
-  - ExpoSymbols (56.0.5):
+  - ExpoSymbols (57.0.1):
     - ExpoModulesCore
-  - ExpoWebBrowser (56.0.5):
+  - ExpoUI (57.0.8):
     - ExpoModulesCore
-  - EXStructuredHeaders (56.0.0)
-  - EXUpdates (56.0.17):
+    - ExpoModulesWorklets
+    - React-RCTFabric
+  - ExpoWebBrowser (57.0.2):
+    - ExpoModulesCore
+  - EXStructuredHeaders (57.0.0)
+  - EXUpdates (57.0.11):
     - boost
     - DoubleConversion
     - EASClient
@@ -323,10 +253,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - EXUpdatesInterface (56.0.2):
+  - EXUpdatesInterface (57.0.1):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.8)
+  - FBLazyVector (0.81.9)
   - fmt (12.1.0)
   - glog (0.3.5)
   - hermes-engine (0.81.6):
@@ -351,28 +281,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 12.1.0)
     - glog
-  - RCTDeprecation (0.81.8)
-  - RCTRequired (0.81.8)
-  - RCTTypeSafety (0.81.8):
-    - FBLazyVector (= 0.81.8)
-    - RCTRequired (= 0.81.8)
-    - React-Core (= 0.81.8)
+  - RCTDeprecation (0.81.9)
+  - RCTRequired (0.81.9)
+  - RCTTypeSafety (0.81.9):
+    - FBLazyVector (= 0.81.9)
+    - RCTRequired (= 0.81.9)
+    - React-Core (= 0.81.9)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.8):
-    - React-Core (= 0.81.8)
-    - React-Core/DevSupport (= 0.81.8)
-    - React-Core/RCTWebSocket (= 0.81.8)
-    - React-RCTActionSheet (= 0.81.8)
-    - React-RCTAnimation (= 0.81.8)
-    - React-RCTBlob (= 0.81.8)
-    - React-RCTImage (= 0.81.8)
-    - React-RCTLinking (= 0.81.8)
-    - React-RCTNetwork (= 0.81.8)
-    - React-RCTSettings (= 0.81.8)
-    - React-RCTText (= 0.81.8)
-    - React-RCTVibration (= 0.81.8)
-  - React-callinvoker (0.81.8)
-  - React-Core (0.81.8):
+  - React (0.81.9):
+    - React-Core (= 0.81.9)
+    - React-Core/DevSupport (= 0.81.9)
+    - React-Core/RCTWebSocket (= 0.81.9)
+    - React-RCTActionSheet (= 0.81.9)
+    - React-RCTAnimation (= 0.81.9)
+    - React-RCTBlob (= 0.81.9)
+    - React-RCTImage (= 0.81.9)
+    - React-RCTLinking (= 0.81.9)
+    - React-RCTNetwork (= 0.81.9)
+    - React-RCTSettings (= 0.81.9)
+    - React-RCTText (= 0.81.9)
+    - React-RCTVibration (= 0.81.9)
+  - React-callinvoker (0.81.9)
+  - React-Core (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -382,7 +312,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.8)
+    - React-Core/Default (= 0.81.9)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -397,82 +327,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.8):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.8):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.8):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.8)
-    - React-Core/RCTWebSocket (= 0.81.8)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.8):
+  - React-Core/CoreModulesHeaders (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -497,7 +352,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.8):
+  - React-Core/Default (0.81.9):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.9):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.9)
+    - React-Core/RCTWebSocket (= 0.81.9)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -522,7 +427,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.8):
+  - React-Core/RCTAnimationHeaders (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -547,7 +452,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.8):
+  - React-Core/RCTBlobHeaders (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -572,7 +477,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.8):
+  - React-Core/RCTImageHeaders (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -597,7 +502,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.8):
+  - React-Core/RCTLinkingHeaders (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -622,7 +527,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.8):
+  - React-Core/RCTNetworkHeaders (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -647,7 +552,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.8):
+  - React-Core/RCTSettingsHeaders (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -672,7 +577,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.8):
+  - React-Core/RCTTextHeaders (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -697,7 +602,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.8):
+  - React-Core/RCTVibrationHeaders (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -707,7 +612,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.8)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -722,7 +627,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.8):
+  - React-Core/RCTWebSocket (0.81.9):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.9)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -730,20 +660,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.8)
-    - React-Core/CoreModulesHeaders (= 0.81.8)
-    - React-jsi (= 0.81.8)
+    - RCTTypeSafety (= 0.81.9)
+    - React-Core/CoreModulesHeaders (= 0.81.9)
+    - React-jsi (= 0.81.9)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.8)
+    - React-RCTImage (= 0.81.9)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.8):
+  - React-cxxreact (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -752,19 +682,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.8)
-    - React-debug (= 0.81.8)
-    - React-jsi (= 0.81.8)
+    - React-callinvoker (= 0.81.9)
+    - React-debug (= 0.81.9)
+    - React-jsi (= 0.81.9)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.8)
-    - React-perflogger (= 0.81.8)
+    - React-logger (= 0.81.9)
+    - React-perflogger (= 0.81.9)
     - React-runtimeexecutor
-    - React-timing (= 0.81.8)
+    - React-timing (= 0.81.9)
     - SocketRocket
-  - React-debug (0.81.8)
-  - React-defaultsnativemodule (0.81.8):
+  - React-debug (0.81.9)
+  - React-defaultsnativemodule (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -781,7 +711,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.8):
+  - React-domnativemodule (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -801,7 +731,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.8):
+  - React-Fabric (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -815,23 +745,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.8)
-    - React-Fabric/attributedstring (= 0.81.8)
-    - React-Fabric/bridging (= 0.81.8)
-    - React-Fabric/componentregistry (= 0.81.8)
-    - React-Fabric/componentregistrynative (= 0.81.8)
-    - React-Fabric/components (= 0.81.8)
-    - React-Fabric/consistency (= 0.81.8)
-    - React-Fabric/core (= 0.81.8)
-    - React-Fabric/dom (= 0.81.8)
-    - React-Fabric/imagemanager (= 0.81.8)
-    - React-Fabric/leakchecker (= 0.81.8)
-    - React-Fabric/mounting (= 0.81.8)
-    - React-Fabric/observers (= 0.81.8)
-    - React-Fabric/scheduler (= 0.81.8)
-    - React-Fabric/telemetry (= 0.81.8)
-    - React-Fabric/templateprocessor (= 0.81.8)
-    - React-Fabric/uimanager (= 0.81.8)
+    - React-Fabric/animations (= 0.81.9)
+    - React-Fabric/attributedstring (= 0.81.9)
+    - React-Fabric/bridging (= 0.81.9)
+    - React-Fabric/componentregistry (= 0.81.9)
+    - React-Fabric/componentregistrynative (= 0.81.9)
+    - React-Fabric/components (= 0.81.9)
+    - React-Fabric/consistency (= 0.81.9)
+    - React-Fabric/core (= 0.81.9)
+    - React-Fabric/dom (= 0.81.9)
+    - React-Fabric/imagemanager (= 0.81.9)
+    - React-Fabric/leakchecker (= 0.81.9)
+    - React-Fabric/mounting (= 0.81.9)
+    - React-Fabric/observers (= 0.81.9)
+    - React-Fabric/scheduler (= 0.81.9)
+    - React-Fabric/telemetry (= 0.81.9)
+    - React-Fabric/templateprocessor (= 0.81.9)
+    - React-Fabric/uimanager (= 0.81.9)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -843,32 +773,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.8):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.8):
+  - React-Fabric/animations (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -893,7 +798,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.8):
+  - React-Fabric/attributedstring (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -918,7 +823,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.8):
+  - React-Fabric/bridging (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -943,7 +848,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.8):
+  - React-Fabric/componentregistry (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -968,36 +873,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.8):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.8)
-    - React-Fabric/components/root (= 0.81.8)
-    - React-Fabric/components/scrollview (= 0.81.8)
-    - React-Fabric/components/view (= 0.81.8)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.8):
+  - React-Fabric/componentregistrynative (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1022,7 +898,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.8):
+  - React-Fabric/components (0.81.9):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.9)
+    - React-Fabric/components/root (= 0.81.9)
+    - React-Fabric/components/scrollview (= 0.81.9)
+    - React-Fabric/components/view (= 0.81.9)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1047,7 +952,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.8):
+  - React-Fabric/components/root (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1072,7 +977,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.8):
+  - React-Fabric/components/scrollview (0.81.9):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1099,7 +1029,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.8):
+  - React-Fabric/consistency (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1124,7 +1054,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.8):
+  - React-Fabric/core (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1149,7 +1079,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.8):
+  - React-Fabric/dom (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1174,7 +1104,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.8):
+  - React-Fabric/imagemanager (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1199,7 +1129,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.8):
+  - React-Fabric/leakchecker (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1224,7 +1154,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.8):
+  - React-Fabric/mounting (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1249,7 +1179,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.8):
+  - React-Fabric/observers (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1263,7 +1193,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.8)
+    - React-Fabric/observers/events (= 0.81.9)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1275,7 +1205,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.8):
+  - React-Fabric/observers/events (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1300,7 +1230,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.8):
+  - React-Fabric/scheduler (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1327,7 +1257,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.8):
+  - React-Fabric/telemetry (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1352,7 +1282,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.8):
+  - React-Fabric/templateprocessor (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1377,7 +1307,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.8):
+  - React-Fabric/uimanager (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1391,7 +1321,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.8)
+    - React-Fabric/uimanager/consistency (= 0.81.9)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1404,7 +1334,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.8):
+  - React-Fabric/uimanager/consistency (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1430,7 +1360,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.8):
+  - React-FabricComponents (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1445,8 +1375,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.8)
-    - React-FabricComponents/textlayoutmanager (= 0.81.8)
+    - React-FabricComponents/components (= 0.81.9)
+    - React-FabricComponents/textlayoutmanager (= 0.81.9)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1459,7 +1389,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.8):
+  - React-FabricComponents/components (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1474,17 +1404,16 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.8)
-    - React-FabricComponents/components/iostextinput (= 0.81.8)
-    - React-FabricComponents/components/modal (= 0.81.8)
-    - React-FabricComponents/components/rncore (= 0.81.8)
-    - React-FabricComponents/components/safeareaview (= 0.81.8)
-    - React-FabricComponents/components/scrollview (= 0.81.8)
-    - React-FabricComponents/components/switch (= 0.81.8)
-    - React-FabricComponents/components/text (= 0.81.8)
-    - React-FabricComponents/components/textinput (= 0.81.8)
-    - React-FabricComponents/components/unimplementedview (= 0.81.8)
-    - React-FabricComponents/components/virtualview (= 0.81.8)
+    - React-FabricComponents/components/inputaccessory (= 0.81.9)
+    - React-FabricComponents/components/iostextinput (= 0.81.9)
+    - React-FabricComponents/components/modal (= 0.81.9)
+    - React-FabricComponents/components/rncore (= 0.81.9)
+    - React-FabricComponents/components/safeareaview (= 0.81.9)
+    - React-FabricComponents/components/switch (= 0.81.9)
+    - React-FabricComponents/components/text (= 0.81.9)
+    - React-FabricComponents/components/textinput (= 0.81.9)
+    - React-FabricComponents/components/unimplementedview (= 0.81.9)
+    - React-FabricComponents/components/virtualview (= 0.81.9)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1497,34 +1426,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.8):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.8):
+  - React-FabricComponents/components/inputaccessory (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1551,7 +1453,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.8):
+  - React-FabricComponents/components/iostextinput (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1578,7 +1480,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.8):
+  - React-FabricComponents/components/modal (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1605,7 +1507,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.8):
+  - React-FabricComponents/components/rncore (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1632,7 +1534,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.8):
+  - React-FabricComponents/components/safeareaview (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1659,7 +1561,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.81.8):
+  - React-FabricComponents/components/switch (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1686,7 +1588,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.8):
+  - React-FabricComponents/components/text (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1713,7 +1615,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.8):
+  - React-FabricComponents/components/textinput (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1740,7 +1642,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.8):
+  - React-FabricComponents/components/unimplementedview (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1767,7 +1669,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.8):
+  - React-FabricComponents/components/virtualview (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1794,7 +1696,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.8):
+  - React-FabricComponents/textlayoutmanager (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1821,7 +1723,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.8):
+  - React-FabricImage (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1830,21 +1732,21 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.8)
-    - RCTTypeSafety (= 0.81.8)
+    - RCTRequired (= 0.81.9)
+    - RCTTypeSafety (= 0.81.9)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.8)
+    - React-jsiexecutor (= 0.81.9)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.8):
+  - React-featureflags (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1853,7 +1755,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.8):
+  - React-featureflagsnativemodule (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1868,7 +1770,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.8):
+  - React-graphics (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1882,7 +1784,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.8):
+  - React-hermes (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1891,16 +1793,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.8)
+    - React-cxxreact (= 0.81.9)
     - React-jsi
-    - React-jsiexecutor (= 0.81.8)
+    - React-jsiexecutor (= 0.81.9)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.8)
+    - React-perflogger (= 0.81.9)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.8):
+  - React-idlecallbacksnativemodule (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1916,7 +1818,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.8):
+  - React-ImageManager (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1931,7 +1833,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.8):
+  - React-jserrorhandler (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1946,7 +1848,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.8):
+  - React-jsi (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1956,7 +1858,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.8):
+  - React-jsiexecutor (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1965,15 +1867,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.8)
-    - React-jsi (= 0.81.8)
+    - React-cxxreact (= 0.81.9)
+    - React-jsi (= 0.81.9)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.8)
+    - React-perflogger (= 0.81.9)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.8):
+  - React-jsinspector (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -1988,10 +1890,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.8)
+    - React-perflogger (= 0.81.9)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.8):
+  - React-jsinspectorcdp (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2000,7 +1902,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.8):
+  - React-jsinspectornetwork (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2013,7 +1915,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.8):
+  - React-jsinspectortracing (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2024,7 +1926,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.8):
+  - React-jsitooling (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2032,16 +1934,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.8)
-    - React-jsi (= 0.81.8)
+    - React-cxxreact (= 0.81.9)
+    - React-jsi (= 0.81.9)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.8):
+  - React-jsitracing (0.81.9):
     - React-jsi
-  - React-logger (0.81.8):
+  - React-logger (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2050,7 +1952,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.8):
+  - React-Mapbuffer (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2060,7 +1962,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.8):
+  - React-microtasksnativemodule (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2102,7 +2004,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-skia (2.4.18):
+  - react-native-skia (2.6.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2160,7 +2062,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.81.8):
+  - React-NativeModulesApple (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2180,8 +2082,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.8)
-  - React-perflogger (0.81.8):
+  - React-oscompat (0.81.9)
+  - React-perflogger (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2190,7 +2092,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.8):
+  - React-performancetimeline (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2203,9 +2105,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.8):
-    - React-Core/RCTActionSheetHeaders (= 0.81.8)
-  - React-RCTAnimation (0.81.8):
+  - React-RCTActionSheet (0.81.9):
+    - React-Core/RCTActionSheetHeaders (= 0.81.9)
+  - React-RCTAnimation (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2221,7 +2123,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.8):
+  - React-RCTAppDelegate (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2255,7 +2157,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.8):
+  - React-RCTBlob (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2274,7 +2176,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.8):
+  - React-RCTFabric (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2309,7 +2211,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.8):
+  - React-RCTFBReactNativeSpec (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2323,10 +2225,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.8)
+    - React-RCTFBReactNativeSpec/components (= 0.81.9)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.8):
+  - React-RCTFBReactNativeSpec/components (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2349,7 +2251,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.8):
+  - React-RCTImage (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2365,14 +2267,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.8):
-    - React-Core/RCTLinkingHeaders (= 0.81.8)
-    - React-jsi (= 0.81.8)
+  - React-RCTLinking (0.81.9):
+    - React-Core/RCTLinkingHeaders (= 0.81.9)
+    - React-jsi (= 0.81.9)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.8)
-  - React-RCTNetwork (0.81.8):
+    - ReactCommon/turbomodule/core (= 0.81.9)
+  - React-RCTNetwork (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2390,7 +2292,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.8):
+  - React-RCTRuntime (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2410,7 +2312,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.8):
+  - React-RCTSettings (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2425,10 +2327,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.8):
-    - React-Core/RCTTextHeaders (= 0.81.8)
+  - React-RCTText (0.81.9):
+    - React-Core/RCTTextHeaders (= 0.81.9)
     - Yoga
-  - React-RCTVibration (0.81.8):
+  - React-RCTVibration (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2442,11 +2344,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.8)
-  - React-renderercss (0.81.8):
+  - React-rendererconsistency (0.81.9)
+  - React-renderercss (0.81.9):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.8):
+  - React-rendererdebug (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2456,7 +2358,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.8):
+  - React-RuntimeApple (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2485,7 +2387,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.8):
+  - React-RuntimeCore (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2507,7 +2409,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.8):
+  - React-runtimeexecutor (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2517,10 +2419,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.8)
+    - React-jsi (= 0.81.9)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.8):
+  - React-RuntimeHermes (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2541,7 +2443,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.8):
+  - React-runtimescheduler (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2563,9 +2465,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.8):
+  - React-timing (0.81.9):
     - React-debug
-  - React-utils (0.81.8):
+  - React-utils (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2575,11 +2477,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.8)
+    - React-jsi (= 0.81.9)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.8):
+  - ReactAppDependencyProvider (0.81.9):
     - ReactCodegen
-  - ReactCodegen (0.81.8):
+  - ReactCodegen (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2605,7 +2507,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.8):
+  - ReactCommon (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2613,9 +2515,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.8)
+    - ReactCommon/turbomodule (= 0.81.9)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.8):
+  - ReactCommon/turbomodule (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2624,15 +2526,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.8)
-    - React-cxxreact (= 0.81.8)
-    - React-jsi (= 0.81.8)
-    - React-logger (= 0.81.8)
-    - React-perflogger (= 0.81.8)
-    - ReactCommon/turbomodule/bridging (= 0.81.8)
-    - ReactCommon/turbomodule/core (= 0.81.8)
+    - React-callinvoker (= 0.81.9)
+    - React-cxxreact (= 0.81.9)
+    - React-jsi (= 0.81.9)
+    - React-logger (= 0.81.9)
+    - React-perflogger (= 0.81.9)
+    - ReactCommon/turbomodule/bridging (= 0.81.9)
+    - ReactCommon/turbomodule/core (= 0.81.9)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.8):
+  - ReactCommon/turbomodule/bridging (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2641,13 +2543,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.8)
-    - React-cxxreact (= 0.81.8)
-    - React-jsi (= 0.81.8)
-    - React-logger (= 0.81.8)
-    - React-perflogger (= 0.81.8)
+    - React-callinvoker (= 0.81.9)
+    - React-cxxreact (= 0.81.9)
+    - React-jsi (= 0.81.9)
+    - React-logger (= 0.81.9)
+    - React-perflogger (= 0.81.9)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.8):
+  - ReactCommon/turbomodule/core (0.81.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2656,14 +2558,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.8)
-    - React-cxxreact (= 0.81.8)
-    - React-debug (= 0.81.8)
-    - React-featureflags (= 0.81.8)
-    - React-jsi (= 0.81.8)
-    - React-logger (= 0.81.8)
-    - React-perflogger (= 0.81.8)
-    - React-utils (= 0.81.8)
+    - React-callinvoker (= 0.81.9)
+    - React-cxxreact (= 0.81.9)
+    - React-debug (= 0.81.9)
+    - React-featureflags (= 0.81.9)
+    - React-jsi (= 0.81.9)
+    - React-logger (= 0.81.9)
+    - React-perflogger (= 0.81.9)
+    - React-utils (= 0.81.9)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -2693,7 +2595,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNGestureHandler (2.32.0):
+  - RNGestureHandler (3.1.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2721,41 +2623,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated (4.5.0):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-jsitooling
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNReanimated/apple (= 4.5.0)
-    - RNReanimated/common (= 4.5.0)
-    - RNReanimated/view (= 4.5.0)
-    - RNWorklets
-    - SocketRocket
-    - Yoga
-  - RNReanimated/apple (4.5.0):
+  - RNReanimated (4.5.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2783,10 +2651,13 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
+    - RNReanimated/apple (= 4.5.1)
+    - RNReanimated/common (= 4.5.1)
+    - RNReanimated/view (= 4.5.1)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/common (4.5.0):
+  - RNReanimated/apple (4.5.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2817,7 +2688,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/view (4.5.0):
+  - RNReanimated/common (4.5.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2848,7 +2719,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNWorklets (0.10.0):
+  - RNReanimated/view (4.5.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2876,11 +2747,42 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/apple (= 0.10.0)
-    - RNWorklets/common (= 0.10.0)
+    - RNWorklets
     - SocketRocket
     - Yoga
-  - RNWorklets/apple (0.10.0):
+  - RNWorklets (0.10.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-jsitooling
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNWorklets/apple (= 0.10.1)
+    - RNWorklets/common (= 0.10.1)
+    - SocketRocket
+    - Yoga
+  - RNWorklets/apple (0.10.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2910,7 +2812,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets/common (0.10.0):
+  - RNWorklets/common (0.10.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2972,6 +2874,7 @@ DEPENDENCIES:
   - ExpoNetwork (from `../../../packages/expo-network/ios`)
   - ExpoSQLite (from `../../../packages/expo-sqlite/ios`)
   - ExpoSymbols (from `../../../packages/expo-symbols/ios`)
+  - ExpoUI (from `../../../packages/expo-ui/ios`)
   - ExpoWebBrowser (from `../../../packages/expo-web-browser/ios`)
   - EXStructuredHeaders (from `../../../packages/expo-structured-headers/ios`)
   - EXUpdates (from `../../../packages/expo-updates/ios`)
@@ -3015,9 +2918,9 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native-macos/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native-macos/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native-macos/ReactCommon/react/nativemodule/microtasks`)
-  - "react-native-netinfo (from `../../../node_modules/.pnpm/@react-native-community+netinfo@12.0.1_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_865d02cabcce576cfb49c3440e59e525/node_modules/@react-native-community/netinfo`)"
-  - "react-native-skia (from `../../../node_modules/.pnpm/@shopify+react-native-skia@2.4.18_71649f90ed6bd3f9def977a43f88e93b/node_modules/@shopify/react-native-skia`)"
-  - "react-native-webview (from `../../../node_modules/.pnpm/react-native-webview@13.16.1_react-native@0.86.0_patch_hash=621e3afe641a0d7facd6172cf2a_2ad29fc6ed84400bc7c1b37294513663/node_modules/react-native-webview`)"
+  - "react-native-netinfo (from `../../../node_modules/.pnpm/@react-native-community+netinfo@12.0.1_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_bbd5d11770d774ea0db93c2d325ee765/node_modules/@react-native-community/netinfo`)"
+  - "react-native-skia (from `../../../node_modules/.pnpm/@shopify+react-native-skia@2.6.2_patch_hash=ba884424a75156115606f768b005e5af9a39e9836f1_a1aba5c4a307685832aa84c92f85f91a/node_modules/@shopify/react-native-skia`)"
+  - "react-native-webview (from `../../../node_modules/.pnpm/react-native-webview@13.16.1_react-native@0.86.0_patch_hash=621e3afe641a0d7facd6172cf2a_91f95875546f68da1f9545986f3115f4/node_modules/react-native-webview`)"
   - React-NativeModulesApple (from `../node_modules/react-native-macos/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native-macos/ReactCommon/oscompat`)
   - React-perflogger (from `../node_modules/react-native-macos/ReactCommon/reactperflogger`)
@@ -3048,10 +2951,10 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native-macos/ReactCommon`)
-  - "RNCAsyncStorage (from `../../../node_modules/.pnpm/@react-native-async-storage+async-storage@2.2.0_react-native@0.86.0_patch_hash=621e3afe_66d5f5ec4ae21dbc551ca70b9b6398ff/node_modules/@react-native-async-storage/async-storage`)"
-  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_patch_hash=621e3afe641a0d7facd6_39b75e4a70338f171d6684faf7ca9570/node_modules/react-native-gesture-handler`)"
-  - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.5.0_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_b822792399a9e605f420cce8ab3589aa/node_modules/react-native-reanimated`)"
-  - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.10.0_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_4a3ca1186fdd18dd396468f99cf10366/node_modules/react-native-worklets`)"
+  - "RNCAsyncStorage (from `../../../node_modules/.pnpm/@react-native-async-storage+async-storage@2.2.0_react-native@0.86.0_patch_hash=621e3afe_8aa95b4e24bb9e685b4d02337a2e9626/node_modules/@react-native-async-storage/async-storage`)"
+  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@3.1.0_react-native@0.86.0_patch_hash=621e3afe641a0d7facd61_bc64dbd7156a24b4d7b3bc13483d23c6/node_modules/react-native-gesture-handler`)"
+  - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_91fb65ffc1e42bf5537ed72b3be73cd7/node_modules/react-native-reanimated`)"
+  - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.10.1_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_c4f47e1b471e074b29d323b92289af75/node_modules/react-native-worklets`)"
   - SocketRocket (~> 0.7.1)
   - Yoga (from `../node_modules/react-native-macos/ReactCommon/yoga`)
 
@@ -3142,6 +3045,9 @@ EXTERNAL SOURCES:
   ExpoSymbols:
     inhibit_warnings: false
     :path: "../../../packages/expo-symbols/ios"
+  ExpoUI:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-ui/ios"
   ExpoWebBrowser:
     inhibit_warnings: false
     :path: "../../../packages/expo-web-browser/ios"
@@ -3232,11 +3138,11 @@ EXTERNAL SOURCES:
   React-microtasksnativemodule:
     :path: "../node_modules/react-native-macos/ReactCommon/react/nativemodule/microtasks"
   react-native-netinfo:
-    :path: "../../../node_modules/.pnpm/@react-native-community+netinfo@12.0.1_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_865d02cabcce576cfb49c3440e59e525/node_modules/@react-native-community/netinfo"
+    :path: "../../../node_modules/.pnpm/@react-native-community+netinfo@12.0.1_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_bbd5d11770d774ea0db93c2d325ee765/node_modules/@react-native-community/netinfo"
   react-native-skia:
-    :path: "../../../node_modules/.pnpm/@shopify+react-native-skia@2.4.18_71649f90ed6bd3f9def977a43f88e93b/node_modules/@shopify/react-native-skia"
+    :path: "../../../node_modules/.pnpm/@shopify+react-native-skia@2.6.2_patch_hash=ba884424a75156115606f768b005e5af9a39e9836f1_a1aba5c4a307685832aa84c92f85f91a/node_modules/@shopify/react-native-skia"
   react-native-webview:
-    :path: "../../../node_modules/.pnpm/react-native-webview@13.16.1_react-native@0.86.0_patch_hash=621e3afe641a0d7facd6172cf2a_2ad29fc6ed84400bc7c1b37294513663/node_modules/react-native-webview"
+    :path: "../../../node_modules/.pnpm/react-native-webview@13.16.1_react-native@0.86.0_patch_hash=621e3afe641a0d7facd6172cf2a_91f95875546f68da1f9545986f3115f4/node_modules/react-native-webview"
   React-NativeModulesApple:
     :path: "../node_modules/react-native-macos/ReactCommon/react/nativemodule/core/platform/ios"
   React-oscompat:
@@ -3298,127 +3204,128 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native-macos/ReactCommon"
   RNCAsyncStorage:
-    :path: "../../../node_modules/.pnpm/@react-native-async-storage+async-storage@2.2.0_react-native@0.86.0_patch_hash=621e3afe_66d5f5ec4ae21dbc551ca70b9b6398ff/node_modules/@react-native-async-storage/async-storage"
+    :path: "../../../node_modules/.pnpm/@react-native-async-storage+async-storage@2.2.0_react-native@0.86.0_patch_hash=621e3afe_8aa95b4e24bb9e685b4d02337a2e9626/node_modules/@react-native-async-storage/async-storage"
   RNGestureHandler:
-    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@2.32.0_react-native@0.86.0_patch_hash=621e3afe641a0d7facd6_39b75e4a70338f171d6684faf7ca9570/node_modules/react-native-gesture-handler"
+    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@3.1.0_react-native@0.86.0_patch_hash=621e3afe641a0d7facd61_bc64dbd7156a24b4d7b3bc13483d23c6/node_modules/react-native-gesture-handler"
   RNReanimated:
-    :path: "../../../node_modules/.pnpm/react-native-reanimated@4.5.0_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_b822792399a9e605f420cce8ab3589aa/node_modules/react-native-reanimated"
+    :path: "../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_91fb65ffc1e42bf5537ed72b3be73cd7/node_modules/react-native-reanimated"
   RNWorklets:
-    :path: "../../../node_modules/.pnpm/react-native-worklets@0.10.0_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_4a3ca1186fdd18dd396468f99cf10366/node_modules/react-native-worklets"
+    :path: "../../../node_modules/.pnpm/react-native-worklets@0.10.1_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_c4f47e1b471e074b29d323b92289af75/node_modules/react-native-worklets"
   Yoga:
     :path: "../node_modules/react-native-macos/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
   boost: cea1d4f90a3a59537f3deb03ff5656489d7133dd
   DoubleConversion: d31b1eb37f6d6f456530c4fd9124b857d6889cab
-  EASClient: 2321f8d99fa86c710a6f68e017f3b54366baed9f
-  EXConstants: 1c400bb9969f4c9e5ab324553138b74ae47b9efe
-  EXManifests: 7e19be8df665a338493060a419847dae76ffcd43
-  Expo: 2f84590402ecef7c27722177775b38bdb8b7439d
-  expo-dev-client: 47bd82ac19bbfce73d04f9140f4a607b8468dde7
-  expo-dev-launcher: 5bc1f37618e01dd78f4731192c9482cdba25292c
-  expo-dev-menu: d21ab72323c504ed0a5e1c4604a64afe77e74f7b
-  expo-dev-menu-interface: 65402d4affb8b418aa6cec29b3abb0e313c8f443
-  ExpoAsset: c2e7b5ba1fe75be683282d6264e38fd7cd8defbb
-  ExpoClipboard: 40221903a1caa68259e022517af49d12962821fe
-  ExpoCrypto: b54a97c4357d46d7f8de079e69fa89029572244b
-  ExpoFileSystem: d730a1cb33f2c91dec01561f0d710054fda32ae9
-  ExpoFont: 6fe496f2be617ed4367f159f215dcc4ba27d37d6
-  ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
-  ExpoLinearGradient: 16c2b9c6105444883d34958d573725de1293b8d0
-  ExpoLinking: 82458b046854a5802092a37a5228a8a228f928a4
-  ExpoLocalAuthentication: 93f29833d2a8b957f996eddc05a632eb2bdeaa7d
-  ExpoLogBox: 7aa03244fe5eeced5129e4ec7ad5bd9a3994378e
-  ExpoMeshGradient: baf62012104fd9c1719de67f88c69958abcd2ed1
-  ExpoModulesCore: 2f9f4e243ddc998ba151ed74df97cec90a0e7ae7
-  ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
-  ExpoModulesWorklets: 874ceeb92a8da1dfa32adf197aa65f926e74b9c5
-  ExpoModulesWorkletsAdapter: 6d23c1e7a078075c4885c3595c335b9c8c1511bb
-  ExpoNetwork: d244aa406eb0aba7e36e5f009a061b2744ab11d7
-  ExpoSQLite: 38a35f67bbb3370d9bb859aa65d106909c4e3b19
-  ExpoSymbols: b3c964ddc1f1c8d8ddb0eeb830e3a8e42b77ed2d
-  ExpoWebBrowser: 6e3d90e3fe1952d21a8494872b1e1a485cd50e2f
-  EXStructuredHeaders: 9e89bcdd636ae2ecb59995cfba3230f5d7547c08
-  EXUpdates: f729bd14cd6088ca8e65013515ff15dfa2328082
-  EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
+  EASClient: 81f44ce9f07ec3d01606507213d21510a5f97388
+  EXConstants: 5efe6122eecac2d970aa50a2a502ecc6ce4b7564
+  EXManifests: f9888c0bf5aaa6ddb7e3d4b224d6d54ac4ca84a4
+  Expo: 3f63bd27f754689bab053910280cbeae79256b4e
+  expo-dev-client: 678dd58df0bd6d3486b8b358e37c79ca67d32af5
+  expo-dev-launcher: a16e4fb685df32e831a67818a3143d9c4155fccc
+  expo-dev-menu: 36d4306eab2e3191fbdaff80de68492e028550d0
+  expo-dev-menu-interface: 7a59e803916fbfd1b96c75ff91ea8dddac7e722f
+  ExpoAsset: a76534cf7b762978861dd31708308496c676166f
+  ExpoClipboard: 95055b11758f339b61d4d8064dd799df1cf03b7f
+  ExpoCrypto: 366380ffafeb22cc9795438cddcbfa299e1aaf42
+  ExpoFileSystem: e441dae0ae671fc451640517550973d9e024fdf0
+  ExpoFont: 59e1faf66ba9bcd232ae1e2ce58d202a48b6f65e
+  ExpoKeepAwake: c26f14275017370cc8a4b7b43a0e23361f2053a5
+  ExpoLinearGradient: 903b3f5fe566c666ff78b2599add51d094483613
+  ExpoLinking: 5a796f9284535c0349537a844dd40680229b7fcb
+  ExpoLocalAuthentication: 96989637e567a10cdeabe61e5c6026d30c0dc53f
+  ExpoLogBox: 6bb73c341aca22e699bd4da6cc61afc844e1a648
+  ExpoMeshGradient: ade33604a92081a2deda41c6107e7d080493012d
+  ExpoModulesCore: 58a54fdbe5cfd2d7f4a183a813639ce22a700d66
+  ExpoModulesJSI: b20fefa4cdd9097e7e6b715466d1900b8c5d4711
+  ExpoModulesWorklets: 6b240031daa3de4df791588fc78236637ff602f6
+  ExpoModulesWorkletsAdapter: 356b6b94d822b881a183306a41594f09b85ba0c1
+  ExpoNetwork: 973d523fe9b1f99223dd945fed9ad1226ae64920
+  ExpoSQLite: ddd65ed74bdebcff20f6766e682f9321ecb28ab8
+  ExpoSymbols: 7c7c7bd3c52f0b6dcbba6e8af4088b0dc1ea7d29
+  ExpoUI: 3f8335f6e5ff5c4457c216e417be69ac26f81706
+  ExpoWebBrowser: 9b98d939d5f1c5dd8f523f0a0683056fb1204434
+  EXStructuredHeaders: 1423c3602a30eb078e03b63b251ef912267dd4c0
+  EXUpdates: b424196b8bc40238147f21aa2ba17c348758e187
+  EXUpdatesInterface: 92d2aa5194b6fb93ca8ab749db75665cb28b2e60
   fast_float: 20817c22759af6ac8d4d67e6e059b8b499953656
-  FBLazyVector: 3b2a51be15bc2f31a5e38d1bb4c007eef833372b
+  FBLazyVector: 3cde5aa3abeda29fd70560e5a3e3199e6add163f
   fmt: 4cf0c5ec5864511c96d8d4bd7b03c3c69040af06
   glog: 0b31c25149b9d350b2666c7d459229861a00ec07
   hermes-engine: 7219f6e751ad6ec7f3d7ec121830ee34dae40749
   RCT-Folly: a3d9b23289a456c318f4814703664bdc33c771cc
-  RCTDeprecation: 777decf5c531f5f1ce3cf2b292e9c4b07e0d3253
-  RCTRequired: 52ab26a5abbaec60bc25f9b00e46c55be4facfc6
-  RCTTypeSafety: 7f9692e86dc2e7bb49f20731ce17638543c501d2
+  RCTDeprecation: ae9e1391708bf992a2a94fb724b0923015be995b
+  RCTRequired: eb7a65dfaf816b64d40e1c96e4fc597bfa28bedc
+  RCTTypeSafety: a54e58687e664b1bfe9e45d2a8f8a53895d0a3eb
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: f879e4fe279376e17d96a9f8ffc383c82f375283
-  React-callinvoker: 8bbc7484f58f559645d4bdd04052a5bdcfad7aad
-  React-Core: 7fc11c8ef2f77e422f62d845a86fb7b7cf4edb79
-  React-CoreModules: 7f5c43a6c5890e2e4055259bc5856aac7e5ef41f
-  React-cxxreact: 5fd1ead32854b87bfd3035bae004d2b32bc0b582
-  React-debug: 1621ceca6bb14a8f02bff4d1b2e5de87185aceb8
-  React-defaultsnativemodule: 8555b9f7a1b4f93f836921842687748b57b9f8d6
-  React-domnativemodule: 957a2b1fad9e59ee3a9fe682356303950915668f
-  React-Fabric: 275eb16cff2a35b91fa7692ea02d2dc9239d903c
-  React-FabricComponents: 0a695bd01bf13df7ab12e644a60361474ec9ae9a
-  React-FabricImage: 1139abad409bbbe84290b7a7d2e7d40c03877c16
-  React-featureflags: 4333d212c40db734863a9b2b33e0c54af3df0265
-  React-featureflagsnativemodule: eb0fd4b7fd30fcecd1f87cdcacd94539eeae7147
-  React-graphics: f008e545fef39134ab66fadbe7f84f620ee4da1b
-  React-hermes: a264a4dbe286a44fd29aeee37dabd0fb82f5bc28
-  React-idlecallbacksnativemodule: 111d80a5415471fc8af8d166e37b092f9ec804e5
-  React-ImageManager: e6da229ebb5815dc28d54d07fcb765c29ad0e4aa
-  React-jserrorhandler: 445c4ada0c96bf4a0ce36355aa429938dfe368b9
-  React-jsi: 699088da9e1c66b7436aae409add6e8a19751a76
-  React-jsiexecutor: 90ec95035647a000dc118807e6f1a900be9008ec
-  React-jsinspector: 11cd3631e80beefd4e752d28c57e491f711ccada
-  React-jsinspectorcdp: 630b2e989d6b5517b641f0509e293b8020fa1adc
-  React-jsinspectornetwork: e925d0378e0a1a2cd2937990aff4df4bad244d31
-  React-jsinspectortracing: 3d7339ccf855d93d2d819bf6ceeb18c076df0c06
-  React-jsitooling: 9bb90758b9ca3d2473bdd9340653bd0d782e5ec7
-  React-jsitracing: 847cfde62317c109c7388f50704103b73905a936
-  React-logger: 85780074297fc704c4d6832f951229c21d5fd35e
-  React-Mapbuffer: 037786a5502d8d25502f892ec2fec7237969b0f6
-  React-microtasksnativemodule: 4963088a1ab9c2ce4bbbfd4db49c5fe667c7911e
+  React: e9544e63efd562e190c906f467ad07948eeaad5f
+  React-callinvoker: 7dfaa2ec8ac499a414dfed53e3ebce46b23bca65
+  React-Core: 06e5f9aa4779f13c00714936f405b1e21d56e465
+  React-CoreModules: 9de28d4e2a12aad01443f2ca0fae0a0e41bea465
+  React-cxxreact: 1b4e0f0e7a857eb642cb13a1c7f6575409b7cde4
+  React-debug: ba7f1d298877aa92a9bf5af856b5606af0ee197a
+  React-defaultsnativemodule: bfce3c5a160043f993110653b2e1bf01ad2cedde
+  React-domnativemodule: 599193de380c13f93586db02c8595b5692c76f03
+  React-Fabric: e3d0577231452d4563420478ef70fb55fe248051
+  React-FabricComponents: be74318b443ea8f728a60cbd4ad7e0c9413c9af9
+  React-FabricImage: 64ef438c49bee98e1a84e6454d13bbae91926698
+  React-featureflags: 7597462adb09b18b3dbff8bd4f1f6441d790f252
+  React-featureflagsnativemodule: d2e560a759e0e5777cfe7ce633cdc413395a8aba
+  React-graphics: 5feb59b27469c4c3e7664d79b1181b62119f82c9
+  React-hermes: 51003f7fd4d0946401770e1b45f3a0f6c4e585d2
+  React-idlecallbacksnativemodule: 8169daed60a88ac9d095da6315daf452d00fb708
+  React-ImageManager: 1399b5c230278af855f09cd5fb76aaac0af89956
+  React-jserrorhandler: e5f0a0f84ccf3da91d56f1018a4b14b53010269b
+  React-jsi: ff817c16523cb90852fe73d405795b2dc70b77c0
+  React-jsiexecutor: 1c56ce69f4efb679bc098135d33a308ce3e7dffc
+  React-jsinspector: 3b228b59e42d7fd5c60594b5cc2edc9ba81d3aec
+  React-jsinspectorcdp: cefb9bd91a9c8b2d743b40999a223543a5bd5879
+  React-jsinspectornetwork: e6fed0da74f1399bac5e758d50cd2f660db3c40b
+  React-jsinspectortracing: bbf416487d9b78d8fb5f5234451163c8ed88ed82
+  React-jsitooling: 1553ece4e91c4283f669999ec8c08c822d356acf
+  React-jsitracing: af182d47427801d4c8b16f995791baa0e0d6129a
+  React-logger: 19586e18cb370047633039b018d365953598739e
+  React-Mapbuffer: 45ec5cdca592f4dc6522c59b8f4575abf573e0b1
+  React-microtasksnativemodule: a0f271cefc1bae9ff0cb8f4237b9f7481cd97543
   react-native-netinfo: a0be8c77f8420a60ddf07eb87be1a36f02a1bd65
-  react-native-skia: 03e8994164f792bc9fa464ed475e7f8edce36d0e
+  react-native-skia: fc73e9bdc46ebb420a98c9c2be29fee80f565e79
   react-native-webview: 8407aaaf6b539b1e38b72fabb55d6885de03beaf
-  React-NativeModulesApple: beeeb17d842ad64aa26f8700340bb14a3fa68d7b
-  React-oscompat: 0f67bb3326c613877d9a4c50031f215fe2764d89
-  React-perflogger: d744ee5245595aa3586331677a6aa0b14650eda7
-  React-performancetimeline: f287cd33bb25fe026c338f1749bf5358d7c09e73
-  React-RCTActionSheet: b1fe9b795181d1cbb7e6d819fbfa34fbb2c7b88f
-  React-RCTAnimation: 976c902ad19df7f18276677b59338aea3b73a0a1
-  React-RCTAppDelegate: f27856e96032bed0f3eef6ff50e882f58503d394
-  React-RCTBlob: 2dac7194b54f761ac9166e85e7051e3f0a55e4d5
-  React-RCTFabric: 6465732b5467224d67d8365f1124282020d999b0
-  React-RCTFBReactNativeSpec: a33df083edcdf80f1f5a51c1b6a583ac07406147
-  React-RCTImage: 8b2f23278e83c8b73ec6a0c14d1eb17f188405cd
-  React-RCTLinking: 29f8d337665a106289a4fc08dff82cef4016e660
-  React-RCTNetwork: b5fa6ca39b05fd9dff160fea4c8deb6e4cc3eae4
-  React-RCTRuntime: 28aa6ecce86849b9ea908d7e17c0408d9caf8ade
-  React-RCTSettings: 353a6d166069f5fdb11fa22ec077936469e9d1c7
-  React-RCTText: a60be83b40f2fd79d5f212b53d035c6087e0965e
-  React-RCTVibration: 1ed99f155147a23a10467a97d06e6a8f81439ee9
-  React-rendererconsistency: cfefe66cc332df4558869980f2a7d859d85ca8db
-  React-renderercss: ba358637db48e3573ead1127de9a0b7d35828346
-  React-rendererdebug: 6ed86fc7285ff47d738a78fc2ef9ffe34f38c5ea
-  React-RuntimeApple: 9fdb57f861eaba3315d38113aebba6ebb175875c
-  React-RuntimeCore: b805aed8a5f9b02fab9a798714d447f3ca2bfb07
-  React-runtimeexecutor: b3b48446f479d9ab899baac746c1e0a384977f46
-  React-RuntimeHermes: af5bf63a349a02eccda90a0d7b7d2b742bd8cac6
-  React-runtimescheduler: ae3507d757dfa085f019c03cbee29811377671aa
-  React-timing: c64eae92f7e50abef3f7952001de9722be2a1df1
-  React-utils: c7eb720119e56ea1e4927cee1182ebabe75ab72c
-  ReactAppDependencyProvider: 3a4b47b0501d4d1068eef3c457c9ebef0b6ae49b
-  ReactCodegen: 28b0869099548209689f9534c1734e146cad1ddb
-  ReactCommon: ef913092a4501cf30c176155312c30abc82dbd34
+  React-NativeModulesApple: 02b57ec4dced7eb81bedcccdad1ca62fee961c4d
+  React-oscompat: 66d4c9c770c0690b00c652a568f30b4713104ebf
+  React-perflogger: 0834475c95233811e2095a13fc6fad0bac270dae
+  React-performancetimeline: cb1c440be4b41ae07924220142a332f483ef0460
+  React-RCTActionSheet: 6f0f30ca45644ea45c8fd4dcc4bb979841c1329c
+  React-RCTAnimation: 768305e2855bb6f42a20359090c289f488166e5c
+  React-RCTAppDelegate: b4f5318820cb2a1e08be6bd687e78ed1bbe63c9e
+  React-RCTBlob: 3a65e0cfc0002b221d72e8ba3e61693ea1cbfd47
+  React-RCTFabric: 3c1ef8c53275964658f9e2d125fba368fba603f3
+  React-RCTFBReactNativeSpec: 1181fd14170f46d062fa14050a4cbc96ba7d81dd
+  React-RCTImage: ca1c3955cfb73dc19375826126f3fc7f282b4133
+  React-RCTLinking: 605ec0a901aa5be3bc1662cc218928dc89d59360
+  React-RCTNetwork: 1dd04e5d9e1a196e341e5593b726e0e1997814a4
+  React-RCTRuntime: 532616e200e07534a313d7d18e8829bdde19b567
+  React-RCTSettings: 6bc84e7f4ec012ad61aad3ca3a1e4e011e98adb6
+  React-RCTText: 7c9b8bee3ebbbc9260677b987fb182f47c8b4003
+  React-RCTVibration: 5c58c1a898e21e7d69264ae81b5ce47715bc6a8f
+  React-rendererconsistency: 0d5c5e660b71e4a7e42008d925af773739030f2a
+  React-renderercss: de2285666b1ab90a867ba238b63d9b8b9cf2e8d3
+  React-rendererdebug: 4636e47266fb8ece0dfac4baf130e986639f762f
+  React-RuntimeApple: 5f3bbce6a8bbb570f3c33eab1510d0061588bc02
+  React-RuntimeCore: 756fab3631299b051ba62811a48b7bb27b10bd05
+  React-runtimeexecutor: 30e08be18783a46a9476d6629715d7cc59306d13
+  React-RuntimeHermes: 49242f750a3f93d99ffccfd602fb1b30a258b199
+  React-runtimescheduler: 1463e92f5f70e254c4aca4173c179304202e37e0
+  React-timing: 990ed60289af22f972123de84fe38f266a604c6a
+  React-utils: ae5bf8031b105dbd3cb85fc63ae56512563f8daf
+  ReactAppDependencyProvider: db0eebc7a9e85c8976d5ea10706d790753a53889
+  ReactCodegen: f98095a82ce3feb59fd2fd54924856375d931118
+  ReactCommon: bc273d1cfc32a36ea662e81293e0961de8c21c77
   RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
-  RNGestureHandler: 83e66307c200b98c746bd03113c4403da5c9b486
-  RNReanimated: 9b5c7dc33fd865193f7a0461bd8957e71f9d11e1
-  RNWorklets: a1009c962243f6faeff04494e483deef5866cbac
+  RNGestureHandler: d9aaa02b8cdfc140cc27bd79cb76936e827f6a17
+  RNReanimated: 125a0994e5482b0b4919a55107ec4865746a2564
+  RNWorklets: 912860eaac5b1a4e91967a91d6bd8b571154e7db
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 9f9bacf26f441fa32d25c32e5583ff72f6d2806d
+  Yoga: a88f30ac6f89fded00f9840e7d043315e5ab4fe0
 
 PODFILE CHECKSUM: 2080184fe7378b7b21bd66f763b107271b042a9b
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🎉 New features
 
+- [macOS] Added `UIColor`, `UIGestureRecognizer` and `UITextContentType` to the AppKit compatibility aliases in `Platform.swift`. (by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Added a `loadImageForManipulationFromURL` overload to `ImageLoaderInterface` that decodes the image within the given `maxWidth`/`maxHeight` bounds. ([#47877](https://github.com/expo/expo/pull/47877) by [@jiunshinn](https://github.com/jiunshinn))
 - Add `useReleasingSharedObjectWithLifecycle` hook. ([#46494](https://github.com/expo/expo/pull/46494) by [@behenate](https://github.com/behenate))
 - Added `ArrayBuffer` as the preferred safe native module argument and return type, and deprecated `NativeArrayBuffer` in favor of it. ([#47106](https://github.com/expo/expo/pull/47106) by [@barthap](https://github.com/barthap))

--- a/packages/expo-modules-core/ios/Platform/Platform.swift
+++ b/packages/expo-modules-core/ios/Platform/Platform.swift
@@ -16,6 +16,9 @@ public typealias UILabel = NSLabel
 public typealias UIImage = NSImage
 public typealias UIImageView = NSImageView
 public typealias UIPasteboard = NSPasteboard
+public typealias UIColor = NSColor
+public typealias UIGestureRecognizer = NSGestureRecognizer
+public typealias UITextContentType = NSTextContentType
 
 extension UIApplication {
   public typealias LaunchOptionsKey = String

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 🎉 New features
 
+- [macOS] Added macOS to the supported platforms and made the SwiftUI layer build against the macOS SDK. Modifiers that have no macOS counterpart — `keyboardType`, `textInputAutocapitalization`, `editMode`, the wheel picker and date picker styles, the paged `TabView` and index view styles, the grouped list styles, `listSectionSpacing` and `listSectionMargins` — are no-ops there, matching how they already behave on tvOS. (by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Added `presentationBackground` SwiftUI modifier and applied it in `community/bottom-sheet`. ([#46285](https://github.com/expo/expo/pull/46285) by [@duyanhv](https://github.com/duyanhv))
 
 ### 🐛 Bug fixes

--- a/packages/expo-ui/ios/ConcentricRectangleView.swift
+++ b/packages/expo-ui/ios/ConcentricRectangleView.swift
@@ -33,7 +33,7 @@ public struct ConcentricRectangleView: ExpoSwiftUI.View {
   }
 
 #if compiler(>=6.2) // Xcode 26
-  @available(iOS 26.0, tvOS 26.0, *)
+  @available(iOS 26.0, macOS 26.0, tvOS 26.0, *)
   private func cornerStyle(from config: CornerStyleConfig?) -> Edge.Corner.Style {
     // default to concentric
     guard let config = config else {
@@ -57,7 +57,7 @@ public struct ConcentricRectangleView: ExpoSwiftUI.View {
 
   public var body: some View {
 #if compiler(>=6.2) // Xcode 26
-    if #available(iOS 26.0, tvOS 26.0, *) {
+    if #available(iOS 26.0, macOS 26.0, tvOS 26.0, *) {
       let topLeadingCorner = cornerStyle(from: props.corners?.topLeadingCorner)
       let topTrailingCorner = cornerStyle(from: props.corners?.topTrailingCorner)
       let bottomLeadingCorner = cornerStyle(from: props.corners?.bottomLeadingCorner)

--- a/packages/expo-ui/ios/ExpoUI.podspec
+++ b/packages/expo-ui/ios/ExpoUI.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '16.4',
-    :tvos => '16.4'
+    :tvos => '16.4',
+    :osx => '13.4'
   }
   s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-ui/ios/ExpoUITouchHandlerHelper.h
+++ b/packages/expo-ui/ios/ExpoUITouchHandlerHelper.h
@@ -1,11 +1,12 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
+// Pulls in UIKit on iOS/tvOS, and on macOS the aliases that map `UIGestureRecognizer` and
+// `UIView` onto their AppKit counterparts. Forward declaring them instead would name classes
+// that do not exist on macOS, and Swift would drop the methods below from the generated interface.
+#import <ExpoModulesCore/Platform.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
-@class UIGestureRecognizer;
-@class UIView;
 
 @interface ExpoUITouchHandlerHelper : NSObject
 

--- a/packages/expo-ui/ios/HostView.swift
+++ b/packages/expo-ui/ios/HostView.swift
@@ -134,7 +134,16 @@ private struct ViewportSizeMeasurementLayout: Layout {
   }
 
   private func safeAreaSize() -> CGSize {
+#if os(macOS)
+    // `SceneGeometry` is built on `UIWindowScene`, which has no macOS counterpart. The closest
+    // analogue to a window's safe area is its content layout rect, which excludes the title bar.
+    guard let window = NSApplication.shared.keyWindow ?? NSApplication.shared.windows.first else {
+      return .zero
+    }
+    return window.contentLayoutRect.size
+#else
     return SceneGeometry.safeAreaSize()
+#endif
   }
 }
 

--- a/packages/expo-ui/ios/Modifiers/ContainerBackgroundModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/ContainerBackgroundModifier.swift
@@ -11,7 +11,9 @@ internal enum ContainerBackgroundPlacementOptions: String, Enumerable {
   case navigation
   case navigationSplitView
 
-#if !os(tvOS)
+// `.navigation` and `.navigationSplitView` are unavailable on macOS, which only defines the
+// `.widget` placement. macOS handles the mapping inline in `body` instead.
+#if !os(tvOS) && !os(macOS)
   @available(iOS 18.0, *)
   var toContainerBackgroundPlacement: ContainerBackgroundPlacement {
     switch self {
@@ -28,7 +30,16 @@ internal struct ContainerBackgroundModifier: ViewModifier, Record {
   @Field var container: ContainerBackgroundPlacementOptions?
 
   func body(content: Content) -> some View {
-#if !os(tvOS)
+#if os(tvOS)
+    content
+#elseif os(macOS)
+    // `.widget` is the only placement macOS defines; the other two are unavailable there.
+    if let color, container == .widget {
+      content.containerBackground(color, for: .widget)
+    } else {
+      content
+    }
+#else
     if let color, let container {
       if #available(iOS 18.0, *) {
         content.containerBackground(color, for: container.toContainerBackgroundPlacement)
@@ -40,8 +51,6 @@ internal struct ContainerBackgroundModifier: ViewModifier, Record {
     } else {
       content
     }
-#else
-    content
 #endif
   }
 }

--- a/packages/expo-ui/ios/Modifiers/DatePickerStyleModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/DatePickerStyleModifier.swift
@@ -17,8 +17,11 @@ internal enum DatePickerStyleType: String, Enumerable {
       content.datePickerStyle(.compact)
     case .graphical:
       content.datePickerStyle(.graphical)
+// The wheel style is unavailable on macOS; it falls through to `automatic` below.
+#if !os(macOS)
     case .wheel:
       content.datePickerStyle(.wheel)
+#endif
     default:
       content.datePickerStyle(.automatic)
     }

--- a/packages/expo-ui/ios/Modifiers/EnvironmentModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/EnvironmentModifier.swift
@@ -15,6 +15,7 @@ internal enum EditModeType: String, Enumerable {
   case inactive
   case transient
 
+#if !os(macOS)
   func toNativeEditMode() -> EditMode {
     switch self {
     case .active:
@@ -25,6 +26,7 @@ internal enum EditModeType: String, Enumerable {
       return .transient
     }
   }
+#endif
 }
 
 internal enum ColorSchemeType: String, Enumerable {
@@ -49,11 +51,17 @@ internal struct EnvironmentModifier: ViewModifier, Record {
   func body(content: Content) -> some View {
     switch key {
     case .editMode:
+      // `EditMode` and the `editMode` environment key are both unavailable on macOS, which has
+      // no list edit mode. Setting the key is a no-op there.
+#if os(macOS)
+      content
+#else
       if let editMode = EditModeType(rawValue: value) {
         content.environment(\.editMode, .constant(editMode.toNativeEditMode()))
       } else {
         content
       }
+#endif
     case .colorScheme:
       if let colorScheme = ColorSchemeType(rawValue: value) {
         content.environment(\.colorScheme, colorScheme.toNativeColorScheme())

--- a/packages/expo-ui/ios/Modifiers/IndexViewStyleModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/IndexViewStyleModifier.swift
@@ -13,6 +13,7 @@ internal enum PageIndexBackgroundDisplayMode: String, Enumerable {
   case never
   case interactive
 
+#if !os(macOS)
   var asSwiftUI: PageIndexViewStyle.BackgroundDisplayMode {
     switch self {
     case .automatic: .automatic
@@ -21,6 +22,7 @@ internal enum PageIndexBackgroundDisplayMode: String, Enumerable {
     case .interactive: .interactive
     }
   }
+#endif
 }
 
 internal struct IndexViewStyleModifier: ViewModifier, Record {
@@ -29,9 +31,15 @@ internal struct IndexViewStyleModifier: ViewModifier, Record {
 
   @ViewBuilder
   func body(content: Content) -> some View {
+#if os(macOS)
+    // macOS has no paged index view: `indexViewStyle` and `PageIndexViewStyle` are both
+    // unavailable there, so the modifier is a no-op.
+    content
+#else
     switch type ?? .page {
     case .page:
       content.indexViewStyle(.page(backgroundDisplayMode: (backgroundDisplayMode ?? .automatic).asSwiftUI))
     }
+#endif
   }
 }

--- a/packages/expo-ui/ios/Modifiers/KeyboardTypeModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/KeyboardTypeModifier.swift
@@ -18,6 +18,7 @@ enum KeyboardType: String, Enumerable {
   case asciiCapableNumberPad = "ascii-capable-number-pad"
 }
 
+#if !os(macOS)
 func getKeyboardType(_ keyboardType: KeyboardType) -> UIKeyboardType {
   switch keyboardType {
   case .defaultKeyboard:
@@ -46,16 +47,22 @@ func getKeyboardType(_ keyboardType: KeyboardType) -> UIKeyboardType {
     return .asciiCapableNumberPad
   }
 }
+#endif
 
 internal struct KeyboardTypeModifier: ViewModifier, Record {
   @Field var keyboardType: KeyboardType?
 
   func body(content: Content) -> some View {
+#if os(macOS)
+    // There is no software keyboard on macOS, so there is no keyboard type to request.
+    content
+#else
     if let keyboardType {
       content.keyboardType(getKeyboardType(keyboardType))
     } else {
       content
     }
+#endif
   }
 }
 

--- a/packages/expo-ui/ios/Modifiers/ListStyleModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/ListStyleModifier.swift
@@ -14,13 +14,19 @@ internal enum ListStyleType: String, Enumerable {
   @ViewBuilder
   func apply<Content: View>(to content: Content) -> some View {
     switch self {
-    case .grouped:
-      content.listStyle(.grouped)
     case .plain:
       content.listStyle(.plain)
-#if !os(tvOS)
+// `grouped` and `insetGrouped` are unavailable on macOS, which has no grouped list styles.
+// They fall through to `automatic` below.
+#if !os(macOS)
+    case .grouped:
+      content.listStyle(.grouped)
+#endif
+#if !os(tvOS) && !os(macOS)
     case .insetGrouped:
       content.listStyle(.insetGrouped)
+#endif
+#if !os(tvOS)
     case .inset:
       content.listStyle(.inset)
     case .sidebar:

--- a/packages/expo-ui/ios/Modifiers/MenuOrderModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/MenuOrderModifier.swift
@@ -15,8 +15,8 @@ internal enum MenuOrderType: String, Enumerable {
     case .fixed:
       return .fixed
     case .priority:
-      // `.priority` is unavailable on tvOS; fall back to the platform default there.
-      #if os(tvOS)
+      // `.priority` is unavailable on tvOS and macOS; fall back to the platform default there.
+      #if os(tvOS) || os(macOS)
       return .automatic
       #else
       return .priority

--- a/packages/expo-ui/ios/Modifiers/PickerStyleModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/PickerStyleModifier.swift
@@ -24,11 +24,16 @@ internal enum PickerStyleType: String, Enumerable {
         content.pickerStyle(.automatic)
       }
     case .navigationLink:
+      // `.navigationLink` is unavailable on macOS, which has no navigation-stack picker.
+#if os(macOS)
+      content.pickerStyle(.automatic)
+#else
       if #available(iOS 16.0, tvOS 16.0, *) {
         content.pickerStyle(.navigationLink)
       } else {
         content.pickerStyle(.automatic)
       }
+#endif
     case .palette:
 #if !os(tvOS)
       if #available(iOS 17.0, *) {
@@ -42,7 +47,7 @@ internal enum PickerStyleType: String, Enumerable {
     case .segmented:
       content.pickerStyle(.segmented)
     case .wheel:
-#if !os(tvOS)
+#if !os(tvOS) && !os(macOS)
       content.pickerStyle(.wheel)
 #else
       content.pickerStyle(.automatic)

--- a/packages/expo-ui/ios/Modifiers/ScrollObservationModifiers.swift
+++ b/packages/expo-ui/ios/Modifiers/ScrollObservationModifiers.swift
@@ -17,7 +17,7 @@ internal struct OnScrollGeometryChangeModifier: ViewModifier, Record {
   }
 
   func body(content: Content) -> some View {
-    if #available(iOS 18.0, tvOS 18.0, *) {
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
       content
         .onScrollGeometryChange(for: ScrollGeometryPayload.self) { ScrollGeometryPayload($0) }
         action: { [workletCallback, eventDispatcher] _, payload in
@@ -45,7 +45,7 @@ internal struct OnScrollPhaseChangeModifier: ViewModifier, Record {
   }
 
   func body(content: Content) -> some View {
-    if #available(iOS 18.0, tvOS 18.0, *) {
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
       content.onScrollPhaseChange { [eventDispatcher] _, newPhase, context in
         eventDispatcher?([
           "onScrollPhaseChange": [
@@ -59,7 +59,7 @@ internal struct OnScrollPhaseChangeModifier: ViewModifier, Record {
     }
   }
 
-  @available(iOS 18.0, tvOS 18.0, *)
+  @available(iOS 18.0, macOS 15.0, tvOS 18.0, *)
   private static func phaseString(_ phase: ScrollPhase) -> String {
     return switch phase {
     case .idle: "idle"
@@ -92,7 +92,7 @@ internal struct ScrollGeometryPayload: Equatable {
   }
 }
 
-@available(iOS 18.0, tvOS 18.0, *)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, *)
 extension ScrollGeometryPayload {
   init(_ geometry: ScrollGeometry) {
     self.init(

--- a/packages/expo-ui/ios/Modifiers/SymbolEffectModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/SymbolEffectModifier.swift
@@ -87,12 +87,12 @@ internal struct SymbolEffectOptionsConfig: Record {
     case .nonRepeating:
       options = .nonRepeating
     case .continuous:
-      if #available(iOS 18.0, tvOS 18.0, *) {
+      if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
         options = .repeat(.continuous)
       }
       // iOS 17: indefinite effects loop by default, so `.default` is fine here.
     case .periodic:
-      if #available(iOS 18.0, tvOS 18.0, *) {
+      if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
         options = .repeat(.periodic(repeatCount, delay: repeatDelay))
       }
     case .none:
@@ -248,7 +248,7 @@ private func buildDisappearEffect(_ config: SymbolEffectConfig) -> DisappearSymb
   }
 }
 
-@available(iOS 18.0, tvOS 18.0, *)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, *)
 private func buildWiggleEffect(_ config: SymbolEffectConfig) -> WiggleSymbolEffect {
   let directed: WiggleSymbolEffect = if let angle = config.customAngle {
     .wiggle.custom(angle: angle)
@@ -272,7 +272,7 @@ private func buildWiggleEffect(_ config: SymbolEffectConfig) -> WiggleSymbolEffe
   }
 }
 
-@available(iOS 18.0, tvOS 18.0, *)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, *)
 private func buildBreatheEffect(_ config: SymbolEffectConfig) -> BreatheSymbolEffect {
   let styled: BreatheSymbolEffect = switch config.style {
   case .pulse: .breathe.pulse
@@ -286,7 +286,7 @@ private func buildBreatheEffect(_ config: SymbolEffectConfig) -> BreatheSymbolEf
   }
 }
 
-@available(iOS 18.0, tvOS 18.0, *)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, *)
 private func buildRotateEffect(_ config: SymbolEffectConfig) -> RotateSymbolEffect {
   let directed: RotateSymbolEffect = switch config.direction {
   case .clockwise: .rotate.clockwise
@@ -300,7 +300,7 @@ private func buildRotateEffect(_ config: SymbolEffectConfig) -> RotateSymbolEffe
   }
 }
 
-@available(iOS 26.0, tvOS 26.0, *)
+@available(iOS 26.0, macOS 26.0, tvOS 26.0, *)
 private func buildDrawOnEffect(_ config: SymbolEffectConfig) -> DrawOnSymbolEffect {
   return switch config.scope {
   case .byLayer: .drawOn.byLayer
@@ -310,7 +310,7 @@ private func buildDrawOnEffect(_ config: SymbolEffectConfig) -> DrawOnSymbolEffe
   }
 }
 
-@available(iOS 26.0, tvOS 26.0, *)
+@available(iOS 26.0, macOS 26.0, tvOS 26.0, *)
 private func buildDrawOffEffect(_ config: SymbolEffectConfig) -> DrawOffSymbolEffect {
   let played: DrawOffSymbolEffect = switch config.playbackStyle {
   case .reversed: .drawOff.reversed
@@ -349,31 +349,31 @@ private func applyIndefiniteEffect<TargetView: View>(
   case .disappear:
     view.symbolEffect(buildDisappearEffect(config), options: options, isActive: isActive)
   case .wiggle:
-    if #available(iOS 18.0, tvOS 18.0, *) {
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
       view.symbolEffect(buildWiggleEffect(config), options: options, isActive: isActive)
     } else {
       view
     }
   case .breathe:
-    if #available(iOS 18.0, tvOS 18.0, *) {
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
       view.symbolEffect(buildBreatheEffect(config), options: options, isActive: isActive)
     } else {
       view
     }
   case .rotate:
-    if #available(iOS 18.0, tvOS 18.0, *) {
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
       view.symbolEffect(buildRotateEffect(config), options: options, isActive: isActive)
     } else {
       view
     }
   case .drawOn:
-    if #available(iOS 26.0, tvOS 26.0, *) {
+    if #available(iOS 26.0, macOS 26.0, tvOS 26.0, *) {
       view.symbolEffect(buildDrawOnEffect(config), options: options, isActive: isActive)
     } else {
       view
     }
   case .drawOff:
-    if #available(iOS 26.0, tvOS 26.0, *) {
+    if #available(iOS 26.0, macOS 26.0, tvOS 26.0, *) {
       view.symbolEffect(buildDrawOffEffect(config), options: options, isActive: isActive)
     } else {
       view
@@ -397,19 +397,19 @@ private func applyDiscreteEffect<TargetView: View>(
   case .variableColor:
     view.symbolEffect(buildVariableColorEffect(config), options: options, value: value)
   case .wiggle:
-    if #available(iOS 18.0, tvOS 18.0, *) {
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
       view.symbolEffect(buildWiggleEffect(config), options: options, value: value)
     } else {
       view
     }
   case .breathe:
-    if #available(iOS 18.0, tvOS 18.0, *) {
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
       view.symbolEffect(buildBreatheEffect(config), options: options, value: value)
     } else {
       view
     }
   case .rotate:
-    if #available(iOS 18.0, tvOS 18.0, *) {
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
       view.symbolEffect(buildRotateEffect(config), options: options, value: value)
     } else {
       view

--- a/packages/expo-ui/ios/Modifiers/TabViewStyleModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/TabViewStyleModifier.swift
@@ -14,6 +14,7 @@ internal enum PageIndexDisplayMode: String, Enumerable {
   case always
   case never
 
+#if !os(macOS)
   var asSwiftUI: PageTabViewStyle.IndexDisplayMode {
     switch self {
     case .automatic: .automatic
@@ -21,6 +22,7 @@ internal enum PageIndexDisplayMode: String, Enumerable {
     case .never: .never
     }
   }
+#endif
 }
 
 internal struct TabViewStyleModifier: ViewModifier, Record {
@@ -31,11 +33,17 @@ internal struct TabViewStyleModifier: ViewModifier, Record {
   func body(content: Content) -> some View {
     switch type ?? .page {
     case .page:
+      // macOS has no paged `TabView`: `PageTabViewStyle` is unavailable there, so `.page`
+      // resolves to the platform default.
+#if os(macOS)
+      content.tabViewStyle(.automatic)
+#else
       content.tabViewStyle(.page(indexDisplayMode: (indexDisplayMode ?? .automatic).asSwiftUI))
+#endif
     case .automatic:
       content.tabViewStyle(.automatic)
     case .sidebarAdaptable:
-      if #available(iOS 18.0, tvOS 18.0, *) {
+      if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
         content.tabViewStyle(.sidebarAdaptable)
       } else {
         content.tabViewStyle(.automatic)

--- a/packages/expo-ui/ios/Modifiers/TextContentTypeModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/TextContentTypeModifier.swift
@@ -95,15 +95,21 @@ internal enum TextContentTypeValue: String, Enumerable {
     case .oneTimeCode: return .oneTimeCode
     case .emailAddress: return .emailAddress
     case .telephoneNumber: return .telephoneNumber
+    // macOS has no `cellularEID` / `cellularIMEI` content type at any version, so it takes the
+    // same `telephoneNumber` fallback the pre-17.4 Apple platforms use.
     case .cellularEID:
+#if !os(macOS)
       if #available(iOS 17.4, tvOS 17.4, *) {
         return .cellularEID
       }
+#endif
       return .telephoneNumber
     case .cellularIMEI:
+#if !os(macOS)
       if #available(iOS 17.4, tvOS 17.4, *) {
         return .cellularIMEI
       }
+#endif
       return .telephoneNumber
     case .creditCardNumber: return .creditCardNumber
     case .creditCardExpiration:

--- a/packages/expo-ui/ios/Modifiers/TextInputAutocapitalizationModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/TextInputAutocapitalizationModifier.swift
@@ -14,6 +14,11 @@ internal struct TextInputAutocapitalizationModifier: ViewModifier, Record {
   @Field var autocapitalization: TextInputAutocapitalizationType = .sentences
 
   func body(content: Content) -> some View {
+#if os(macOS)
+    // Autocapitalization is a software-keyboard behaviour and `textInputAutocapitalization`
+    // is unavailable on macOS, so the modifier is a no-op there.
+    content
+#else
     switch autocapitalization {
     case .never:
       content.textInputAutocapitalization(.never)
@@ -24,5 +29,6 @@ internal struct TextInputAutocapitalizationModifier: ViewModifier, Record {
     case .characters:
       content.textInputAutocapitalization(.characters)
     }
+#endif
   }
 }

--- a/packages/expo-ui/ios/Modifiers/View+ModifierArray.swift
+++ b/packages/expo-ui/ios/Modifiers/View+ModifierArray.swift
@@ -67,7 +67,7 @@ internal extension Image {
         )
       }
 
-      if #available(iOS 18.0, *),
+      if #available(iOS 18.0, macOS 15.0, *),
          let modifierConfig = modifiers.first(where: { $0["$type"] as? String == "widgetAccentedRenderingMode" }),
          let modifier = try? WidgetAccentedRenderingModeModifier(from: modifierConfig, appContext: appContext) {
         modifier.apply(to: image)

--- a/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
+++ b/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
@@ -16,7 +16,8 @@ internal struct ListSectionSpacingModifier: ViewModifier, Record {
   @Field var value: CGFloat = 0
 
   func body(content: Content) -> some View {
-#if os(tvOS)
+// `listSectionSpacing` is unavailable on tvOS and macOS.
+#if os(tvOS) || os(macOS)
     content
 #else
     if #available(iOS 17.0, *) {
@@ -537,7 +538,12 @@ internal struct MenuActionDismissBehaviorModifier: ViewModifier, Record {
       case .automatic:
         content.menuActionDismissBehavior(.automatic)
       case .disabled:
+        // `.disabled` is unavailable on macOS; menus there always dismiss on action.
+#if os(macOS)
+        content.menuActionDismissBehavior(.automatic)
+#else
         content.menuActionDismissBehavior(.disabled)
+#endif
       case .enabled:
         content.menuActionDismissBehavior(.enabled)
       }
@@ -1260,7 +1266,8 @@ internal struct ListSectionMargins: ViewModifier, Record {
   @Field var edges: EdgeOptions?
 
   func body(content: Content) -> some View {
-#if compiler(>=6.2) && !os(tvOS) // Xcode 26
+// `listSectionMargins` is unavailable on tvOS and macOS.
+#if compiler(>=6.2) && !os(tvOS) && !os(macOS) // Xcode 26
     if #available(iOS 26.0, *) {
       if let edges {
         content.listSectionMargins(edges.toEdge(), length ?? 0)

--- a/packages/expo-ui/ios/Modifiers/WidgetModifiers.swift
+++ b/packages/expo-ui/ios/Modifiers/WidgetModifiers.swift
@@ -13,7 +13,7 @@ internal enum WidgetAccentedRenderingModeOptions: String, Enumerable {
   case fullColor
 
 #if !os(tvOS)
-  @available(iOS 18.0, *)
+  @available(iOS 18.0, macOS 15.0, *)
   var toWidgetAccentedRenderingMode: WidgetAccentedRenderingMode {
     switch self {
     case .accented: return .accented
@@ -34,7 +34,7 @@ internal struct WidgetAccentedRenderingModeModifier: Record {
   @ViewBuilder
   func apply(to image: Image) -> some View {
 #if !os(tvOS)
-    if #available(iOS 18.0, *), renderingMode != nil {
+    if #available(iOS 18.0, macOS 15.0, *), renderingMode != nil {
       image.widgetAccentedRenderingMode(renderingMode?.toWidgetAccentedRenderingMode)
     } else {
       image

--- a/packages/expo-ui/ios/SecureFieldView.swift
+++ b/packages/expo-ui/ios/SecureFieldView.swift
@@ -38,7 +38,13 @@ struct SecureFieldView: ExpoSwiftUI.View, ExpoSwiftUI.FocusableView {
 
   func forceResignFirstResponder() {
     if textManager.isFocused {
+#if os(macOS)
+      // `NSApplication.sendAction` has no `for:` event argument, and AppKit clears focus by
+      // handing the window a nil first responder.
+      NSApplication.shared.keyWindow?.makeFirstResponder(nil)
+#else
       UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+#endif
     }
 
     textManager.isFocused = false

--- a/packages/expo-ui/ios/TabView/TabView.swift
+++ b/packages/expo-ui/ios/TabView/TabView.swift
@@ -27,7 +27,7 @@ internal struct TabView: ExpoSwiftUI.View {
     // No default tabViewStyle — the innermost modifier wins, so a default
     // here would shadow the user's. Callers must supply one explicitly.
     Group {
-      if #available(iOS 18.0, tvOS 18.0, *) {
+      if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
         valueBasedTabView(tabs)
       } else {
         legacyTabView(children, tabs: tabs)
@@ -44,7 +44,7 @@ internal struct TabView: ExpoSwiftUI.View {
 
   // MARK: - iOS 18+: value-based Tab(value:) API
 
-  @available(iOS 18.0, tvOS 18.0, *)
+  @available(iOS 18.0, macOS 15.0, tvOS 18.0, *)
   @ViewBuilder
   private func valueBasedTabView(_ tabs: [Tab]) -> some View {
     SwiftUI.TabView(selection: stringBinding) {

--- a/packages/expo-ui/ios/TextFieldView.swift
+++ b/packages/expo-ui/ios/TextFieldView.swift
@@ -56,7 +56,13 @@ struct TextFieldView: ExpoSwiftUI.View, ExpoSwiftUI.FocusableView {
 
   func forceResignFirstResponder() {
     if textManager.isFocused {
+#if os(macOS)
+      // `NSApplication.sendAction` has no `for:` event argument, and AppKit clears focus by
+      // handing the window a nil first responder.
+      NSApplication.shared.keyWindow?.makeFirstResponder(nil)
+#else
       UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+#endif
     }
 
     textManager.isFocused = false


### PR DESCRIPTION
# Why

We can add basic `@expo/ui` support for macOS by using availability clauses and a few type aliases. This also unblocks app-intents (https://github.com/expo/expo/pull/50066)

# How

- Add `UIColor`, `UIGestureRecognizer`, `UITextContentType` type aliases to expo-modules-core`'s Platform.swift
- `HostView.safeAreaSize()` — `SceneGeometry` is `#if os(iOS) || os(tvOS)`, built on `UIWindowScene`. macOS uses `window.contentLayoutRect.size`, which excludes the title bar. A `.zero` no-op would break the viewport-measurement layout.
- `forceResignFirstResponder()` in `TextFieldView` / `SecureFieldView` — `NSApplication.sendAction` has no `for:` argument. macOS uses `NSApplication.shared.keyWindow?.makeFirstResponder(nil)`.

`ExpoUITouchHandlerHelper.h` forward-declared `@class UIGestureRecognizer; @class UIView;`. On macOS those name classes that do not exist, so Swift dropped both methods from the generated interface — the error surfaced as "type has no member", not as a missing type. It now imports `<ExpoModulesCore/Platform.h>`, which pulls in react-native-macos's `RCTUIKit.h`.

The rest no-op or fall through to `.automatic`, matching the tvOS precedent already present in each file: `keyboardType`, `textInputAutocapitalization`, `editMode`, the wheel picker and date picker styles, paged `TabView` and `PageIndexViewStyle`, grouped and inset-grouped list styles, `pickerStyle(.navigationLink)`, `MenuOrder.priority`, `menuActionDismissBehavior(.disabled)`, `listSectionSpacing`, `listSectionMargins`, and the `cellularEID`/`cellularIMEI` content types.
 

# Test Plan

Build BareExpo macOS locally
 

https://github.com/user-attachments/assets/f30db7a7-0af7-41d9-95e3-a74e1258a583


 
# Checklist

- [x] Added a `CHANGELOG.md` entry to `expo-ui` and `expo-modules-core`
- [x] Builds on macOS and iOS
- [ ] Documentation updated (see follow-up 4)
