### PR TITLE
[precompiled] Place resource bundles inside the product framework in each slice

### DIFF
--- a/tools/src/prebuilds/Frameworks.test.ts
+++ b/tools/src/prebuilds/Frameworks.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for resource bundle placement in composed xcframeworks:
+ *  - copyResourceBundlesIntoXCFrameworkAsync
+ */
+import fs from 'fs-extra';
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import os from 'os';
+import path from 'path';
+
+import type { SPMPackageSource } from './ExternalPackage';
+import { copyResourceBundlesIntoXCFrameworkAsync } from './Frameworks';
+import { SPMBuild } from './SPMBuild';
+import type { SPMConfig, SPMProduct } from './SPMConfig.types';
+import { setForceNonInteractive } from './Utils';
+
+setForceNonInteractive(true);
+
+const PACKAGE_NAME = 'expo-media-library';
+const PRODUCT_NAME = 'ExpoMediaLibrary';
+const TARGET_NAME = 'ExpoMediaLibrary';
+const BUNDLE_NAME = `${PACKAGE_NAME}_${TARGET_NAME}.bundle`;
+const MARKER = 'Photos.strings';
+
+const SLICE_SDKS: Record<string, string> = {
+  'ios-arm64': 'iphoneos',
+  'ios-arm64_x86_64-simulator': 'iphonesimulator',
+};
+
+const productWithResources: SPMProduct = {
+  name: PRODUCT_NAME,
+  podName: PRODUCT_NAME,
+  platforms: ['iOS(.v15)'],
+  targets: [
+    {
+      type: 'swift',
+      name: TARGET_NAME,
+      path: 'ios',
+      resources: [{ path: 'Resources', rule: 'process' }],
+    },
+  ],
+};
+
+const productWithoutResources: SPMProduct = {
+  ...productWithResources,
+  targets: [{ type: 'swift', name: TARGET_NAME, path: 'ios' }],
+};
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+});
+
+/**
+ * Lays out an xcframework whose slices contain only the product framework, plus the SPM build
+ * output the copier reads the resource bundle from.
+ */
+async function createFixtureAsync(options: {
+  slices: string[];
+  builtBundleSlices?: string[];
+  product?: typeof productWithResources;
+}): Promise<{ pkg: SPMPackageSource; xcframeworkPath: string }> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'prebuild-resource-bundles-'));
+  tempRoots.push(root);
+
+  const pkg: SPMPackageSource = {
+    path: path.join(root, 'packages', PACKAGE_NAME),
+    buildPath: path.join(root, 'build'),
+    packageName: PACKAGE_NAME,
+    packageVersion: '1.0.0',
+    getSwiftPMConfiguration: (): SPMConfig => ({
+      products: [options.product ?? productWithResources],
+    }),
+  };
+
+  const xcframeworkPath = path.join(root, `${PRODUCT_NAME}.xcframework`);
+  for (const slice of options.slices) {
+    await fs.mkdirp(path.join(xcframeworkPath, slice, `${PRODUCT_NAME}.framework`));
+  }
+
+  const buildProductsPath = path.join(
+    SPMBuild.getPackageBuildPath(pkg, productWithResources, 'Debug'),
+    'Build',
+    'Products'
+  );
+  for (const slice of options.builtBundleSlices ?? options.slices) {
+    const sdk = SLICE_SDKS[slice];
+    if (!sdk) {
+      continue;
+    }
+    await fs.outputFile(
+      path.join(buildProductsPath, `Debug-${sdk}`, BUNDLE_NAME, MARKER),
+      `${slice}\n`
+    );
+  }
+
+  return { pkg, xcframeworkPath };
+}
+
+describe('copyResourceBundlesIntoXCFrameworkAsync', () => {
+  it('copies the resource bundle into the product framework of every slice', async () => {
+    const slices = Object.keys(SLICE_SDKS);
+    const { pkg, xcframeworkPath } = await createFixtureAsync({ slices });
+
+    await copyResourceBundlesIntoXCFrameworkAsync(
+      pkg,
+      productWithResources,
+      'Debug',
+      slices,
+      xcframeworkPath
+    );
+
+    for (const slice of slices) {
+      const markerPath = path.join(
+        xcframeworkPath,
+        slice,
+        `${PRODUCT_NAME}.framework`,
+        BUNDLE_NAME,
+        MARKER
+      );
+      assert.equal(
+        await fs.readFile(markerPath, 'utf8'),
+        `${slice}\n`,
+        `Expected the slice's own resource bundle inside ${slice}/${PRODUCT_NAME}.framework`
+      );
+    }
+  });
+
+  it('leaves no resource bundle beside the framework, where embedding cannot reach it', async () => {
+    const slices = Object.keys(SLICE_SDKS);
+    const { pkg, xcframeworkPath } = await createFixtureAsync({ slices });
+
+    await copyResourceBundlesIntoXCFrameworkAsync(
+      pkg,
+      productWithResources,
+      'Debug',
+      slices,
+      xcframeworkPath
+    );
+
+    for (const slice of slices) {
+      const sliceEntries = await fs.readdir(path.join(xcframeworkPath, slice));
+      assert.deepEqual(
+        sliceEntries.filter((entry) => entry.endsWith('.bundle')),
+        [],
+        `Slice ${slice} must not carry a resource bundle beside the framework`
+      );
+    }
+  });
+
+  it('skips slices with an unrecognized identifier', async () => {
+    const slices = ['ios-arm64', 'watchos-arm64_32'];
+    const { pkg, xcframeworkPath } = await createFixtureAsync({ slices });
+
+    await copyResourceBundlesIntoXCFrameworkAsync(
+      pkg,
+      productWithResources,
+      'Debug',
+      slices,
+      xcframeworkPath
+    );
+
+    assert.deepEqual(
+      await fs.readdir(path.join(xcframeworkPath, 'watchos-arm64_32', `${PRODUCT_NAME}.framework`)),
+      []
+    );
+  });
+
+  it('does nothing when no target declares resources', async () => {
+    const slices = ['ios-arm64'];
+    const { pkg, xcframeworkPath } = await createFixtureAsync({
+      slices,
+      product: productWithoutResources,
+    });
+
+    await copyResourceBundlesIntoXCFrameworkAsync(
+      pkg,
+      productWithoutResources,
+      'Debug',
+      slices,
+      xcframeworkPath
+    );
+
+    assert.deepEqual(
+      await fs.readdir(path.join(xcframeworkPath, 'ios-arm64', `${PRODUCT_NAME}.framework`)),
+      []
+    );
+  });
+});

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -198,6 +198,28 @@ export const Frameworks = {
   },
 
   /**
+   * Returns the path a target's resource bundle takes within an xcframework slice.
+   * The bundle belongs inside the product's `.framework` because consumers embed a framework by
+   * copying that directory as a whole — a bundle placed beside it never reaches the app. It is
+   * also where the Expo runtime looks for it: `Bundle(for:).resourceURL` of a framework-bound
+   * class is the framework directory itself.
+   *
+   * @param xcframeworkPath Path to the .xcframework
+   * @param slice Slice name (e.g. 'ios-arm64_x86_64-simulator')
+   * @param productName SPM product name, which is also the framework name
+   * @param bundleName Resource bundle name, as produced by SPM
+   * @returns Full path to the resource bundle inside the slice
+   */
+  getResourceBundlePathInSlice: (
+    xcframeworkPath: string,
+    slice: string,
+    productName: string,
+    bundleName: string
+  ): string => {
+    return path.join(xcframeworkPath, slice, `${productName}.framework`, bundleName);
+  },
+
+  /**
    * Finds an xcframework at either a non-versioned or versioned output path.
    * Versioned paths have the format:
    * output/<packageVersion>/<rnVersion>/<hermesVersion>/<flavor>/xcframeworks/
@@ -392,8 +414,8 @@ const processXCFrameworkSlices = async (
 /**
  * Copies resource bundles from SPM build output into each xcframework slice.
  * SPM produces resource bundles named {packageName}_{targetName}.bundle in the
- * build output directory. These need to be placed alongside the .framework in
- * each slice of the xcframework so consumers can find them.
+ * build output directory. These are placed inside the product's .framework in
+ * each slice — see `Frameworks.getResourceBundlePathInSlice`.
  *
  * @param pkg Package information
  * @param product SPM product
@@ -401,7 +423,7 @@ const processXCFrameworkSlices = async (
  * @param slices Array of slice names in the xcframework
  * @param xcframeworkOutputPath Path to the xcframework
  */
