### PR TITLE
[metro-file-map] Match an ancestor watch root only inside it, so the on-demand filesystem can follow symlinks past it

### DIFF
--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Let the on-demand filesystem follow a symlink past an ancestor watch root: the pattern for a root above `rootDir` (`..`, `../..`) was a prefix of every deeper escape, so packages linked from a global virtual store (pnpm, Bun) failed with "Unable to resolve" whenever the app's parent folder was itself a watched workspace package. ([#50078](https://github.com/expo/expo/pull/50078) by [@jeromenagle537](https://github.com/jeromenagle537))
 ### 💡 Others
 
 ## 58.0.0 — 2026-09-10

--- a/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
+++ b/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
@@ -355,16 +355,22 @@ export function getAncestorOfRootIdx(normalPath: string): number {
   return pos / UP_FRAGMENT_SEP_LENGTH;
 }
 
+function isAncestorPath(normalPath: string): boolean {
+  return normalPath.split(path.sep).every((segment) => segment === '..' || segment === '');
+}
+
 export function pathsToPattern(paths: readonly string[], pathUtils: RootPathUtils): RegExp | null {
   if (paths.length === 0) {
     return null;
   }
+  // A normal path may not escape the matched root via further '..' indirections.
+  const noFurtherEscape = `(?!\\.\\.(?:\\${path.sep}|$))`;
   const pathsPatterns = paths.map((input) => {
     let pattern = pathUtils.absoluteToNormal(input);
     // When pattern is '' (root === rootDir), match any normal path that
     // doesn't escape the root via '..' indirections.
     if (pattern === '') {
-      return `(?!\\.\\.(?:\\${path.sep}|$))`;
+      return noFurtherEscape;
     }
     // Append separator so that 'src' matches 'src/foo' but not 'src2'.
     if (!pattern.endsWith(path.sep)) {
@@ -372,7 +378,10 @@ export function pathsToPattern(paths: readonly string[], pathUtils: RootPathUtil
     }
     // Escape all regex-special characters.
     // eslint-disable-next-line no-useless-escape
-    return pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|\/]/g, '\\$&');
+    const escaped = pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|\/]/g, '\\$&');
+    // When the root is an ancestor of rootDir ('..', '../..'), its pattern is a
+    // prefix of every deeper escape ('../../x'); match only paths inside it.
+    return isAncestorPath(pattern) ? escaped + noFurtherEscape : escaped;
   });
   return new RegExp(`^(?:${pathsPatterns.join('|')})`);
 }

--- a/packages/@expo/metro-file-map/src/lib/__tests__/RootPathUtils.test.ts
+++ b/packages/@expo/metro-file-map/src/lib/__tests__/RootPathUtils.test.ts
@@ -255,6 +255,21 @@ describe.each([['win32'], ['posix']] as const)('RootPathUtils on %s', (platform)
       expect(pattern.test('..')).toBe(false);
     });
 
+    test('an ancestor root matches only paths inside it, never a deeper escape', () => {
+      // rootDir is an app inside a workspace package; that package is a root above rootDir
+      // ('..'), and the package manager's store lives further up ('../../../…').
+      pathUtils = new RootPathUtils(p('/monorepo/packages/app'));
+      const pattern = pathsToPattern(
+        [p('/monorepo/packages'), p('/monorepo/packages/app')],
+        pathUtils
+      )!;
+      expect(pattern.test(p('../other/foo.js'))).toBe(true);
+      expect(pattern.test(p('src/foo.js'))).toBe(true);
+      expect(pattern.test(p('../../node_modules/pkg/index.js'))).toBe(false);
+      expect(pattern.test(p('../../../store/pkg/index.js'))).toBe(false);
+      expect(pattern.test('..')).toBe(false);
+    });
+
     test('handles multiple roots', () => {
       const pattern = pathsToPattern([p('/project/src'), p('/project/lib')], pathUtils)!;
       expect(pattern.test(p('src/foo.js'))).toBe(true);


### PR DESCRIPTION
# Why

With the on-demand filesystem, a symlink out of the server root (a package manager's global virtual store — pnpm `virtualStoreType: global`, Bun) resolves lazily through the fallback filesystem. That works when the project root is the only watch folder, but in a monorepo where the app's **parent folder is itself a workspace package** (e.g. `packages/app` inside the package `packages/`, both watched), every dependency failed with `Unable to resolve "expo-router/entry"` in `expo start`, while `expo export` (which cuts `watchFolders` to the project root) worked.

Cause: `pathsToPattern` turns a watch root that is an ancestor of `rootDir` into the pattern `^\.\./` (or `^\.\./\.\./`), which is a prefix of every deeper escape such as `../../../Library/pnpm/store/...`. `TreeFS.#populateFromFilesystem` reads that as "inside a crawled root, so genuinely missing" and refuses the fallback. The `''` root already guards against this with `(?!\.\.(?:/|$))`; ancestor roots did not.

# How

- `pathsToPattern`: a root whose normal path consists only of `..` segments gets the same "no further escape" lookahead as the `''` root, so `..` matches `../sibling/x` but not `../../x`.
- Test: an ancestor root matches only paths inside it, never a deeper escape.

# Test Plan

- New unit test in `RootPathUtils.test.ts`.
- Reproduced and fixed live on SDK 57 (`@expo/metro-file-map` 57.0.2) in a pnpm 12 workspace with `virtualStoreType: global`, where the app lives at `innovations/<name>/app` and `innovations/<name>` is itself a workspace package: before the change every `expo start --web` bundle failed with `Unable to resolve "expo-router/entry"`; with the change (applied as a pnpm patch) the same five apps bundle.

# Checklist

- [x] I added a `CHANGELOG.md` entry
- [x] Conforms with the style guide
- [ ] Documentation update (not needed: behaviour fix, no API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
