### PR TITLE
[ui][iOS] Add RecyclingList with buffered row recycling

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add `RecyclingList` with fixed-height row recycling, configurable backward overscan and programmatic scrolling on iOS/tvOS 18+. (by [@dougbot-agent](https://github.com/dougbot-agent))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-ui/ios/ExpoUIModule.swift
+++ b/packages/expo-ui/ios/ExpoUIModule.swift
@@ -166,6 +166,7 @@ public final class ExpoUIModule: Module {
     ExpoUIView(HStackView.self)
     ExpoUIView(LazyHStackView.self)
     ExpoUIView(LazyVStackView.self)
+    ExpoUIView(RecyclingListView.self)
     ExpoUIView(ImageView.self)
     ExpoUIView(LabelView.self)
     ExpoUIView(ListView.self)

--- a/packages/expo-ui/ios/RecyclingListView.swift
+++ b/packages/expo-ui/ios/RecyclingListView.swift
@@ -1,0 +1,157 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+import SwiftUI
+
+/// A data-driven list that lets React recycle its row views.
+///
+/// `LazyVStackView` is lazy on SwiftUI's side only: it defers evaluating the
+/// bodies of children React has already built, so every row still becomes a
+/// native view before SwiftUI sees it. Windowing that from JS helps, but it
+/// cannot recycle — inside a stack the child order has to match the visual
+/// order, so advancing the window by one row reassigns every slot to a
+/// different item and all of them push new props.
+///
+/// This view breaks that coupling. Each child is placed by the data index it
+/// carries (`slotIndices`) rather than by its position among its siblings, so
+/// JS is free to use `slot = index % windowSize`. Advancing the window by one
+/// row then changes exactly one slot, and re-renders exactly one row.
+public final class RecyclingListViewProps: UIBaseViewProps {
+  /// Total number of items, including those React has not rendered.
+  @Field var itemCount: Int = 0
+  /// Fixed row height, in points.
+  @Field var itemSize: Double = 0
+  /// The data index each child currently represents, in child order.
+  @Field var slotIndices: [Int] = []
+  /// Index to scroll to. Resolved to an offset natively, so the target row does
+  /// not have to be mounted — which in a recycling list it usually is not.
+  @Field var scrollToIndex: Int?
+  /// Seconds. Zero scrolls immediately.
+  @Field var scrollAnimationDuration: Double = 0
+  /// Timing curve for programmatic scrolling.
+  @Field var scrollAnimationCurve: String = "linear"
+
+  var onFirstVisibleIndexChange = EventDispatcher()
+}
+
+public struct RecyclingListView: ExpoSwiftUI.View {
+  @ObservedObject public var props: RecyclingListViewProps
+
+  public init(props: RecyclingListViewProps) {
+    self.props = props
+  }
+
+  private var contentHeight: CGFloat {
+    CGFloat(props.itemCount) * CGFloat(props.itemSize)
+  }
+
+  /// Placement is by data index, not by sibling position. This is the whole
+  /// point of the view: it is what lets the child order differ from the visual
+  /// order, and therefore what lets JS recycle.
+  private func offset(forChildAt index: Int) -> CGFloat {
+    guard index < props.slotIndices.count else { return 0 }
+    return CGFloat(props.slotIndices[index]) * CGFloat(props.itemSize)
+  }
+
+  @ViewBuilder
+  private func content(width: CGFloat) -> some View {
+    ScrollView {
+      ZStack(alignment: .topLeading) {
+        // Establishes the scrollable extent for the whole data set, not just
+        // the rows that happen to be mounted.
+        Color.clear.frame(height: contentHeight)
+
+        ForEach(Array((props.children ?? []).enumerated()), id: \.element.id) { index, child in
+          let view: any View = child.childView
+          AnyView(view)
+            // Top-aligned: `itemSize` is the row pitch, which may exceed the
+            // row's own height when the caller wants a gap. Centring the child
+            // in the pitch would offset every row by half the difference.
+            .frame(width: width, height: CGFloat(props.itemSize), alignment: .top)
+            .offset(y: offset(forChildAt: index))
+        }
+      }
+    }
+  }
+
+  public var body: some View {
+    GeometryReader { geometry in
+      if #available(iOS 18.0, tvOS 18.0, *), props.itemSize.isFinite, props.itemSize > 0, props.itemCount >= 0,
+        contentHeight.isFinite
+      {
+        ScrollDriver(
+          itemCount: props.itemCount,
+          itemSize: CGFloat(props.itemSize),
+          targetIndex: props.scrollToIndex,
+          duration: props.scrollAnimationDuration,
+          curve: props.scrollAnimationCurve,
+          onFirstVisibleIndexChange: { props.onFirstVisibleIndexChange(["index": $0]) }
+        ) {
+          content(width: geometry.size.width)
+        }
+      } else {
+        EmptyView()
+      }
+    }
+  }
+}
+
+/// Owns the scroll position and reports the first visible row.
+///
+/// Resolving `scrollToIndex` to an offset rather than using `scrollTo(id:)` is
+/// deliberate: an id-based scroll needs the target row to be mounted, and here
+/// it usually is not. The first visible index is reported only when it changes,
+/// so JS hears from this once per row rather than once per frame.
+@available(iOS 18.0, tvOS 18.0, *)
+private struct ScrollDriver<C: View>: View {
+  let itemCount: Int
+  let itemSize: CGFloat
+  let targetIndex: Int?
+  let duration: Double
+  let curve: String
+  let onFirstVisibleIndexChange: (Int) -> Void
+  @ViewBuilder let content: () -> C
+
+  @State private var position = ScrollPosition()
+  @State private var reportedIndex: Int = -1
+
+  private struct Request: Equatable {
+    let index: Int?
+    let pitch: CGFloat
+  }
+
+  var body: some View {
+    content()
+      .scrollPosition($position)
+      .onChange(
+        of: Request(
+          index: targetIndex.flatMap { itemCount > 0 ? min(max(0, $0), itemCount - 1) : nil },
+          pitch: itemSize
+        ),
+        initial: true
+      ) { _, request in
+        guard let index = request.index, itemCount > 0, itemSize.isFinite, itemSize > 0 else { return }
+        let y = CGFloat(min(max(0, index), itemCount - 1)) * itemSize
+        guard y.isFinite else { return }
+        if duration.isFinite && duration > 0 {
+          let animation: Animation =
+            curve == "easeOut"
+            ? .easeOut(duration: duration)
+            : .linear(duration: duration)
+          withAnimation(animation) { position.scrollTo(y: y) }
+        } else {
+          position.scrollTo(y: y)
+        }
+      }
+      .onScrollGeometryChange(for: Int.self) { geometry in
+        let offset = geometry.contentOffset.y + geometry.contentInsets.top
+        guard itemCount > 0, offset.isFinite, itemSize.isFinite, itemSize > 0 else { return 0 }
+        let index = min(CGFloat(itemCount - 1), max(0, (offset / itemSize).rounded(.down)))
+        return Int(index)
+      } action: { _, newValue in
+        guard newValue != reportedIndex else { return }
+        reportedIndex = newValue
+        onFirstVisibleIndexChange(newValue)
+      }
+  }
+}

--- a/packages/expo-ui/src/swift-ui/RecyclingList/__tests__/index.test.ios.tsx
+++ b/packages/expo-ui/src/swift-ui/RecyclingList/__tests__/index.test.ios.tsx
@@ -1,0 +1,282 @@
+import { act, render, renderHook } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+
+import { RecyclingList, indexForSlot, useRecyclingWindow } from '..';
+import { opacity } from '../../modifiers';
+
+const mockNativeViewFn = jest.fn();
+
+jest.mock('expo', () => ({
+  requireNativeModule: jest.fn(() => ({})),
+  requireNativeView: jest.fn((moduleName, viewName) => {
+    if (moduleName !== 'ExpoUI' || viewName !== 'RecyclingListView') {
+      throw new Error(`Unexpected native view requested: ${moduleName} ${viewName}`);
+    }
+    const { View } = require('react-native');
+    const { createElement } = require('react');
+    return (props: any) => {
+      mockNativeViewFn(props);
+      return createElement(View, props);
+    };
+  }),
+}));
+
+beforeEach(() => {
+  mockNativeViewFn.mockClear();
+  jest.spyOn(Platform, 'Version', 'get').mockReturnValue('18.0');
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function nativeProps() {
+  return mockNativeViewFn.mock.calls.at(-1)![0];
+}
+
+function expectWindow(
+  value: ReturnType<typeof useRecyclingWindow>,
+  itemCount: number,
+  windowSize: number,
+  first: number
+) {
+  const size = Math.min(itemCount, windowSize);
+  expect(value.first).toBe(first);
+  expect(value.slots).toHaveLength(size);
+  expect(new Set(value.slots).size).toBe(size);
+  expect([...value.slots].sort((a, b) => a - b)).toEqual(
+    Array.from({ length: size }, (_, index) => first + index)
+  );
+  value.slots.forEach((index, slot) => {
+    expect(index).toBeGreaterThanOrEqual(0);
+    expect(index).toBeLessThan(itemCount);
+    expect(index % size).toBe(slot);
+  });
+}
+
+describe('indexForSlot', () => {
+  it('keeps each slot congruent to its item index across ring boundaries', () => {
+    for (const size of [1, 2, 7, 18]) {
+      for (let first = 0; first < 100; first++) {
+        const indices = Array.from({ length: size }, (_, slot) => indexForSlot(slot, first, size));
+        expect([...indices].sort((a, b) => a - b)).toEqual(
+          Array.from({ length: size }, (_, offset) => first + offset)
+        );
+        indices.forEach((index, slot) => expect(index % size).toBe(slot));
+      }
+    }
+  });
+});
+
+describe('useRecyclingWindow', () => {
+  it.each([0, 1, 3, 8])('handles %i items with an eight-slot pool', (itemCount) => {
+    const { result } = renderHook(() => useRecyclingWindow(itemCount, 8));
+    expectWindow(result.current, itemCount, 8, 0);
+    act(() => result.current.onFirstVisibleIndexChange(100));
+    expectWindow(result.current, itemCount, 8, 0);
+  });
+
+  it('covers forward and reverse motion, retaining a buffer behind the visible row', () => {
+    const { result } = renderHook(() => useRecyclingWindow(100, 8, 2));
+    const forward = Array.from({ length: 106 }, (_, index) => index - 3);
+    for (const visible of [...forward, ...forward.reverse()]) {
+      act(() => result.current.onFirstVisibleIndexChange(visible));
+      expectWindow(result.current, 100, 8, Math.max(0, Math.min(visible - 2, 92)));
+    }
+  });
+
+  it('reassigns exactly one slot for each one-row move in either direction', () => {
+    const { result } = renderHook(() => useRecyclingWindow(100, 8));
+    const forward = Array.from({ length: 80 }, (_, index) => index + 1);
+    const reverse = Array.from({ length: 80 }, (_, index) => 79 - index);
+    for (const visible of [...forward, ...reverse]) {
+      const previous = result.current.slots;
+      act(() => result.current.onFirstVisibleIndexChange(visible));
+      expect(result.current.slots.filter((index, slot) => index !== previous[slot])).toHaveLength(
+        1
+      );
+    }
+  });
+
+  it('recalculates when count, window size, or overscan changes without another scroll event', () => {
+    const { result, rerender } = renderHook(
+      ({ count, size, overscan }: { count: number; size: number; overscan: number }) =>
+        useRecyclingWindow(count, size, overscan),
+      { initialProps: { count: 100, size: 8, overscan: 2 } }
+    );
+    act(() => result.current.onFirstVisibleIndexChange(70));
+    expectWindow(result.current, 100, 8, 68);
+
+    rerender({ count: 100, size: 8, overscan: 4 });
+    expectWindow(result.current, 100, 8, 66);
+    rerender({ count: 100, size: 40, overscan: 4 });
+    expectWindow(result.current, 100, 40, 60);
+    rerender({ count: 10, size: 8, overscan: 2 });
+    expectWindow(result.current, 10, 8, 2);
+    rerender({ count: 3, size: 8, overscan: 2 });
+    expectWindow(result.current, 3, 8, 0);
+    rerender({ count: 0, size: 8, overscan: 2 });
+    expectWindow(result.current, 0, 8, 0);
+    rerender({ count: 100, size: 8, overscan: 2 });
+    expectWindow(result.current, 100, 8, 0);
+  });
+
+  it('does not jump back to a removed visible row when the data grows again', () => {
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => useRecyclingWindow(count, 8, 2),
+      {
+        initialProps: { count: 100 },
+      }
+    );
+    act(() => result.current.onFirstVisibleIndexChange(70));
+    rerender({ count: 10 });
+    expectWindow(result.current, 10, 8, 2);
+    rerender({ count: 100 });
+    expectWindow(result.current, 100, 8, 7);
+  });
+
+  it('reflects a newer visible index after count shrinks', () => {
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => useRecyclingWindow(count, 8, 2),
+      {
+        initialProps: { count: 100 },
+      }
+    );
+    act(() => result.current.onFirstVisibleIndexChange(70));
+    rerender({ count: 10 });
+    act(() => result.current.onFirstVisibleIndexChange(1));
+    rerender({ count: 100 });
+    expectWindow(result.current, 100, 8, 0);
+  });
+
+  it.each([
+    [-1, 8, 0],
+    [1.5, 8, 0],
+    [NaN, 8, 0],
+    [Infinity, 8, 0],
+    [Number.MAX_SAFE_INTEGER + 1, 8, 0],
+    [10, 0, 0],
+    [10, -1, 0],
+    [10, 1.5, 0],
+    [10, Infinity, 0],
+    [10, NaN, 0],
+    [10, Number.MAX_SAFE_INTEGER + 1, 0],
+    [10, 8, -1],
+    [10, 8, 1.5],
+    [10, 8, 8],
+    [10, 8, NaN],
+    [10, 8, Infinity],
+  ])('rejects invalid count/window/overscan (%s, %s, %s)', (count, size, overscan) => {
+    expect(() => renderHook(() => useRecyclingWindow(count, size, overscan))).toThrow(RangeError);
+  });
+});
+
+describe('RecyclingList', () => {
+  it('forwards slot order, an initial scroll target, animation options, and modifiers', () => {
+    const onFirstVisibleIndexChange = jest.fn();
+    render(
+      <RecyclingList
+        itemCount={100}
+        itemSize={64}
+        slotIndices={[4, 5, 2, 3]}
+        scrollToIndex={30}
+        scrollAnimationDuration={0.5}
+        scrollAnimationCurve="easeOut"
+        modifiers={[opacity(0.5)]}
+        onFirstVisibleIndexChange={onFirstVisibleIndexChange}>
+        {null}
+      </RecyclingList>
+    );
+    expect(nativeProps()).toMatchObject({
+      itemCount: 100,
+      itemSize: 64,
+      slotIndices: [4, 5, 2, 3],
+      scrollToIndex: 30,
+      scrollAnimationDuration: 0.5,
+      scrollAnimationCurve: 'easeOut',
+      modifiers: [opacity(0.5)],
+    });
+    expect(nativeProps().onGlobalEvent).toBeInstanceOf(Function);
+    act(() => nativeProps().onFirstVisibleIndexChange({ nativeEvent: { index: 12 } }));
+    expect(onFirstVisibleIndexChange).toHaveBeenCalledWith(12);
+    expect(onFirstVisibleIndexChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts an empty list and omits an unused event handler', () => {
+    render(
+      <RecyclingList itemCount={0} itemSize={1} slotIndices={[]}>
+        {null}
+      </RecyclingList>
+    );
+    expect(nativeProps().slotIndices).toEqual([]);
+    expect(nativeProps().onFirstVisibleIndexChange).toBeUndefined();
+    expect(nativeProps().onGlobalEvent).toBeUndefined();
+  });
+
+  it.each([
+    { itemCount: -1 },
+    { itemCount: 1.5 },
+    { itemCount: Number.MAX_SAFE_INTEGER + 1 },
+    { itemSize: 0 },
+    { itemSize: -1 },
+    { itemSize: Infinity },
+    { itemSize: NaN },
+    { scrollToIndex: -1 },
+    { scrollToIndex: 0.5 },
+    { scrollToIndex: Infinity },
+    { scrollToIndex: Number.MAX_SAFE_INTEGER + 1 },
+    { scrollAnimationDuration: -1 },
+    { scrollAnimationDuration: Infinity },
+    { scrollAnimationDuration: NaN },
+    { slotIndices: [0, 0] },
+    { slotIndices: [-1] },
+    { slotIndices: [10] },
+    { slotIndices: [0.5] },
+    { slotIndices: [NaN] },
+  ])('rejects invalid native props %j', (invalidProps) => {
+    expect(() =>
+      render(
+        <RecyclingList itemCount={10} itemSize={64} slotIndices={[0]} {...invalidProps}>
+          {null}
+        </RecyclingList>
+      )
+    ).toThrow(RangeError);
+  });
+
+  it('rejects an unsupported animation curve', () => {
+    expect(() =>
+      render(
+        <RecyclingList
+          itemCount={10}
+          itemSize={64}
+          slotIndices={[0]}
+          // @ts-expect-error Runtime callers can supply invalid strings.
+          scrollAnimationCurve="spring">
+          {null}
+        </RecyclingList>
+      )
+    ).toThrow();
+  });
+
+  it('requires iOS 18 or newer', () => {
+    jest.spyOn(Platform, 'Version', 'get').mockReturnValue('17.5');
+    expect(() =>
+      render(
+        <RecyclingList itemCount={0} itemSize={64} slotIndices={[]}>
+          {null}
+        </RecyclingList>
+      )
+    ).toThrow(/iOS 18/);
+  });
+
+  it('rejects platforms other than iOS', () => {
+    jest.replaceProperty(Platform, 'OS', 'android');
+    expect(() =>
+      render(
+        <RecyclingList itemCount={0} itemSize={64} slotIndices={[]}>
+          {null}
+        </RecyclingList>
+      )
+    ).toThrow(/iOS/);
+  });
+});

--- a/packages/expo-ui/src/swift-ui/RecyclingList/index.tsx
+++ b/packages/expo-ui/src/swift-ui/RecyclingList/index.tsx
@@ -1,0 +1,168 @@
+import { requireNativeView } from 'expo';
+import * as React from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
+
+import { createViewModifierEventListener } from '../modifiers/utils';
+import { type CommonViewModifierProps } from '../types';
+
+/**
+ * A data-driven list that recycles its row views.
+ *
+ * `LazyVStack` is lazy on SwiftUI's side only: it defers evaluating the bodies
+ * of children React has already built. Every row still becomes a native view
+ * before SwiftUI sees it, so a long list pays for all of them up front.
+ *
+ * Windowing that in JS helps, but it cannot recycle. In a linear stack the
+ * child order has to match the visual order, so advancing the window by one row
+ * reassigns every slot to a different item and all of them push new props.
+ * Recycling needs `slot = index % windowSize`, which produces a child order
+ * that deliberately does not match the visual order — and that only works if
+ * the native side positions each child by its own index instead of by its
+ * position among its siblings.
+ *
+ * That is what this view does. JS owns which item each slot shows; native owns
+ * where each slot sits. Advancing the window by one row then changes exactly
+ * one slot, and therefore re-renders exactly one row.
+ */
+export interface RecyclingListProps extends CommonViewModifierProps {
+  /** Total number of items, including the ones not currently rendered. */
+  itemCount: number;
+  /** Fixed row pitch in points, including any separator or gap. */
+  itemSize: number;
+  /** The data index represented by each child, in child order. */
+  slotIndices: number[];
+  /** Scroll to this row index. Resolved to an offset natively. */
+  scrollToIndex?: number;
+  /** Seconds. Zero scrolls immediately. */
+  scrollAnimationDuration?: number;
+  /** Timing curve for programmatic scrolling. Defaults to linear. */
+  scrollAnimationCurve?: 'linear' | 'easeOut';
+  /** Called when the first visible index changes. */
+  onFirstVisibleIndexChange?: (index: number) => void;
+  /** One child for each slotIndices entry, in the same order. */
+  children: React.ReactNode;
+}
+
+type NativeProps = Omit<RecyclingListProps, 'onFirstVisibleIndexChange'> & {
+  onFirstVisibleIndexChange?: (event: { nativeEvent: { index: number } }) => void;
+};
+
+const RecyclingListNativeView: React.ComponentType<NativeProps> = requireNativeView(
+  'ExpoUI',
+  'RecyclingListView'
+);
+
+/** The unique index in `[first, first + windowSize)` congruent to `slot`. */
+export function indexForSlot(slot: number, first: number, windowSize: number): number {
+  const firstSlot = ((first % windowSize) + windowSize) % windowSize;
+  return first + ((((slot - firstSlot) % windowSize) + windowSize) % windowSize);
+}
+
+function nonnegativeInteger(value: number, name: string) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a nonnegative safe integer`);
+  }
+}
+
+/**
+ * Keeps a fixed pool of slots around the first visible row.
+ * Allocate enough slots for the viewport plus buffers in both directions.
+ * `overscanRows` reserves part of that pool before the visible row; it does not
+ * increase the number of mounted children. It must be smaller than `windowSize`.
+ */
+export function useRecyclingWindow(itemCount: number, windowSize: number, overscanRows = 0) {
+  nonnegativeInteger(itemCount, 'itemCount');
+  nonnegativeInteger(windowSize, 'windowSize');
+  nonnegativeInteger(overscanRows, 'overscanRows');
+  if (windowSize === 0 || overscanRows >= windowSize) {
+    throw new RangeError('windowSize must be positive and greater than overscanRows');
+  }
+  const [visibleIndex, setVisibleIndex] = useState(0);
+  const visible = Math.min(visibleIndex, Math.max(0, itemCount - 1));
+  // Correct retained state before committing children after a dataset shrink.
+  // Waiting for a native geometry event can expose out-of-bounds rows first.
+  if (visible !== visibleIndex) {
+    setVisibleIndex(visible);
+  }
+  const first = Math.max(0, Math.min(visible - overscanRows, Math.max(0, itemCount - windowSize)));
+  const onFirstVisibleIndexChange = useCallback((index: number) => {
+    if (Number.isFinite(index)) {
+      setVisibleIndex(Math.max(0, Math.floor(index)));
+    }
+  }, []);
+  const slots = useMemo(() => {
+    const count = Math.min(windowSize, itemCount);
+    return Array.from({ length: count }, (_, slot) => indexForSlot(slot, first, count));
+  }, [first, windowSize, itemCount]);
+
+  return { first, slots, onFirstVisibleIndexChange };
+}
+
+/**
+ * A fixed-height recycling list for iOS and tvOS 18 or later.
+ *
+ * Children are keyed by pool slot, not item ID. Reset item-specific local state
+ * when a slot receives a different item. The pool must cover the viewport and
+ * enough overscan for JS updates to complete during a fling.
+ *
+ * @example
+ * const { slots, onFirstVisibleIndexChange } = useRecyclingWindow(items.length, 40, 10);
+ * return (
+ *   <RecyclingList itemCount={items.length} itemSize={60} slotIndices={slots}
+ *     onFirstVisibleIndexChange={onFirstVisibleIndexChange}>
+ *     {slots.map((index, slot) => <Row key={slot} item={items[index]} />)}
+ *   </RecyclingList>
+ * );
+ */
+
+export function RecyclingList(props: RecyclingListProps) {
+  if (Platform.OS !== 'ios' || !(Number.parseInt(String(Platform.Version), 10) >= 18)) {
+    throw new Error('RecyclingList requires iOS 18+ or tvOS 18+');
+  }
+  nonnegativeInteger(props.itemCount, 'itemCount');
+  if (
+    !Number.isFinite(props.itemSize) ||
+    props.itemSize <= 0 ||
+    !Number.isFinite(props.itemSize * props.itemCount)
+  ) {
+    throw new RangeError('itemSize must be positive and finite');
+  }
+  if (props.scrollToIndex !== undefined) nonnegativeInteger(props.scrollToIndex, 'scrollToIndex');
+  if (
+    props.scrollAnimationDuration !== undefined &&
+    (!Number.isFinite(props.scrollAnimationDuration) || props.scrollAnimationDuration < 0)
+  ) {
+    throw new RangeError('scrollAnimationDuration must be nonnegative and finite');
+  }
+  if (
+    props.scrollAnimationCurve !== undefined &&
+    props.scrollAnimationCurve !== 'linear' &&
+    props.scrollAnimationCurve !== 'easeOut'
+  ) {
+    throw new RangeError('scrollAnimationCurve must be linear or easeOut');
+  }
+  if (
+    props.slotIndices.some(
+      (index) => !Number.isSafeInteger(index) || index < 0 || index >= props.itemCount
+    ) ||
+    new Set(props.slotIndices).size !== props.slotIndices.length
+  ) {
+    throw new RangeError('slotIndices must contain unique indices within itemCount');
+  }
+  const { modifiers, children, onFirstVisibleIndexChange, ...restProps } = props;
+
+  return (
+    <RecyclingListNativeView
+      {...restProps}
+      modifiers={modifiers}
+      {...(modifiers ? createViewModifierEventListener(modifiers) : undefined)}
+      onFirstVisibleIndexChange={
+        onFirstVisibleIndexChange
+          ? ({ nativeEvent: { index } }) => onFirstVisibleIndexChange(index)
+          : undefined
+      }>
+      {children}
+    </RecyclingListNativeView>
+  );
+}

--- a/packages/expo-ui/src/swift-ui/index.tsx
+++ b/packages/expo-ui/src/swift-ui/index.tsx
@@ -52,6 +52,7 @@ export {
 export * from './SecureField';
 export * from './Namespace';
 export * from './GlassEffectContainer';
+export * from './RecyclingList';
 export * from './ScrollView';
 export * from './Shapes';
 export * from './Mask';


### PR DESCRIPTION
# Why

`LazyVStack` defers SwiftUI layout, but React still constructs its declared children. Windowing those children reduces the initial work; reusing a fixed set of row views also requires native placement to follow data indices rather than child order.

This draft adds `RecyclingList`, a fixed-row-pitch SwiftUI primitive, and `useRecyclingWindow`. In steady-state scrolling, advancing one row reassigns one pool slot while the other row views stay mounted.

# How

- Native layout positions each mounted child using `slotIndices` and retains the complete scroll extent through `itemCount` and `itemSize`.
- The hook maintains stable ring slots with configurable backward overscan. It derives bounds from current inputs and repairs retained state when data shrinks, including empty-to-populated transitions and pool resizing.
- Programmatic scrolling resolves an index to a native offset, including the initial target, a target becoming available after loading, and row-pitch changes. Targets clamp to the available range. Linear and ease-out animation curves are supported.
- The component explicitly requires iOS/tvOS 18+, where SwiftUI exposes the scroll position and geometry APIs it needs. It rejects invalid sizes, counts and indices instead of rendering a partial nonfunctional fallback.

```tsx
const { slots, onFirstVisibleIndexChange } = useRecyclingWindow(items.length, 40, 10);

<RecyclingList
  itemCount={items.length}
  itemSize={60}
  slotIndices={slots}
  onFirstVisibleIndexChange={onFirstVisibleIndexChange}>
  {slots.map((index, slot) => <Row key={slot} item={items[index]} />)}
</RecyclingList>
```

The caller must size the pool for the visible viewport plus both scroll directions, and reset item-specific local state when a recycled slot receives a new item. Variable-height rows and Android are outside this component's current support.

# Test Plan

- **50 Jest tests pass** in the package's iOS project using React 19.2.3 and the repository's RN 0.88 test dependencies. Coverage includes ring identity, forward/reverse traversal, single-slot reassignment, shrink/grow/empty/resize transitions, invalid inputs, native prop/event forwarding, and the OS requirement.
- Package library and plugin builds, `tsc -b tsconfig.all.json`, Oxlint, formatting, and `git diff --check` pass.
- The SwiftUI view body typechecks against the iOS 18 simulator target using minimal Expo Core interface stubs. This checks SwiftUI API/type usage; it is **not an integrated Expo native build**.
- A development backport was exercised on SDK 57 on an iPhone 17 Pro Max and matched simulators, including fast reverse flings. That app also contains separate Core/chart experiments; its timing numbers are not attributed to this draft.

Local Jest invocation after building dependencies:

```sh
cd packages/expo-ui
NODE_PATH="$PWD/../../node_modules/.pnpm/node_modules" \
  node ../../node_modules/jest/bin/jest.js --runInBand \
  --runTestsByPath src/swift-ui/RecyclingList/__tests__/index.test.ios.tsx
```

`NODE_PATH` exposes the already-installed transitive `chalk` dependency needed by the current upstream Jest preset; no dependency manifests or lockfiles are changed.

**Before ready for review:** integrated SDK 58 native build and runtime checks on iOS 18 and tvOS, VoiceOver traversal order for offset-positioned ring children, and isolated performance measurements of this diff. This remains a draft while those checks and API review are pending.

# Checklist

- [x] I added a changelog entry and rebuilt the package sources.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (integrated SDK 58 validation pending).
- [x] API documentation describes the platform minimum, pool sizing and recycled state requirements.