-const copyResourceBundlesIntoXCFrameworkAsync = async (
+export const copyResourceBundlesIntoXCFrameworkAsync = async (
   pkg: SPMPackageSource,
   product: SPMProduct,
   buildType: BuildFlavor,
@@ -447,12 +469,16 @@ const copyResourceBundlesIntoXCFrameworkAsync = async (
         continue;
       }
 
-      // Copy bundle into the xcframework slice (alongside the .framework)
-      const destBundlePath = path.join(xcframeworkOutputPath, slice, bundleName);
+      const destBundlePath = Frameworks.getResourceBundlePathInSlice(
+        xcframeworkOutputPath,
+        slice,
+        product.name,
+        bundleName
+      );
       await fs.copy(buildOutputPath, destBundlePath, { overwrite: true });
 
       spinner.info(
-        `Copied resource bundle ${chalk.cyan(bundleName)} → ${chalk.cyan(slice + '/' + bundleName)}`
+        `Copied resource bundle ${chalk.cyan(bundleName)} → ${chalk.cyan(path.relative(xcframeworkOutputPath, destBundlePath))}`
       );
     }
   }

--- a/tools/src/prebuilds/Verifier.ts
+++ b/tools/src/prebuilds/Verifier.ts
@@ -251,7 +251,12 @@ export const FrameworkVerifier = {
           const foundSlices: string[] = [];
 
           for (const slice of sliceNames) {
-            const bundlePath = path.join(xcframeworkPath, slice, bundleName);
+            const bundlePath = Frameworks.getResourceBundlePathInSlice(
+              xcframeworkPath,
+              slice,
+              product.name,
+              bundleName
+            );
             if (await fs.pathExists(bundlePath)) {
               foundSlices.push(slice);
             } else {


### PR DESCRIPTION
## Why

A target's SwiftPM resource bundle was written into every xcframework slice **beside** the `.framework`, but React Native's SwiftPM embed step copies the framework directory whole and nothing next to it. 

A prebuilt `expo-media-library` arrived without its privacy manifest, which Apple requires in shipping builds.

The failure is silent. The build succeeds and the missing manifest only surfaces at submission.

## How

This PR Fixes this so that the bundle now lands at `<slice>/<Product>.framework/<bundle>` and gets picked up by React/SwiftPM.

## Test Plan

✅ unit tests

## Checklist

- [x] Verified the change builds, type-checks, lints and tests (`tools` suite green)
- [ ] ~Added a `CHANGELOG.md` entry~ — n/a, `tools/` is not a published package
- [x] Conforms to the documentation style guide
